### PR TITLE
TAN-7159 - Tighten user bio sanitization so it matches what the front-end allows

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -381,7 +381,7 @@ class User < ApplicationRecord
     service = SanitizationService.new
     self.bio_multiloc = service.sanitize_multiloc(
       bio_multiloc,
-      %i[title alignment list decoration link video]
+      %i[decoration link]
     )
     self.bio_multiloc = service.remove_multiloc_empty_trailing_tags(bio_multiloc)
     self.bio_multiloc = service.linkify_multiloc(bio_multiloc)

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -497,6 +497,29 @@ RSpec.describe User do
       })
       expect(user.bio_multiloc).to eq({ 'en' => '<p>Test</p>This should be removed!' })
     end
+
+    it 'strips style attributes from the body' do
+      user = create(:user, bio_multiloc: {
+        'en' => '<p style="color:red"><strong>Hi</strong></p>'
+      })
+      expect(user.bio_multiloc).to eq({ 'en' => '<p><strong>Hi</strong></p>' })
+    end
+
+    it 'keeps decoration and link formatting' do
+      user = create(:user, bio_multiloc: {
+        'en' => '<p><strong>bold</strong> <em>italic</em> <a href="https://example.com">link</a></p>'
+      })
+      expect(user.bio_multiloc).to eq({
+        'en' => '<p><strong>bold</strong> <em>italic</em> <a href="https://example.com" rel="nofollow">link</a></p>'
+      })
+    end
+
+    it 'removes video iframes from the body' do
+      user = create(:user, bio_multiloc: {
+        'en' => '<p>Watch</p><iframe src="https://www.youtube.com/embed/abc"></iframe>'
+      })
+      expect(user.bio_multiloc).to eq({ 'en' => '<p>Watch</p>' })
+    end
   end
 
   describe 'locale' do


### PR DESCRIPTION
# Changelog
## Fixed
- Tightened user bio HTML tag sanitization so it matches what the front-end allows
