### PR TITLE
[TAN-7266] Fix AI analysis for Common Ground phases

### DIFF
--- a/back/engines/commercial/analysis/app/models/analysis/analysis.rb
+++ b/back/engines/commercial/analysis/app/models/analysis/analysis.rb
@@ -107,7 +107,7 @@ module Analysis
       # TODO: move-participation-method-logic
       allowed_project_methods = %w[ideation voting]
       project_or_nil = project || nil
-      if phase && %w[native_survey proposals community_monitor_survey].exclude?(phase.participation_method)
+      if phase && %w[native_survey proposals community_monitor_survey common_ground].exclude?(phase.participation_method)
         errors.add(:base, :project_or_phase_form_context, message: 'An analysis should be associated with a valid form context. The passed phase is not associated with a form definition.')
       elsif project_or_nil&.phases&.none? { |phase| allowed_project_methods.include?(phase.participation_method) }
         errors.add(:base, :project_or_phase_form_context, message: 'An analysis should be associated with a valid form context. The passed project has no phases supporting a participation method that can hold inputs')

--- a/back/engines/commercial/analysis/spec/acceptance/analyses_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/analyses_spec.rb
@@ -144,6 +144,24 @@ resource 'Analyses' do
         expect(response_status).to eq 422
       end
     end
+
+    describe do
+      let(:project) { create(:project) }
+      let(:phase) { create(:common_ground_phase, :ongoing, project: project) }
+      let(:phase_id) { phase.id }
+
+      example_request 'Create a phase analysis (common ground phase) when no custom_form exists' do
+        expect(response_status).to eq 201
+        additional_custom_field_ids = response_data.dig(:relationships, :additional_custom_fields, :data).pluck(:id)
+        expect(additional_custom_field_ids).not_to be_empty
+        included_additional_fields = json_response_body[:included].select { |d| additional_custom_field_ids.include? d[:id] }
+        expect(included_additional_fields.map { |d| d[:attributes][:code] }).to match_array(%w[title_multiloc])
+
+        tags = Analysis::Analysis.find(response_data[:id]).tags
+        expect(tags.count).to be > 0
+        expect(tags.pluck(:tag_type).uniq).to eq ['onboarding_example']
+      end
+    end
   end
 
   patch 'web_api/v1/analyses/:id' do

--- a/back/lib/participation_method/common_ground.rb
+++ b/back/lib/participation_method/common_ground.rb
@@ -27,6 +27,20 @@ module ParticipationMethod
       input.idea_status ||= IdeaStatus.find_by!(code: 'proposed', participation_method: 'ideation')
     end
 
+    # NOTE: This is only ever used by the analyses controller - otherwise the front-end always persists the form
+    def create_default_form!
+      form = CustomForm.create(participation_context: phase)
+
+      default_fields(form).reverse_each do |field|
+        field.save!
+        field.move_to_top
+      end
+
+      phase.reload
+
+      form
+    end
+
     # This is necessary in order to be able to retrieve the inputs using the +IdeasFinder+
     # class, which excludes inputs that aren't publicly visible. While this isn't a great
     # reason to set the flag to true, it doesn't cause too much harm. The main issue with

--- a/back/spec/lib/participation_method/common_ground_spec.rb
+++ b/back/spec/lib/participation_method/common_ground_spec.rb
@@ -63,6 +63,18 @@ RSpec.describe ParticipationMethod::CommonGround do
     end
   end
 
+  describe '#create_default_form!' do
+    it 'creates a phase-scoped custom form with the default fields' do
+      expect { participation_method.create_default_form! }.to change(CustomForm, :count).by(1)
+
+      form = phase.reload.custom_form
+      expect(form).to be_present
+      expect(form.participation_context).to eq(phase)
+      expect(form.custom_fields.pluck(:code)).to match_array(%w[title_page title_multiloc] + [nil])
+      expect(form.custom_fields.find_by(code: 'title_multiloc').input_type).to eq('text_multiloc')
+    end
+  end
+
   describe 'constraints' do
     it 'has no constraints' do
       expect(participation_method.constraints).to eq({})


### PR DESCRIPTION
- Fix 500 when clicking "Open AI analysis" on a Common Ground phase. `SideFxAnalysisService#before_create` calls `participation_method.create_default_form!` to auto-create a fallback form, but `ParticipationMethod::CommonGround` inherited the base no-op. With no form created, the subsequent `IdeaCustomFieldsService.new(nil)` raised `NoMethodError: undefined method 'participation_context'` for `nil`.
- Override `create_default_form!` in `ParticipationMethod::CommonGround` to create a phase-scoped `CustomForm` populated with the default fields (matches the `NativeSurvey` pattern, since Common Ground is non-transitive).
- Allow `common_ground` in `Analysis::Analysis#project_or_phase_form_context` — without this, even after a form exists the create would 422.
- Net result: the auto-fallback picks up the `title_multiloc` field as the additional field and the analysis is created successfully.

## Test plan

- `bin/rspec spec/lib/participation_method/common_ground_spec.rb` — covers the new `create_default_form!`
- `bin/rspec engines/commercial/analysis/spec/acceptance/analyses_spec.rb` — new acceptance example for Common Ground phase analysis creation
- Manual: in back office, open a Common Ground phase's input manager and click "Open AI analysis" — should land on the analysis page with `title_multiloc` selected as an additional field => It does, (testing locally), and AI summarising of inputs also seems to work.

## Claude Code's opinion on 'transitive' issues raised in ticket:

**What "transitive" means here:**

It's a participation-method flag (`ParticipationMethod::Base#transitive?`). It controls two things:
  1. Where the `CustomForm` lives — `transitive? = true` → form on the `project; false` → form on the phase.
  2. Whether inputs are scoped to one phase or shared across the project's phases — `transitive? = true` → `creation_phase_id` is `nil` and the same `Idea` record can be associated to multiple phases via `ideas_phases` (`app/models/idea.rb:258`: `scope :transitive, -> { where(creation_phase: nil) })`; `false` → `creation_phase_id` is pinned to the phase the input was created in.

Only ideation and voting are transitive. `common_ground`, `native_survey`, `proposals`, etc. are not. So the rule for Common Ground is already: each input has `creation_phase_id = <that common ground phase>` and is linked to exactly one phase.

**What James was probably seeing:**
Likely the Import inputs flow (the "Start from past inputs" button in the Common Ground input manager). `Ideas::CopyService` (`back/app/services/ideas/copy_service.rb:5-62`) creates brand new Idea records for the destination Common Ground phase — it sets `i.phases = [dest_phase]` and `i.creation_phase = dest_phase`. The copies look like ideation ideas (same title/body), and an `IdeaRelation` links each copy back to the source idea, but they are not the same record and not shared. The existing `copy_service_spec` at `back/spec/services/ideas/copy_service_spec.rb:25-33` codifies this: "sets the creation_phase_id to the destination phase".

So the apparent "sharing from the ideation phase" is actually copies, not a violation of non-transitivity.

**Is there a separate issue to address?**
I don't see one for the AI analysis fix. Specifically:
- No code path in normal usage links a Common Ground idea to multiple phases. The `CopyService` explicitly assigns a single phase, and `validate_creation_phase` (`app/models/idea.rb:439-458`) only forbids setting `creation_phase` on transitive methods — it doesn't enforce single-phase membership, but nothing creates multi-phase links for non-transitive methods either.
- `Analysis#inputs` (`engines/commercial/analysis/app/models/analysis/analysis.rb:58-64`) for a phase analysis uses `phase.ideas.published` (joined through `ideas_phases`). So the analysis would only ever see the ideas linked to the Common Ground phase itself, regardless of what else happens elsewhere.

Sebi's suggestion ("only linking common ground inputs to one common ground phase") is essentially the current behavior. There's nothing to enforce or fix to make AI analysis work correctly. If a specific tenant has corrupt data with Common Ground ideas linked to multiple phases (e.g. from an old project clone), that would be a data cleanup task on that tenant, not part of TAN-7266.

Recommendation: ship the fix as is. If James wants a defensive validation ("non-transitive ideas can only be linked to their creation_phase"), that's a separate, broader ticket — it would apply to `native_survey` and `proposals` too, and could surface unexpected data issues. Worth raising as a follow-up but not blocking this PR.

# Changelog
## Fixed
- [TAN-7266] Fix AI analysis for Common Ground phases
