### PR TITLE
TAN-7807-a11y/fix-map-source-link-at-zoom-400

### DIFF
--- a/front/app/components/EsriMap/index.tsx
+++ b/front/app/components/EsriMap/index.tsx
@@ -53,6 +53,12 @@ const MapContainer = styled(Box)<{
     box-shadow: none !important;
   }
 
+  .esri-attribution__sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
   ${media.phone`
     .esri-legend {
       max-width: 240px !important;

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -214,10 +214,6 @@
         "whatwg-fetch": "3.6.20",
         "yargs": "17.7.2"
       },
-      "engines": {
-        "node": ">=24.14.0",
-        "npm": ">=11.11.0"
-      },
       "optionalDependencies": {
         "fsevents": "2"
       }

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -214,6 +214,10 @@
         "whatwg-fetch": "3.6.20",
         "yargs": "17.7.2"
       },
+      "engines": {
+        "node": ">=24.14.0",
+        "npm": ">=11.11.0"
+      },
       "optionalDependencies": {
         "fsevents": "2"
       }


### PR DESCRIPTION
# Changelog
## a11y
- add flex-wrap to map attribution sources div 

before:
<img width="678" height="186" alt="Screenshot 2026-05-18 at 14 43 17" src="https://github.com/user-attachments/assets/6b1b08d5-fcb8-4ba4-b430-394a4552017c" />

after:
<img width="639" height="193" alt="Screenshot 2026-05-18 at 14 43 35" src="https://github.com/user-attachments/assets/289b4c85-794a-495a-b90e-f2ed98ee8ca4" />



# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
