### PR TITLE
[No-ticket] Always pull main when run make claude-setup

### DIFF
--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -88,6 +88,17 @@ else
   else
     echo "  (current branch has no upstream — skipping pull, using local working tree)"
   fi
+
+  # Also fast-forward local `main` to `origin/main` even when HEAD is on a
+  # feature branch. `git pull` above only advances the currently-checked-out
+  # branch, so without this `main` silently lags between setup runs — devs
+  # who later switch to main get a "behind by N commits" surprise.
+  current_branch="$(git -C "$PRIVATE_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")"
+  if [ "$current_branch" != "main" ]; then
+    if ! git -C "$PRIVATE_DIR" fetch origin main:main 2>/dev/null; then
+      echo "  (could not fast-forward local main — no remote main, or local main has diverged from origin/main)"
+    fi
+  fi
 fi
 
 mkdir -p .claude

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -456,6 +456,52 @@ preserved="$(cat "$PUBLIC/.claude/settings.local.json" 2>/dev/null || true)"
 assert_eq "$preserved" "$PERSONAL_CONTENT" "personal .claude/settings.local.json regular file preserved by setup-claude"
 
 
+# ----------------------------------------------------------------------------
+# Test: setup-claude fast-forwards local `main` to `origin/main` even when
+# HEAD is on a feature branch. Without this, `git pull` only advances the
+# currently-checked-out branch and the dev's local `main` silently lags
+# between setup runs — they hit "behind by N commits" when they later
+# switch to it.
+# ----------------------------------------------------------------------------
+# Ensure origin has a `main` branch (the initial fixture push may have
+# landed on `master` if the test runner's `init.defaultBranch` is `master`).
+(
+  cd "$FIXTURE_WT"
+  git fetch -q origin
+  if ! git ls-remote --exit-code --heads origin main >/dev/null 2>&1; then
+    cur="$(git rev-parse --abbrev-ref HEAD)"
+    git branch -f main "$cur"
+    git -c user.email=t@t -c user.name=t push -u -q origin main
+  fi
+  git checkout -q main
+  git pull -q --ff-only
+)
+# Ensure PRIVATE has a local `main`, then put HEAD on a feature branch
+# with no upstream (so the existing pull is skipped — exercising the path
+# where the main fast-forward is the only update happening).
+(
+  cd "$PRIVATE"
+  git fetch -q origin
+  if ! git rev-parse --verify --quiet refs/heads/main >/dev/null; then
+    git branch main origin/main
+  fi
+  git checkout -q -B feature-for-main-test
+)
+behind_sha="$(git -C "$PRIVATE" rev-parse main)"
+# Advance origin/main from FIXTURE_WT.
+(
+  cd "$FIXTURE_WT"
+  echo "advance" > main-advance.txt
+  git -c user.email=t@t -c user.name=t add -A
+  git -c user.email=t@t -c user.name=t commit -q -m "advance main"
+  git push -q origin main
+)
+ahead_sha="$(git -C "$FIXTURE_WT" rev-parse main)"
+assert_eq "$(git -C "$PRIVATE" rev-parse main)" "$behind_sha" "test setup sanity: PRIVATE main starts behind origin/main"
+run_setup
+assert_eq "$(git -C "$PRIVATE" rev-parse main)" "$ahead_sha" "local main fast-forwarded to origin/main even when HEAD is on a feature branch"
+
+
 # ============================================================================
 # Summary
 # ============================================================================


### PR DESCRIPTION
# Changelog
## Technical
- [No-ticket] Always pull main, if possible, when run `make claude-setup` (fixes case where main would not be updated if on different branch locally)
