### PR TITLE
Tighten theme typing in typedStyled interpolations

### DIFF
--- a/front/app/utils/cl-router/Link.tsx
+++ b/front/app/utils/cl-router/Link.tsx
@@ -9,7 +9,10 @@ import {
   type LinkComponentProps,
   type RegisteredRouter,
 } from '@tanstack/react-router';
-import styled from 'styled-components';
+import styled, {
+  type DefaultTheme,
+  type Interpolation,
+} from 'styled-components';
 
 import useLocale from 'hooks/useLocale';
 
@@ -23,12 +26,16 @@ export type { WrapperTo, TypedLinkProps } from './localeAware';
 // components like cl-router/Link, so `styled(Link)` drops route-aware typing.
 // Use `typedStyled(Link)` instead of casting `as typeof Link` to preserve the
 // wrapped component's full type.
+//
+// Interpolations are typed as styled-components' `Interpolation` (props carry
+// `theme`) rather than `unknown` — otherwise `${({ theme }) => ...}` callbacks
+// lose their contextual type and `theme` becomes an implicit `any`.
 export function typedStyled<C>(component: C) {
   return styled(
     component as unknown as React.ComponentType<unknown>
   ) as unknown as (
     strings: TemplateStringsArray,
-    ...interpolations: unknown[]
+    ...interpolations: Interpolation<{ theme: DefaultTheme }>[]
   ) => C;
 }
 


### PR DESCRIPTION
# Changelog
## Technical
- Fixed `typedStyled` (`cl-router/Link`) so `theme` is correctly typed inside styled-component template interpolations instead of being inferred as `any`. Interpolations are now typed as styled-components' `Interpolation` rather than `unknown`.
