### PR TITLE
[TAN-7839] Fix perspectives topics cards background colour

### DIFF
--- a/front/app/component-library/components/Box/Box.test.tsx
+++ b/front/app/component-library/components/Box/Box.test.tsx
@@ -522,4 +522,29 @@ describe('<Box />', () => {
       expect(el).toHaveAttribute('aria-label', 'hello');
     });
   });
+  describe('Box rendered as a custom component via `as`', () => {
+    it('forwards non-HTML props to the custom component', () => {
+      // Regression: a previous shouldForwardProp applied the HTML-attribute
+      // validator unconditionally, stripping component-specific props (e.g.
+      // Button's `buttonStyle`) when Box was rendered via `as={Component}`.
+      const received: Record<string, unknown> = {};
+      const CustomComponent = (props: { buttonStyle?: string }) => {
+        received.buttonStyle = props.buttonStyle;
+        return <div data-testid="custom">{String(props.buttonStyle)}</div>;
+      };
+      render(<Box as={CustomComponent} buttonStyle="secondary-outlined" />);
+      expect(received.buttonStyle).toBe('secondary-outlined');
+    });
+    it('still does not forward Box style props to the custom component', () => {
+      const received: Record<string, unknown> = {};
+      const CustomComponent = (props: { display?: string; gap?: string }) => {
+        received.display = props.display;
+        received.gap = props.gap;
+        return <div data-testid="custom" />;
+      };
+      render(<Box as={CustomComponent} display="flex" gap="8px" />);
+      expect(received.display).toBeUndefined();
+      expect(received.gap).toBeUndefined();
+    });
+  });
 });

--- a/front/app/component-library/components/Box/index.tsx
+++ b/front/app/component-library/components/Box/index.tsx
@@ -310,8 +310,26 @@ const styleOnlyProps = new Set<string>([
 ]);
 
 const Box = styled.div.withConfig({
-  shouldForwardProp: (prop, defaultValidatorFn) =>
-    !styleOnlyProps.has(prop) && defaultValidatorFn(prop),
+  // styled-components passes a third arg — the element being rendered (the `as`
+  // target, or `div` by default). Its TS types omit it, so it's declared
+  // optional here; at runtime v5 always supplies it.
+  shouldForwardProp: (
+    prop,
+    defaultValidatorFn,
+    elementToBeCreated?: unknown
+  ) => {
+    // Box's own style props are consumed by the css interpolations below and
+    // must never reach the rendered element (some collide with valid HTML
+    // attributes like `color`/`width`).
+    if (styleOnlyProps.has(prop)) return false;
+    // Mirror styled-components' default forwarding rule: when Box is rendered
+    // as a custom component via `as` (e.g. `as={StyledButton}`), forward all
+    // remaining props so the component receives the ones it needs (e.g.
+    // Button's `buttonStyle`). Only filter against valid HTML attributes when
+    // rendering an actual DOM element, where unknown props would leak.
+    const isDOMElement = typeof elementToBeCreated === 'string';
+    return !isDOMElement || defaultValidatorFn(prop);
+  },
 })<BoxProps>`
   // colors and background
   ${(props) => css`


### PR DESCRIPTION
## What
Fixes dark navy/purple/unreadable idea cards in the ideation "perspectives" sidebar, introduced by recent PR #13896

## Why

A recent `Box` `shouldForwardProp` change validated props unconditionally, stripping `buttonStyle` from `<Box as={StyledButton}>`. `Button` then fell back to its `primary` style (tenant navy). Now `Box` forwards non-style props to custom `as` components and only filters for real DOM elements — fixing every `Box as={Component}` site, not just this one.

## Testing
Added 2 `Box` regression tests.

Before:
<img width="1714" height="834" alt="Screenshot 2026-05-21 at 17 46 57" src="https://github.com/user-attachments/assets/ec4340f2-e7aa-456d-abdc-b383d83028ac" />

After:
<img width="1714" height="834" alt="Screenshot 2026-05-21 at 17 47 33" src="https://github.com/user-attachments/assets/73b7a1b5-21dd-46e6-a8d8-aefac29744d9" />

# Changelog
## Fixed
- [TAN-7839] Fix perspectives topics cards background colour
