### PR TITLE
[TAN-7790] Add single use task to set user first or last names containing '@' to nil

### DIFF
--- a/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
+++ b/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
@@ -18,23 +18,24 @@ namespace :single_use do
       puts "Processing tenant: #{tenant.host} - #{users.size} affected user(s)"
 
       users.each do |user|
-        new_attrs = {}
-        new_attrs[:first_name] = nil if user.first_name.to_s.include?('@')
-        new_attrs[:last_name]  = nil if user.last_name.to_s.include?('@')
-        next if new_attrs.empty?
+        before = user.attributes.symbolize_keys
 
-        before = { id: user.id, email: user.email, first_name: user.first_name, last_name: user.last_name }
-        after  = before.merge(new_attrs)
+        user.first_name = nil if user.first_name.to_s.include?('@')
+        user.last_name  = nil if user.last_name.to_s.include?('@')
+        next unless user.changed?
 
         if execute
           begin
-            user.update!(new_attrs)
+            user.save!
           rescue StandardError => e
             reporter.add_error(e.message, context: { tenant: tenant.host, user_id: user.id })
             puts "ERROR! Failed to update user #{user.id}: #{e.message}"
             user.reload
             next
           end
+          after = user.reload.attributes.symbolize_keys
+        else
+          after = user.attributes.symbolize_keys
         end
 
         reporter.add_change(before, after, context: { tenant: tenant.host, user_id: user.id })

--- a/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
+++ b/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
@@ -9,41 +9,37 @@ namespace :single_use do
 
     reporter = ScriptReporter.new
 
-    Tenant.all.find_each do |tenant|
-      next unless Apartment.connection.schema_exists?(tenant.schema_name)
+    Tenant.safe_switch_each do |tenant|
+      reporter.add_processed_tenant(tenant)
 
-      tenant.switch do
-        reporter.add_processed_tenant(tenant)
+      users = User.where("first_name LIKE '%@%' OR last_name LIKE '%@%'").to_a
+      next if users.empty?
 
-        users = User.where("first_name LIKE '%@%' OR last_name LIKE '%@%'").to_a
-        next if users.empty?
+      puts "Processing tenant: #{tenant.host} - #{users.size} affected user(s)"
 
-        puts "Processing tenant: #{tenant.host} - #{users.size} affected user(s)"
+      users.each do |user|
+        new_attrs = {}
+        new_attrs[:first_name] = nil if user.first_name.to_s.include?('@')
+        new_attrs[:last_name]  = nil if user.last_name.to_s.include?('@')
+        next if new_attrs.empty?
 
-        users.each do |user|
-          new_attrs = {}
-          new_attrs[:first_name] = nil if user.first_name.to_s.include?('@')
-          new_attrs[:last_name]  = nil if user.last_name.to_s.include?('@')
-          next if new_attrs.empty?
+        before = { id: user.id, email: user.email, first_name: user.first_name, last_name: user.last_name }
+        after  = before.merge(new_attrs)
 
-          before = { id: user.id, email: user.email, first_name: user.first_name, last_name: user.last_name }
-          after  = before.merge(new_attrs)
-
-          if execute
-            begin
-              user.update!(new_attrs)
-            rescue StandardError => e
-              reporter.add_error(e.message, context: { tenant: tenant.host, user_id: user.id })
-              puts "ERROR! Failed to update user #{user.id}: #{e.message}"
-              user.reload
-              next
-            end
+        if execute
+          begin
+            user.update!(new_attrs)
+          rescue StandardError => e
+            reporter.add_error(e.message, context: { tenant: tenant.host, user_id: user.id })
+            puts "ERROR! Failed to update user #{user.id}: #{e.message}"
+            user.reload
+            next
           end
-
-          reporter.add_change(before, after, context: { tenant: tenant.host, user_id: user.id })
         end
+
+        reporter.add_change(before, after, context: { tenant: tenant.host, user_id: user.id })
       end
-    rescue Apartment::TenantNotFound, StandardError => e
+    rescue StandardError => e
       reporter.add_error(e.message, context: { tenant: tenant.host })
       puts "ERROR! Failed to process tenant #{tenant.host}: #{e.message}"
     end

--- a/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
+++ b/back/lib/tasks/single_use/20260515_nullify_email_like_user_names.rake
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+namespace :single_use do
+  desc "Set users' first_name and/or last_name to nil when they contain an '@' (likely an email stored as a name)"
+  task :nullify_email_like_user_names, %i[execute] => [:environment] do |_t, args|
+    execute = args[:execute] == 'execute'
+    puts "---------- STARTING TASK: Nullify email-like user names ----------\n\n"
+    puts "Mode: #{execute ? 'EXECUTE - changes WILL be applied' : 'Dry run - no changes will be applied'}\n\n"
+
+    reporter = ScriptReporter.new
+
+    Tenant.all.find_each do |tenant|
+      next unless Apartment.connection.schema_exists?(tenant.schema_name)
+
+      tenant.switch do
+        reporter.add_processed_tenant(tenant)
+
+        users = User.where("first_name LIKE '%@%' OR last_name LIKE '%@%'").to_a
+        next if users.empty?
+
+        puts "Processing tenant: #{tenant.host} - #{users.size} affected user(s)"
+
+        users.each do |user|
+          new_attrs = {}
+          new_attrs[:first_name] = nil if user.first_name.to_s.include?('@')
+          new_attrs[:last_name]  = nil if user.last_name.to_s.include?('@')
+          next if new_attrs.empty?
+
+          before = { id: user.id, email: user.email, first_name: user.first_name, last_name: user.last_name }
+          after  = before.merge(new_attrs)
+
+          if execute
+            begin
+              user.update!(new_attrs)
+            rescue StandardError => e
+              reporter.add_error(e.message, context: { tenant: tenant.host, user_id: user.id })
+              puts "ERROR! Failed to update user #{user.id}: #{e.message}"
+              user.reload
+              next
+            end
+          end
+
+          reporter.add_change(before, after, context: { tenant: tenant.host, user_id: user.id })
+        end
+      end
+    rescue Apartment::TenantNotFound, StandardError => e
+      reporter.add_error(e.message, context: { tenant: tenant.host })
+      puts "ERROR! Failed to process tenant #{tenant.host}: #{e.message}"
+    end
+
+    begin
+      NullifyEmailLikeUserNamesSummaryPrinter.print_summary(reporter)
+    rescue StandardError => e
+      puts "ERROR! Failed to print summary: #{e.message}"
+    ensure
+      reporter.report!('nullify_email_like_user_names.json', verbose: false)
+    end
+
+    puts "\n---------- FINISHED TASK: Nullify email-like user names ----------\n\n"
+  end
+end
+
+class NullifyEmailLikeUserNamesSummaryPrinter
+  BRANCH = '|-- '
+  CORNER = '`-- '
+
+  def self.print_summary(reporter)
+    puts "\nSummary of changes:"
+    total_first = 0
+    total_last  = 0
+    changes_by_tenant = reporter.changes.group_by { |c| c[:context][:tenant] }
+
+    changes_by_tenant.each do |tenant_host, changes|
+      first_cleared = changes.count { |c| !c[:old_value][:first_name].nil? && c[:new_value][:first_name].nil? }
+      last_cleared  = changes.count { |c| !c[:old_value][:last_name].nil?  && c[:new_value][:last_name].nil? }
+
+      puts "Tenant: #{tenant_host} (#{changes.size} user(s))"
+      changes.each_with_index do |change, idx|
+        last_row = idx == changes.size - 1
+        branch = last_row ? CORNER : BRANCH
+        puts "#{branch}user=#{change[:context][:user_id]} email=#{change[:old_value][:email]} " \
+             "first_name=#{change[:old_value][:first_name].inspect}->#{change[:new_value][:first_name].inspect} " \
+             "last_name=#{change[:old_value][:last_name].inspect}->#{change[:new_value][:last_name].inspect}"
+      end
+      puts "Stats: #{first_cleared} first_name(s) cleared, #{last_cleared} last_name(s) cleared"
+      puts
+
+      total_first += first_cleared
+      total_last  += last_cleared
+    end
+
+    puts "Total across #{changes_by_tenant.size} tenant(s): #{total_first} first_name(s) cleared, #{total_last} last_name(s) cleared\n"
+  end
+end

--- a/back/spec/tasks/single_use/nullify_email_like_user_names_spec.ignore.rb
+++ b/back/spec/tasks/single_use/nullify_email_like_user_names_spec.ignore.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'single_use:nullify_email_like_user_names rake task' do
+  before { load_rake_tasks_if_not_loaded }
+  after { Rake::Task['single_use:nullify_email_like_user_names'].reenable }
+
+  def run_task(execute: false)
+    Rake::Task['single_use:nullify_email_like_user_names'].invoke(execute ? 'execute' : nil)
+  end
+
+  describe 'dry-run mode' do
+    it 'does not modify users with email-like names' do
+      user = create(:user, first_name: 'someone@example.com', last_name: 'someone@example.com')
+
+      run_task(execute: false)
+
+      user.reload
+      expect(user.first_name).to eq('someone@example.com')
+      expect(user.last_name).to eq('someone@example.com')
+    end
+  end
+
+  describe 'execute mode' do
+    context 'when only last_name contains @' do
+      it 'nullifies last_name and preserves first_name' do
+        user = create(:user, first_name: 'John', last_name: 'john@example.com')
+
+        run_task(execute: true)
+
+        user.reload
+        expect(user.first_name).to eq('John')
+        expect(user.last_name).to be_nil
+      end
+    end
+
+    context 'when only first_name contains @' do
+      it 'nullifies first_name and preserves last_name' do
+        user = create(:user, first_name: 'jane@example.com', last_name: 'Doe')
+
+        run_task(execute: true)
+
+        user.reload
+        expect(user.first_name).to be_nil
+        expect(user.last_name).to eq('Doe')
+      end
+    end
+
+    context 'when both first_name and last_name contain @' do
+      it 'nullifies both' do
+        user = create(:user, first_name: 'someone@example.com', last_name: 'someone@example.com')
+
+        run_task(execute: true)
+
+        user.reload
+        expect(user.first_name).to be_nil
+        expect(user.last_name).to be_nil
+      end
+    end
+
+    context 'when @ appears anywhere in the name' do
+      it 'still nullifies the field' do
+        user = create(:user, first_name: 'Bob', last_name: 'Smith@home')
+
+        run_task(execute: true)
+
+        user.reload
+        expect(user.first_name).to eq('Bob')
+        expect(user.last_name).to be_nil
+      end
+    end
+
+    context 'when neither name contains @' do
+      it 'leaves the user unchanged' do
+        user = create(:user, first_name: 'Bob', last_name: 'Smith')
+
+        run_task(execute: true)
+
+        user.reload
+        expect(user.first_name).to eq('Bob')
+        expect(user.last_name).to eq('Smith')
+      end
+    end
+
+    context 'with a mix of affected and unaffected users' do
+      it 'only updates the affected users' do
+        affected = create(:user, first_name: 'x', last_name: 'foo@example.com')
+        unaffected = create(:user, first_name: 'Alice', last_name: 'Wonderland')
+
+        run_task(execute: true)
+
+        expect(affected.reload.last_name).to be_nil
+        expect(unaffected.reload.first_name).to eq('Alice')
+        expect(unaffected.reload.last_name).to eq('Wonderland')
+      end
+    end
+
+    context 'when user.update! raises' do
+      it 'leaves the user unchanged and logs an error' do
+        user = create(:user, first_name: 'John', last_name: 'john@example.com')
+        allow_any_instance_of(User).to receive(:update!).and_raise('Boom')
+
+        expect { run_task(execute: true) }.to output(/ERROR! Failed to update user/).to_stdout
+
+        expect(user.reload.last_name).to eq('john@example.com')
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/back/spec/tasks/single_use/nullify_email_like_user_names_spec.ignore.rb
+++ b/back/spec/tasks/single_use/nullify_email_like_user_names_spec.ignore.rb
@@ -97,10 +97,10 @@ describe 'single_use:nullify_email_like_user_names rake task' do
       end
     end
 
-    context 'when user.update! raises' do
+    context 'when user.save! raises' do
       it 'leaves the user unchanged and logs an error' do
         user = create(:user, first_name: 'John', last_name: 'john@example.com')
-        allow_any_instance_of(User).to receive(:update!).and_raise('Boom')
+        allow_any_instance_of(User).to receive(:save!).and_raise('Boom')
 
         expect { run_task(execute: true) }.to output(/ERROR! Failed to update user/).to_stdout
 


### PR DESCRIPTION
For use in gauging scale of problem on production servers (in 'dry-run' mode) and cleaning up after work to add a model validation to prevent user names containing '@' has been merged (Not yet written)

# Changelog
## Technical
- [TAN-7790] Add single use task to set user first or last names containing '@' to nil
