### PR TITLE
[TAN-7831] Quick fix: do not assign UUID to bigint ID in Templates::ApplyService

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/apply_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/apply_service.rb
@@ -104,6 +104,14 @@ module MultiTenancy
 
         serialized_models['models'].each do |klass, models|
           next unless klass.attribute_names.include?('id')
+          # Only pre-generate identifiers for models with a UUID primary key. A bigint
+          # sequence PK (e.g. the areas_static_pages join table) would cast the UUID
+          # string to a garbage/colliding integer ('cbd4...'.to_i == 0), so leave its id
+          # unset and let the database sequence assign it.
+          # Temporary fix to avoid errors when processing AreasStaticPage records,
+          # which have a bigint PK but are included in the template with UUIDs as ids.
+          # See TAN-7831 ticket for details.
+          next unless klass.columns_hash['id']&.sql_type == 'uuid'
 
           models.each do |id, attributes|
             raise "Template contains duplicate id: #{id}" if id_mapping.key?(id)

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
@@ -36,4 +36,34 @@ describe MultiTenancy::Templates::ApplyService do
         .to raise_error(MultiTenancy::Templates::Utils::UnknownTemplateError)
     end
   end
+
+  describe '#generate_model_identifiers!' do
+    # AreasStaticPage is the only model with a bigint (sequence) PK; every other model
+    # uses a UUID. Pre-generating a UUID for its id would cast to a garbage/colliding
+    # integer and break template application, so its id must be left for the DB sequence.
+    let(:serialized_models) do
+      {
+        'models' => {
+          Area => { 'area-1' => { 'title_multiloc' => { 'en' => 'Area' } } },
+          AreasStaticPage => { 'asp-1' => {}, 'asp-2' => {} }
+        }
+      }
+    end
+
+    it 'pre-generates a UUID id for UUID-keyed models' do
+      mapping = service.send(:generate_model_identifiers!, serialized_models)
+
+      generated_id = serialized_models['models'][Area]['area-1']['id']
+      expect(generated_id).to match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/)
+      expect(mapping['area-1']).to eq(generated_id)
+    end
+
+    it 'does not assign an id to bigint-keyed models (leaves it to the DB sequence)' do
+      mapping = service.send(:generate_model_identifiers!, serialized_models)
+
+      expect(serialized_models['models'][AreasStaticPage]['asp-1']).not_to have_key('id')
+      expect(serialized_models['models'][AreasStaticPage]['asp-2']).not_to have_key('id')
+      expect(mapping).not_to include('asp-1', 'asp-2')
+    end
+  end
 end


### PR DESCRIPTION
See [TAN-7831](https://www.notion.so/govocal/Create-tenant-via-AdminHQ-failing-due-to-bigInt-ID-for-AreasStaticPage-3679663b7b26809d9e40c18b0a3ffe87) for details of bug, and planned permanent fix (not in this PR, but probably quite simple).

This should get things working again (only create from template with 2 or more `areas_static_pages` would reveal this issue before this fix). I want to do some research before writing and applying the proper fix.

# Changelog
## Fixed
- [TAN-7831] Quick fix: do not assign `UUID` to `bigint` ID in `Templates::ApplyService` (Temporary fix to prevent error when creating tenant from template with 2 or more `areas_static_pages` records)