### PR TITLE
[TAN-7834] Correctly detect duplicate emails when inviting

### DIFF
--- a/back/app/services/invites/service.rb
+++ b/back/app/services/invites/service.rb
@@ -129,12 +129,20 @@ class Invites::Service
   end
 
   def check_duplicate_emails(invitees)
-    emails_indexes = invitees.each_with_object(Hash.new { [] }).with_index do |(invitee, object), index|
-      object[invitee.email] += [index]
+    # Group case-insensitively (like User.find_by_cimail), otherwise case variants
+    # of the same email slip past this check and only collide at save! time, raising
+    # an unhandled :taken_by_invite. Keep the first spelling seen for the error value.
+    indexes_by_email = Hash.new { |hash, key| hash[key] = [] }
+    display_emails = {}
+    invitees.each_with_index do |invitee, index|
+      next unless invitee.email
+
+      key = invitee.email.downcase
+      indexes_by_email[key] << index
+      display_emails[key] ||= invitee.email
     end
-    duplicated_emails_indexes = emails_indexes.select { |email, row_indexes| email && row_indexes.size > 1 }
-    duplicated_emails_indexes.each do |email, row_indexes|
-      add_error(:emails_duplicate, rows: row_indexes, value: email)
+    indexes_by_email.select { |_key, row_indexes| row_indexes.size > 1 }.each do |key, row_indexes|
+      add_error(:emails_duplicate, rows: row_indexes, value: display_emails[key])
     end
   end
 

--- a/back/app/services/invites/service.rb
+++ b/back/app/services/invites/service.rb
@@ -130,19 +130,13 @@ class Invites::Service
 
   def check_duplicate_emails(invitees)
     # Group case-insensitively (like User.find_by_cimail), otherwise case variants
-    # of the same email slip past this check and only collide at save! time, raising
-    # an unhandled :taken_by_invite. Keep the first spelling seen for the error value.
-    indexes_by_email = Hash.new { |hash, key| hash[key] = [] }
-    display_emails = {}
-    invitees.each_with_index do |invitee, index|
-      next unless invitee.email
-
-      key = invitee.email.downcase
-      indexes_by_email[key] << index
-      display_emails[key] ||= invitee.email
+    # of the same email slip past this check and only collide at save! time.
+    emails_indexes = invitees.each_with_object(Hash.new { [] }).with_index do |(invitee, object), index|
+      object[invitee.email&.downcase] += [index]
     end
-    indexes_by_email.select { |_key, row_indexes| row_indexes.size > 1 }.each do |key, row_indexes|
-      add_error(:emails_duplicate, rows: row_indexes, value: display_emails[key])
+    duplicated_emails_indexes = emails_indexes.select { |email, row_indexes| email && row_indexes.size > 1 }
+    duplicated_emails_indexes.each do |email, row_indexes|
+      add_error(:emails_duplicate, rows: row_indexes, value: email)
     end
   end
 

--- a/back/spec/services/invites/service_spec.rb
+++ b/back/spec/services/invites/service_spec.rb
@@ -608,6 +608,27 @@ describe Invites::Service do
       end
     end
 
+    context 'with duplicate emails that differ only in case' do
+      let(:hash_array) do
+        [
+          { email: 'someuser@somedomain.com' },
+          { email: 'SomeUser@somedomain.com' }
+        ]
+      end
+
+      # check_duplicate_emails compares the raw email strings, so case variants
+      # slip past the up-front duplicate check. The collision is then only caught
+      # by the case-insensitive DB lookup at save! time, which raises
+      # :taken_by_invite (an error key with no translation) and crashes
+      # Invites::CountNewSeatsJob. They should be flagged as duplicates instead.
+      it 'detects them as duplicates instead of crashing at save time' do
+        expect { service.bulk_create_xlsx(xlsx, {}) }.to raise_error(Invites::FailedError)
+        expect(service_errors.size).to eq 1
+        expect(service_errors.first.error_key).to eq Invites::ErrorStorage::INVITE_ERRORS[:emails_duplicate]
+        expect(service_errors.first.rows).to eq [2, 3]
+      end
+    end
+
     context 'with duplicate first and last names' do
       let(:hash_array) do
         [


### PR DESCRIPTION
When duplicate emails existed in the provided list of invitees (XLSX), but the duplicates used different character casings (e.g. `alice@g.com` && `Alice@g.com`) the import service did not detect and raise an error, but the save! would fail, resulting in a silent error and an infinite loop in the async import process == infinite spinner, no invites created, and no error message.

Now, we catch the error and feedback the failure to the user in the UI:

<img width="608" height="343" alt="Screenshot 2026-05-21 at 15 14 09" src="https://github.com/user-attachments/assets/50a439fa-7297-41fc-a222-a8634ab3a7c5" />

# Changelog
## Fixed
- [TAN-7834] Correctly detect duplicate emails when inviting (fixes bug when different character case used for an duplicate emails in XLSX import. e.g. `Alice@g.com` && `alice@g.com`, resulted in infinite spinner, no useful error and no invites created)
