### PR TITLE
[TAN-7831] Migration to change areas_static_pages ID to UUID

### DIFF
--- a/back/app/models/areas_static_page.rb
+++ b/back/app/models/areas_static_page.rb
@@ -4,11 +4,11 @@
 #
 # Table name: areas_static_pages
 #
+#  id             :uuid             not null, primary key
 #  area_id        :uuid             not null
 #  static_page_id :uuid             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
-#  id             :uuid             not null, primary key
 #
 # Indexes
 #

--- a/back/app/models/areas_static_page.rb
+++ b/back/app/models/areas_static_page.rb
@@ -4,11 +4,11 @@
 #
 # Table name: areas_static_pages
 #
-#  id             :bigint           not null, primary key
 #  area_id        :uuid             not null
 #  static_page_id :uuid             not null
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
+#  id             :uuid             not null, primary key
 #
 # Indexes
 #

--- a/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
+++ b/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# areas_static_pages was created (20221111132019) without `id: :uuid`, so it received
+# the Rails-default bigint primary key - the only such table in the schema; every other
+# table uses a uuid id. Nothing references this id (no foreign keys, no application
+# code - the associations join on area_id / static_page_id), so we replace it outright
+# with a uuid to match the convention.
+#
+# This also removes the root cause of the tenant-template failure in TAN-7831: template
+# application assigns a uuid to every model id, and a uuid string cast to this bigint
+# column collapsed to a colliding integer ('cbd4...'.to_i == 0).
+class ChangeAreasStaticPagesIdToUuid < ActiveRecord::Migration[7.2]
+  # The table is small and unreferenced, so this brief rewrite is safe. Dropping the
+  # column also drops its owned sequence. Rails has no DSL for the primary-key constraint
+  # itself, so that one step stays raw SQL. Strong Migrations can't introspect these, so
+  # the change is wrapped in safety_assured.
+  # rubocop:disable Rails/DangerousColumnNames -- intentionally redefining the `id` PK
+  def up
+    safety_assured do
+      remove_column :areas_static_pages, :id
+      add_column :areas_static_pages, :id, :uuid,
+        default: -> { 'shared_extensions.gen_random_uuid()' }, null: false
+      execute 'ALTER TABLE areas_static_pages ADD PRIMARY KEY (id)'
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :areas_static_pages, :id
+      add_column :areas_static_pages, :id, :primary_key
+    end
+  end
+  # rubocop:enable Rails/DangerousColumnNames
+end

--- a/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
+++ b/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
@@ -9,26 +9,50 @@
 # This also removes the root cause of the tenant-template failure in TAN-7831: template
 # application assigns a uuid to every model id, and a uuid string cast to this bigint
 # column collapsed to a colliding integer ('cbd4...'.to_i == 0).
+#
+# PostgreSQL cannot reposition a column, so swapping the id type in place would leave the
+# new id as the last column - inconsistent with every other table, where id comes first.
+# The table is small and unreferenced, so we rebuild it from scratch instead: a fresh
+# table with id first, the rows copied over, then the old table dropped. Index and
+# foreign-key names derive from the table name, so the rebuilt table reproduces them
+# identically.
 class ChangeAreasStaticPagesIdToUuid < ActiveRecord::Migration[7.2]
-  # The table is small and unreferenced, so this brief rewrite is safe. Dropping the
-  # column also drops its owned sequence. Rails has no DSL for the primary-key constraint
-  # itself, so that one step stays raw SQL. Strong Migrations can't introspect these, so
-  # the change is wrapped in safety_assured.
-  # rubocop:disable Rails/DangerousColumnNames -- intentionally redefining the `id` PK
   def up
     safety_assured do
-      remove_column :areas_static_pages, :id
-      add_column :areas_static_pages, :id, :uuid,
-        default: -> { 'shared_extensions.gen_random_uuid()' }, null: false
-      execute 'ALTER TABLE areas_static_pages ADD PRIMARY KEY (id)'
+      rebuild_table do |t|
+        t.primary_key :id, :uuid, default: -> { 'shared_extensions.gen_random_uuid()' }
+      end
     end
   end
 
+  # Rebuilds the original bigint-id table, again with id first.
   def down
     safety_assured do
-      remove_column :areas_static_pages, :id
-      add_column :areas_static_pages, :id, :primary_key
+      rebuild_table do |t|
+        t.primary_key :id
+      end
     end
   end
-  # rubocop:enable Rails/DangerousColumnNames
+
+  private
+
+  def rebuild_table
+    # rename_table also renames the table's indexes, pkey and sequence to the _old name,
+    # which frees the canonical names for the rebuilt table below.
+    rename_table :areas_static_pages, :areas_static_pages_old
+
+    create_table :areas_static_pages, id: false do |t|
+      yield t
+      t.references :area, index: true, foreign_key: true, type: :uuid, null: false
+      t.references :static_page, index: true, foreign_key: true, type: :uuid, null: false
+      t.timestamps
+    end
+
+    execute(<<~SQL.squish)
+      INSERT INTO areas_static_pages (area_id, static_page_id, created_at, updated_at)
+      SELECT area_id, static_page_id, created_at, updated_at FROM areas_static_pages_old
+    SQL
+
+    drop_table :areas_static_pages_old
+  end
 end

--- a/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
+++ b/back/db/migrate/20260521120000_change_areas_static_pages_id_to_uuid.rb
@@ -20,7 +20,9 @@ class ChangeAreasStaticPagesIdToUuid < ActiveRecord::Migration[7.2]
   def up
     safety_assured do
       rebuild_table do |t|
+        # rubocop:disable Rails/DangerousColumnNames -- intentionally (re)defining the `id` PK
         t.primary_key :id, :uuid, default: -> { 'shared_extensions.gen_random_uuid()' }
+        # rubocop:enable Rails/DangerousColumnNames
       end
     end
   end
@@ -29,7 +31,9 @@ class ChangeAreasStaticPagesIdToUuid < ActiveRecord::Migration[7.2]
   def down
     safety_assured do
       rebuild_table do |t|
+        # rubocop:disable Rails/DangerousColumnNames -- intentionally (re)defining the `id` PK
         t.primary_key :id
+        # rubocop:enable Rails/DangerousColumnNames
       end
     end
   end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -637,7 +637,6 @@ ALTER TABLE IF EXISTS ONLY public.analysis_additional_custom_fields DROP CONSTRA
 ALTER TABLE IF EXISTS ONLY public.admin_publications DROP CONSTRAINT IF EXISTS admin_publications_pkey;
 ALTER TABLE IF EXISTS ONLY public.activities DROP CONSTRAINT IF EXISTS activities_pkey;
 ALTER TABLE IF EXISTS public.que_jobs ALTER COLUMN id DROP DEFAULT;
-ALTER TABLE IF EXISTS public.areas_static_pages ALTER COLUMN id DROP DEFAULT;
 DROP TABLE IF EXISTS public.wise_voice_flags;
 DROP TABLE IF EXISTS public.webhooks_subscriptions;
 DROP TABLE IF EXISTS public.webhooks_deliveries;
@@ -735,7 +734,6 @@ DROP TABLE IF EXISTS public.common_passwords;
 DROP TABLE IF EXISTS public.claim_tokens;
 DROP TABLE IF EXISTS public.baskets_ideas;
 DROP TABLE IF EXISTS public.authoring_assistance_responses;
-DROP SEQUENCE IF EXISTS public.areas_static_pages_id_seq;
 DROP TABLE IF EXISTS public.areas_static_pages;
 DROP TABLE IF EXISTS public.areas_projects;
 DROP TABLE IF EXISTS public.areas;
@@ -2169,31 +2167,12 @@ CREATE TABLE public.areas_projects (
 --
 
 CREATE TABLE public.areas_static_pages (
-    id bigint NOT NULL,
     area_id uuid NOT NULL,
     static_page_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL,
+    id uuid DEFAULT shared_extensions.gen_random_uuid() NOT NULL
 );
-
-
---
--- Name: areas_static_pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.areas_static_pages_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: areas_static_pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.areas_static_pages_id_seq OWNED BY public.areas_static_pages.id;
 
 
 --
@@ -3873,13 +3852,6 @@ CREATE TABLE public.wise_voice_flags (
     created_at timestamp(6) without time zone NOT NULL,
     updated_at timestamp(6) without time zone NOT NULL
 );
-
-
---
--- Name: areas_static_pages id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.areas_static_pages ALTER COLUMN id SET DEFAULT nextval('public.areas_static_pages_id_seq'::regclass);
 
 
 --
@@ -8581,6 +8553,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260521120000'),
 ('20260429101252'),
 ('20260421105121'),
 ('20260420120659'),

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -2167,11 +2167,11 @@ CREATE TABLE public.areas_projects (
 --
 
 CREATE TABLE public.areas_static_pages (
+    id uuid DEFAULT shared_extensions.gen_random_uuid() NOT NULL,
     area_id uuid NOT NULL,
     static_page_id uuid NOT NULL,
     created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    id uuid DEFAULT shared_extensions.gen_random_uuid() NOT NULL
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
@@ -38,32 +38,36 @@ describe MultiTenancy::Templates::ApplyService do
   end
 
   describe '#generate_model_identifiers!' do
-    # AreasStaticPage is the only model with a bigint (sequence) PK; every other model
-    # uses a UUID. Pre-generating a UUID for its id would cast to a garbage/colliding
-    # integer and break template application, so its id must be left for the DB sequence.
-    let(:serialized_models) do
-      {
+    it 'assigns a fresh SecureRandom uuid to each UUID-keyed record, including areas_static_pages' do
+      new_ids = [SecureRandom.uuid, SecureRandom.uuid, SecureRandom.uuid]
+      allow(SecureRandom).to receive(:uuid).and_return(*new_ids)
+
+      serialized_models = {
         'models' => {
           Area => { 'area-1' => { 'title_multiloc' => { 'en' => 'Area' } } },
+          # areas_static_pages now has a uuid PK (TAN-7831), so its join rows each get a
+          # distinct uuid instead of colliding when cast to the old bigint id.
           AreasStaticPage => { 'asp-1' => {}, 'asp-2' => {} }
         }
       }
-    end
 
-    it 'pre-generates a UUID id for UUID-keyed models' do
       mapping = service.send(:generate_model_identifiers!, serialized_models)
 
-      generated_id = serialized_models['models'][Area]['area-1']['id']
-      expect(generated_id).to match(/\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/)
-      expect(mapping['area-1']).to eq(generated_id)
+      expect(serialized_models['models'][Area]['area-1']['id']).to eq(new_ids[0])
+      expect(serialized_models['models'][AreasStaticPage]['asp-1']['id']).to eq(new_ids[1])
+      expect(serialized_models['models'][AreasStaticPage]['asp-2']['id']).to eq(new_ids[2])
+      expect(mapping).to eq('area-1' => new_ids[0], 'asp-1' => new_ids[1], 'asp-2' => new_ids[2])
     end
 
-    it 'does not assign an id to bigint-keyed models (leaves it to the DB sequence)' do
+    it 'skips models whose primary key is not a UUID, leaving the id for the database' do
+      column = instance_double(ActiveRecord::ConnectionAdapters::Column, sql_type: 'bigint')
+      non_uuid_model = class_double(Area, attribute_names: ['id'], columns_hash: { 'id' => column })
+      serialized_models = { 'models' => { non_uuid_model => { 'row-1' => {} } } }
+
       mapping = service.send(:generate_model_identifiers!, serialized_models)
 
-      expect(serialized_models['models'][AreasStaticPage]['asp-1']).not_to have_key('id')
-      expect(serialized_models['models'][AreasStaticPage]['asp-2']).not_to have_key('id')
-      expect(mapping).not_to include('asp-1', 'asp-2')
+      expect(serialized_models['models'][non_uuid_model]['row-1']).not_to have_key('id')
+      expect(mapping).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Plan
- merge & release this migration
- rebuild templates from template tenants (or wait for nightly job to do so)
- check templates are valid after rebuild (CI job will fail if not)
- remove the temporary guard mechanism introduced in #13934

# Changelog
## Technical
- [TAN-7831] Migration to change areas_static_pages ID to UUID
