### PR TITLE
[TAN-7363] Task to translate AI generated tags by regenerating them

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/base.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/base.rb
@@ -40,6 +40,11 @@ module Analysis
 
     attr_reader :analysis, :task, :input_to_text, :input_to_text_classify
 
+    # Optional locale (e.g. 'nl-NL') forcing the language AI-generated tag names are
+    # written in, overriding the platform/user-derived default. Left nil on the normal
+    # UI/job path; set only by maintenance scripts that regenerate tags in a chosen locale.
+    attr_accessor :specified_locale
+
     class AutoTaggingFailedError < StandardError; end
 
     def self.for_auto_tagging_method auto_tagging_method, *params

--- a/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/auto_tagging_method/nlp_topic.rb
@@ -70,7 +70,8 @@ module Analysis
     end
 
     def response_language
-      locale = Locale.monolingual&.to_s ||
+      locale = specified_locale ||
+               Locale.monolingual&.to_s ||
                most_recent_task_created_activity&.user&.locale ||
                AppConfiguration.instance.settings('core', 'locales').first ||
                I18n.default_locale

--- a/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_analysis_tags.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/demos/translate_analysis_tags.rake
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+# Regenerates the AI-generated topic tags (tag_type 'nlp_topic') of every analysis on a
+# single tenant, in a given locale.
+#
+# Background: nlp_topic tag names are free text written by the topic-modeling LLM in
+# whatever language it was instructed to use at generation time, and stored as a plain
+# string (no multiloc). So they don't follow a platform locale switch - a demo cloned with
+# English topics keeps showing English tags. This task re-runs topic modeling forcing the
+# requested locale, so the tags come out in the right language.
+#
+# Intended for manual use on freshly cloned tenants used as demo platforms - NOT on live
+# tenants. Topic modeling is non-deterministic, so regeneration produces *new* topics, not
+# translations of the existing ones; the previous nlp_topic tags (and their input
+# assignments) are deleted first. For that reason execute mode only runs on demo platforms
+# (lifecycle_stage = 'demo') or in local development; a dry run is allowed everywhere.
+#
+# It re-runs real LLM calls (one topic-modeling call plus one classification call per
+# input, per analysis), so it can be slow and incur API cost on tenants with many inputs.
+#
+# What it does:
+#   - Targets one tenant, identified by the `host` argument.
+#   - Requires the target `locale` to be one of the tenant's configured locales.
+#   - For each analysis that currently has nlp_topic tags: deletes those tags (their
+#     taggings cascade), then re-runs nlp_topic auto-tagging forcing the target locale,
+#     reusing the filters of the analysis's most recent nlp_topic run (or all inputs).
+#   - Regenerates the auto-insights heatmap for each touched analysis.
+#   - Writes a JSON report (translate_analysis_tags.json) of the per-analysis changes.
+#
+# What it does NOT do:
+#   - It does not touch other tag types (sentiment, language, controversial, platform_topic,
+#     custom) - their names are fixed strings, codes, or already localized.
+#   - It does not change anything in dry-run mode (the default).
+#   - It does not run across multiple tenants - one `host` per invocation.
+#
+# Example commands (run from the repo root):
+#   Dry run (no changes applied, just reports what would happen):
+#     docker compose run --rm web bundle exec rake 'demos:translate_analysis_tags[example.com,nl-NL]'
+#
+#   Execute (applies the changes):
+#     docker compose run --rm web bundle exec rake 'demos:translate_analysis_tags[example.com,nl-NL,execute]'
+
+namespace :demos do
+  desc 'Regenerate AI-generated (nlp_topic) analysis tags in a given locale'
+  task :translate_analysis_tags, %i[host locale execute] => [:environment] do |_t, args|
+    host = args[:host]
+    locale = args[:locale]
+    execute = args[:execute] == 'execute'
+
+    puts "---------- STARTING TASK: Translate analysis tags to '#{locale}' ----------\n\n"
+    puts "Mode: #{execute ? 'EXECUTE - changes WILL be applied' : 'Dry run - no changes will be applied'}\n\n"
+
+    if host.blank? || locale.blank?
+      puts 'ERROR! Both host and locale arguments are required. Usage: rake demos:translate_analysis_tags[example.com,nl-NL,execute]'
+      next
+    end
+
+    tenant = Tenant.find_by(host: host)
+    if tenant.nil?
+      puts "ERROR! No tenant found for host '#{host}'. Aborting."
+      next
+    end
+
+    # Regenerating tags deletes the existing ones, so applying changes is only allowed on
+    # demo platforms (lifecycle_stage = 'demo') or in local development. A dry run stays
+    # available everywhere.
+    lifecycle_stage = tenant.switch { AppConfiguration.instance.settings('core', 'lifecycle_stage') }
+    if execute && lifecycle_stage != 'demo' && !Rails.env.development?
+      puts "ERROR! Execute mode is only allowed on demo platforms (lifecycle_stage = 'demo') or in development (current: '#{lifecycle_stage}'). Run without 'execute' to do a dry run."
+      next
+    end
+
+    # The requested locale must be one the tenant is configured for - otherwise the tags
+    # would be generated in a language the platform can't display.
+    tenant_locales = tenant.switch { AppConfiguration.instance.settings('core', 'locales') }
+    unless tenant_locales.include?(locale)
+      puts "ERROR! Tenant '#{host}' does not have locale '#{locale}' configured (has: #{tenant_locales.join(', ')}). Aborting."
+      next
+    end
+
+    reporter = ScriptReporter.new
+    reporter.add_processed_tenant(tenant)
+
+    total_analyses = 0
+    total_tags_removed = 0
+    total_tags_created = 0
+    total_errors = 0
+
+    tenant.switch do
+      # Target the analyses that actually have AI-generated topic tags to regenerate.
+      analyses = Analysis::Analysis
+        .joins(:tags)
+        .where(analysis_tags: { tag_type: Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE })
+        .distinct
+
+      if analyses.empty?
+        puts 'No analyses with nlp_topic tags found - nothing to do.'
+      end
+
+      analyses.each do |analysis|
+        total_analyses += 1
+        existing_tags = analysis.tags.where(tag_type: Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE)
+        old_tag_names = existing_tags.pluck(:name).sort
+        context = { tenant: host, locale: locale, analysis: analysis.id }
+
+        puts "\n=== Analysis #{analysis.id} (#{old_tag_names.size} nlp_topic tags) ==="
+
+        unless execute
+          total_tags_removed += old_tag_names.size
+          puts "WOULD DELETE #{old_tag_names.size} nlp_topic tags: #{old_tag_names.join(', ')}"
+          puts "WOULD REGENERATE nlp_topic tags in '#{locale}'."
+          reporter.add_change(
+            { nlp_topic_tags: old_tag_names },
+            { nlp_topic_tags: "regenerated in '#{locale}'" },
+            context: context
+          )
+          next
+        end
+
+        begin
+          # Reuse the filters of the most recent nlp_topic run on this analysis, so the
+          # regenerated tags cover the same set of inputs. Fall back to all inputs ({}).
+          last_task = analysis.background_tasks
+            .where(type: 'Analysis::AutoTaggingTask', auto_tagging_method: Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE)
+            .order(created_at: :desc)
+            .first
+          filters = last_task&.filters || {}
+
+          existing_tags.destroy_all # taggings cascade via Tag's dependent: :destroy
+          total_tags_removed += old_tag_names.size
+          puts "DELETED #{old_tag_names.size} nlp_topic tags: #{old_tag_names.join(', ')}"
+
+          task = Analysis::AutoTaggingTask.create!(
+            analysis: analysis,
+            auto_tagging_method: Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE,
+            filters: filters,
+            state: 'queued'
+          )
+          atm = Analysis::AutoTaggingMethod::Base.for_auto_tagging_method(
+            Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE, task
+          )
+          atm.specified_locale = locale
+          atm.execute
+
+          raise "auto-tagging task ended in state '#{task.reload.state}'" unless task.state == 'succeeded'
+
+          new_tag_names = analysis.tags
+            .where(tag_type: Analysis::AutoTaggingMethod::NLPTopic::TAG_TYPE)
+            .pluck(:name).sort
+          total_tags_created += new_tag_names.size
+          puts "CREATED #{new_tag_names.size} nlp_topic tags: #{new_tag_names.join(', ')}"
+
+          Analysis::HeatmapGenerationJob.perform_later(analysis)
+
+          reporter.add_change(
+            { nlp_topic_tags: old_tag_names },
+            { nlp_topic_tags: new_tag_names },
+            context: context
+          )
+        rescue StandardError => e
+          total_errors += 1
+          reporter.add_error(e.message, context: context)
+          puts "  ERROR! Failed to regenerate tags for analysis #{analysis.id}: #{e.message}"
+        end
+      end
+    end
+
+    summary = {
+      'Analyses processed' => total_analyses,
+      (execute ? 'nlp_topic tags removed' : 'nlp_topic tags to be removed') => total_tags_removed
+    }
+    summary['nlp_topic tags created'] = total_tags_created if execute
+    summary['Errors'] = total_errors if execute
+
+    label_width = summary.keys.map(&:length).max
+    puts "\nSummary for tenant #{host} (target locale '#{locale}'):"
+    summary.each { |label, count| puts "  #{"#{label}:".ljust(label_width + 1)}  #{count}" }
+
+    begin
+      reporter.report!('translate_analysis_tags.json', verbose: false)
+      puts "\nReport written to translate_analysis_tags.json"
+    rescue StandardError => e
+      puts "ERROR! Failed to write report: #{e.message}"
+    end
+
+    puts "\n---------- FINISHED TASK: Translate analysis tags to '#{locale}' ----------\n\n"
+  end
+end

--- a/back/engines/commercial/multi_tenancy/spec/tasks/demos/translate_analysis_tags_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/tasks/demos/translate_analysis_tags_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'demos:translate_analysis_tags rake task' do
+  before { load_rake_tasks_if_not_loaded }
+
+  after do
+    Rake::Task['demos:translate_analysis_tags'].reenable
+    # The task writes its JSON report to the working directory.
+    FileUtils.rm_f(Rails.root.join('translate_analysis_tags.json'))
+  end
+
+  def run_task(execute: false, host: Tenant.current.host, locale: 'nl-NL')
+    Rake::Task['demos:translate_analysis_tags'].invoke(host, locale, execute ? 'execute' : nil)
+  end
+
+  let(:project) { create(:single_phase_ideation_project) }
+  let(:custom_form) { create(:custom_form, :with_default_fields, participation_context: project) }
+  let(:analysis) do
+    create(:analysis, main_custom_field: nil, additional_custom_fields: custom_form.custom_fields, project: project)
+  end
+
+  describe 'argument validation' do
+    it 'aborts when no host is given' do
+      expect { run_task(host: nil) }.to output(/Both host and locale arguments are required/).to_stdout
+    end
+
+    it 'aborts when no locale is given' do
+      expect { run_task(locale: nil) }.to output(/Both host and locale arguments are required/).to_stdout
+    end
+
+    it 'aborts when no tenant matches the host' do
+      expect { run_task(host: 'does-not-exist.example.com') }.to output(/No tenant found/).to_stdout
+    end
+
+    it 'aborts when the locale is not configured on the tenant' do
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      expect { run_task(execute: false, locale: 'de-DE') }.to output(/does not have locale 'de-DE' configured/).to_stdout
+      expect(analysis.tags.where(tag_type: 'nlp_topic').pluck(:name)).to eq(['Affordable Housing'])
+    end
+  end
+
+  describe 'dry-run mode' do
+    it 'does not delete existing nlp_topic tags' do
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      run_task(execute: false)
+
+      expect(analysis.tags.where(tag_type: 'nlp_topic').pluck(:name)).to eq(['Affordable Housing'])
+    end
+
+    it 'reports the tags that would be regenerated' do
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      expect { run_task(execute: false) }.to output(/WOULD DELETE 1 nlp_topic tags: Affordable Housing/).to_stdout
+    end
+  end
+
+  describe 'lifecycle guard' do
+    # The default test tenant has lifecycle_stage 'active', and tests run outside the
+    # development env, so execute mode is blocked here.
+    it 'refuses to apply changes on a non-demo tenant outside development' do
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      expect { run_task(execute: true) }.to output(/Execute mode is only allowed on demo platforms/).to_stdout
+      expect(analysis.tags.where(tag_type: 'nlp_topic').pluck(:name)).to eq(['Affordable Housing'])
+    end
+
+    it 'still allows a dry run on a non-demo tenant' do
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      expect { run_task(execute: false) }.to output(/WOULD DELETE/).to_stdout
+    end
+  end
+
+  # Execute mode only applies changes on demo platforms or in development, and the real
+  # nlp_topic run uses a thread pool (so no transactional fixtures).
+  describe 'execute mode', use_transactional_fixtures: false do
+    before do
+      # The default test tenant is 'active' and the model forbids flipping it to 'demo', so
+      # stub the lifecycle_stage the guard reads (passing other settings lookups through).
+      allow_any_instance_of(AppConfiguration).to receive(:settings).and_call_original
+      allow_any_instance_of(AppConfiguration)
+        .to receive(:settings).with('core', 'lifecycle_stage').and_return('demo')
+    end
+
+    def stub_topic_modeling(topics:, classification:)
+      topics_response = topics.map { |t| "- #{t}" }.join("\n")
+      allow_any_instance_of(Analysis::LLM::GPT41).to receive(:chat).and_return(topics_response)
+      allow_any_instance_of(Analysis::LLM::GPT4oMini).to receive(:chat).and_return(*classification)
+    end
+
+    it 'deletes the English nlp_topic tags and regenerates them in the target locale' do
+      create_list(:idea, 2, project: project)
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+      stub_topic_modeling(topics: ['Betaalbare woningen'], classification: ['Betaalbare woningen', 'Betaalbare woningen'])
+
+      run_task(execute: true)
+
+      nlp_names = analysis.tags.where(tag_type: 'nlp_topic').pluck(:name)
+      expect(nlp_names).to eq(['Betaalbare woningen'])
+    end
+
+    it 'forces topic generation into the requested locale' do
+      create(:idea, project: project)
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+
+      # The topic-modeling prompt instructs the LLM to write in the locale's language.
+      expect_any_instance_of(Analysis::LLM::GPT41)
+        .to receive(:chat).with(/Dutch/).and_return('- Betaalbare woningen')
+      allow_any_instance_of(Analysis::LLM::GPT4oMini).to receive(:chat).and_return('Betaalbare woningen')
+
+      run_task(execute: true)
+    end
+
+    it 'leaves other tag types untouched' do
+      create(:idea, project: project)
+      create(:tag, tag_type: 'nlp_topic', analysis: analysis, name: 'Affordable Housing')
+      sentiment_tag = create(:tag, tag_type: 'sentiment', analysis: analysis, name: 'sentiment +')
+      stub_topic_modeling(topics: ['Betaalbare woningen'], classification: ['Betaalbare woningen'])
+
+      run_task(execute: true)
+
+      expect(Analysis::Tag.exists?(sentiment_tag.id)).to be(true)
+    end
+
+    it 'does nothing for analyses without nlp_topic tags' do
+      create(:idea, project: project)
+      create(:tag, tag_type: 'sentiment', analysis: analysis, name: 'sentiment +')
+
+      expect_any_instance_of(Analysis::LLM::GPT41).not_to receive(:chat)
+
+      run_task(execute: true)
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
Eventual use = a task made available to use via AdminHQ &/or as part of a larger 'clone to demo' process available via AdminHQ (if/when developed).
Immediate use = standalone task a dev can run on request.

# Changelog
## Technical
- [TAN-7363] Task to translate AI generated tags by regenerating them
