### PR TITLE
TAN-7825: Redirect logged-out users from admin routes to home

### DIFF
--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -113,7 +113,7 @@ const AdminLayoutElement = () => {
 
   // Logged-out users hitting an admin route are sent home; the Unauthorized
   // screen is reserved for logged-in users without the right permissions.
-  if (!redirect && !accessAuthorized && authUser === null) {
+  if (!redirect && !accessAuthorized && !authUser) {
     return <Navigate to="/" />;
   }
 

--- a/front/app/containers/Admin/routes.tsx
+++ b/front/app/containers/Admin/routes.tsx
@@ -102,13 +102,20 @@ const AdminLayoutElement = () => {
     action: 'access',
   });
 
+  const { data: authUser, isLoading: isLoadingAuthUser } = useAuthUser();
   const { data: appConfiguration } = useAppConfiguration();
 
-  if (!appConfiguration) return null;
+  if (!appConfiguration || isLoadingAuthUser) return null;
 
   const redirect = accessAuthorized
     ? null
     : getUnauthorizedRedirect(appConfiguration.data, pathname);
+
+  // Logged-out users hitting an admin route are sent home; the Unauthorized
+  // screen is reserved for logged-in users without the right permissions.
+  if (!redirect && !accessAuthorized && authUser === null) {
+    return <Navigate to="/" />;
+  }
 
   if (!redirect && !accessAuthorized) {
     return <Unauthorized />;
@@ -150,9 +157,11 @@ export const adminRoute = createRoute({
 
 // Moderators don't have access to /admin/dashboard/overview.
 const AdminIndexRedirect = () => {
-  const { data: authUser } = useAuthUser();
+  const { data: authUser, isLoading } = useAuthUser();
 
-  if (!authUser) return null;
+  if (isLoading) return null;
+
+  if (!authUser) return <Navigate to="/" />;
 
   if (!isAdmin(authUser) && isModerator(authUser)) {
     return <Navigate to="/admin/projects" />;

--- a/front/app/utils/permissions/rules/routePermissions.ts
+++ b/front/app/utils/permissions/rules/routePermissions.ts
@@ -95,7 +95,7 @@ export const canAccessRoute = (
       return isCommunityMonitorModerator(user, tenant);
     }
 
-    if (!isRegularUser(user) && isModeratorRoute(item)) {
+    if (user && !isRegularUser(user) && isModeratorRoute(item)) {
       return true;
     }
 


### PR DESCRIPTION
# Changelog
## Fixed
- Logged-out visitors who navigate to an admin URL are now redirected to the home page. 