### PR TITLE
Fix moderator admin navigation regressions after TanStack Router upgrade

### DIFF
--- a/front/app/api/phase_permissions/usePhasePermissions.ts
+++ b/front/app/api/phase_permissions/usePhasePermissions.ts
@@ -26,6 +26,7 @@ const usePhasePermissions = ({ phaseId }: PhasePermissionsProps) => {
   >({
     queryKey: phasePermissionKeys.list({ phaseId }),
     queryFn: () => fetchPhasePermissions({ phaseId }),
+    enabled: !!phaseId,
   });
 };
 

--- a/front/app/containers/Admin/index.tsx
+++ b/front/app/containers/Admin/index.tsx
@@ -7,7 +7,6 @@ import useAuthUser from 'api/me/useAuthUser';
 
 import clHistory from 'utils/cl-router/history';
 import { usePermission } from 'utils/permissions';
-import { isAdmin, isModerator } from 'utils/permissions/roles';
 import { Outlet as RouterOutlet, useLocation } from 'utils/router';
 
 import Sidebar from './sideBar/';
@@ -95,22 +94,10 @@ const AdminPage = memo<Props>(({ className }) => {
   });
 
   useEffect(() => {
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (authUser === null || (authUser !== undefined && !userCanViewPath)) {
+    if (authUser && !userCanViewPath) {
       clHistory.push('/');
     }
-
-    if (pathname.endsWith('/admin') || pathname.endsWith('/admin/')) {
-      if (isAdmin(authUser)) {
-        clHistory.push('/admin/dashboard/overview');
-      }
-
-      if (isModerator(authUser)) {
-        clHistory.push('/admin/projects');
-      }
-    }
-  }, [authUser, userCanViewPath, pathname]);
+  }, [authUser, userCanViewPath]);
 
   if (!userCanViewPath) {
     return null;

--- a/front/app/containers/Admin/projects/project/phase/index.tsx
+++ b/front/app/containers/Admin/projects/project/phase/index.tsx
@@ -121,9 +121,14 @@ export default () => {
       }
     }
 
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (phases.data.length === 0 && !isLoadingPhases && !isFetchingPhases) {
+    // Without this guard, navigating to a sibling tab re-runs the effect
+    // (pathname is in deps) and yanks the user back to /phases/new before the
+    // route unmounts.
+    const stillOnPhasesPath = pathname.includes(
+      `/admin/projects/${projectId}/phases`
+    );
+
+    if (stillOnPhasesPath && phases.data.length === 0 && !isFetchingPhases) {
       clHistory.replace(`/admin/projects/${projectId}/phases/new`);
     } else if (phaseShown && pathname.endsWith('phases/setup')) {
       const redirectTab = getPhaseLandingTab(phaseShown);
@@ -133,7 +138,7 @@ export default () => {
     }
 
     setSelectedPhase(phaseShown);
-  }, [phaseId, phases, projectId, pathname, isLoadingPhases, isFetchingPhases]);
+  }, [phaseId, phases, projectId, pathname, isFetchingPhases]);
 
   if (isLoadingProject || isLoadingPhases) {
     return (

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -5,6 +5,7 @@ import * as yup from 'yup';
 
 import { IAppConfigurationData } from 'api/app_configuration/types';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
+import useAuthUser from 'api/me/useAuthUser';
 
 import { supportedLocales } from 'containers/App/constants';
 
@@ -17,6 +18,7 @@ import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
 import { isUUID } from 'utils/helperUtils';
 import type { Routes } from 'utils/moduleUtils';
 import { usePermission } from 'utils/permissions';
+import { isAdmin, isModerator } from 'utils/permissions/roles';
 import { createRoute, useLocation } from 'utils/router';
 
 import createAdminCommunityMonitorRoutes from './communityMonitor/routes';
@@ -146,13 +148,23 @@ export const adminRoute = createRoute({
   component: AdminLayoutElement,
 });
 
-// Admin index route - redirects to dashboard
+// Moderators don't have access to /admin/dashboard/overview.
+const AdminIndexRedirect = () => {
+  const { data: authUser } = useAuthUser();
+
+  if (!authUser) return null;
+
+  if (!isAdmin(authUser) && isModerator(authUser)) {
+    return <Navigate to="/admin/projects" />;
+  }
+
+  return <Navigate to="/admin/dashboard/overview" />;
+};
+
 const adminIndexRoute = createRoute({
   getParentRoute: () => adminRoute,
-  // Careful: moderators currently have access to the admin index route
-  // Adjust isModerator in routePermissions.ts if needed.
   path: '/',
-  component: () => <Navigate to="/admin/dashboard/overview" />,
+  component: AdminIndexRedirect,
 });
 
 // Favicon route


### PR DESCRIPTION
# Changelog

## Fixed
- Routing to other links after opening a project without a phase for project moderators