### PR TITLE
Set NODE_OPTIONS memory limit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,6 +131,7 @@ services:
     environment:
       - API_HOST=web
       - API_PORT=4000
+      - NODE_OPTIONS=--max-old-space-size=4096
     tty: true
     stdin_open: true
     profiles:


### PR DESCRIPTION
# Changelog
## Technical
- Set memory limit to FE container if running `make up-docker` to avoid out of memory error
