### PR TITLE
[TAN-7785] (a11y) Fix contrast for n votes text on report input widget

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SingleIdeaWidget/IdeaCard/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SingleIdeaWidget/IdeaCard/index.tsx
@@ -175,7 +175,7 @@ const IdeaCard = ({
       <Box display="flex" {...(showAuthor ? { pt: '8px' } : {})}>
         {showAuthor && <AuthorAvatar idea={idea} />}
         <Box marginLeft="auto">
-          <Text color="coolGrey500" fontSize="s">
+          <Text color="coolGrey600" fontSize="s">
             {showVotes && (
               <Box as="span" display="inline" mr="10px">
                 {textNumberOfVotes}
@@ -185,14 +185,14 @@ const IdeaCard = ({
               <Box as="span" display="inline">
                 <Icon
                   height="16px"
-                  fill={colors.coolGrey500}
+                  fill={colors.coolGrey600}
                   mr="3px"
                   name="vote-up"
                 />
                 {likes}
                 <Icon
                   height="16px"
-                  fill={colors.coolGrey500}
+                  fill={colors.coolGrey600}
                   ml="8px"
                   mr="3px"
                   name="vote-down"


### PR DESCRIPTION
The "{n} votes 👍 x 👎 y" footer in `SingleIdeaWidget` / `MostReactedIdeasWidget` rendered text + icons in `coolGrey500` (#84939E), giving ~3.15:1 contrast against white — failing WCAG AA's 4.5:1 minimum for normal text.

Bumped to `coolGrey600` (#596B7A, ~5.47:1) for both the `Text` color and the two `Icon` fills.

Flagged in the Frameless accessibility audit.

### Test plan

- In Report Builder, add a `SingleIdeaWidget`, enable "Show votes" + "Show reactions" → footer text and icons render visibly darker.
- Inspect element on the footer → computed color is rgb(89, 107, 122).

Before:
<img width="169" height="50" alt="Screenshot 2026-05-14 at 10 48 38" src="https://github.com/user-attachments/assets/065ab69e-ab90-48b1-b381-9aa2dbb552b4" />

After:
<img width="169" height="50" alt="Screenshot 2026-05-14 at 10 48 24" src="https://github.com/user-attachments/assets/0d9d813a-0349-414d-a7c9-7532e1732ac4" />

# Changelog
- [TAN-7785] (a11y) Fix contrast for n votes text on report input widget
