### PR TITLE
 Fix dropdown keyboard navigation

### DIFF
--- a/front/app/components/FilterSelector/MultiSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/MultiSelectDropdown.tsx
@@ -156,13 +156,28 @@ const MultiSelectDropdown = ({
         break;
 
       case 'ArrowUp':
-        if (!opened) return;
         event.preventDefault();
+        if (!opened) {
+          toggleValuesList();
+          return;
+        }
         // From the trigger, jump to the last item.
         // From a list item, navigate to previous (circular ...,3,2,1,0,3).
         tabsRef.current[
           isNaN(index) ? totalItems - 1 : (index - 1 + totalItems) % totalItems
         ]?.focus();
+        break;
+
+      case 'Home':
+        if (!opened || isNaN(index)) return;
+        event.preventDefault();
+        tabsRef.current[0]?.focus();
+        break;
+
+      case 'End':
+        if (!opened || isNaN(index)) return;
+        event.preventDefault();
+        tabsRef.current[totalItems - 1]?.focus();
         break;
 
       case 'Enter':

--- a/front/app/components/FilterSelector/MultiSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/MultiSelectDropdown.tsx
@@ -210,6 +210,8 @@ const MultiSelectDropdown = ({
   }, [opened]);
 
   const handleOnClickOutside = (event: FormEvent) => {
+    // Skip trigger clicks — its onClick already toggles, otherwise it'd reopen immediately.
+    if (triggerRef.current?.contains(event.target as Node)) return;
     onClickOutside?.(event);
   };
 

--- a/front/app/components/FilterSelector/MultiSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/MultiSelectDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, KeyboardEvent, FormEvent } from 'react';
+import React, { useRef, KeyboardEvent, FormEvent, useEffect } from 'react';
 
 import {
   Dropdown,
@@ -87,7 +87,6 @@ export interface SelectorProps {
   closeExpanded: () => void;
   textColor?: string;
   currentTitle: string | JSX.Element;
-  handleKeyDown?: (event: KeyboardEvent) => void;
   isLoading?: boolean;
 }
 
@@ -121,7 +120,6 @@ const MultiSelectDropdown = ({
   closeExpanded,
   textColor,
   currentTitle,
-  handleKeyDown,
   isLoading,
 }: Props) => {
   const tabsRef = useRef<(HTMLLIElement | null)[]>([]);
@@ -146,11 +144,12 @@ const MultiSelectDropdown = ({
 
     switch (key) {
       case 'ArrowDown':
+        event.preventDefault();
         if (!opened) {
-          handleKeyDown?.(event);
+          // ArrowDown on the closed trigger opens the list, same as Enter.
+          toggleValuesList();
           return;
         }
-        event.preventDefault();
         // From the trigger (no data-index), jump into the list at item 0.
         // From a list item, navigate to next (circular 0,1,2,3,...,0).
         tabsRef.current[isNaN(index) ? 0 : (index + 1) % totalItems]?.focus();
@@ -189,6 +188,11 @@ const MultiSelectDropdown = ({
         break;
     }
   };
+  useEffect(() => {
+    if (opened) {
+      focusTrigger();
+    }
+  }, [opened]);
 
   const handleOnClickOutside = (event: FormEvent) => {
     onClickOutside?.(event);

--- a/front/app/components/FilterSelector/SingleSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/SingleSelectDropdown.tsx
@@ -71,7 +71,6 @@ const SingleSelectDropdown = ({
   closeExpanded,
   textColor,
   currentTitle,
-  handleKeyDown,
 }: Props) => {
   const listboxRef = useRef<HTMLUListElement>(null);
   const triggerRef = useRef<HTMLDivElement>(null);
@@ -85,14 +84,23 @@ const SingleSelectDropdown = ({
   const onTriggerKeyDown = (event: KeyboardEvent) => {
     // When the listbox is open, ArrowDown / ArrowUp on the trigger moves focus
     // into the listbox and highlights the first / last option.
-    if (opened && (event.key === 'ArrowDown' || event.key === 'ArrowUp')) {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (!opened) {
+        toggleValuesList();
+        return;
+      }
+      listboxRef.current?.focus();
+      setFocusedIndex(0);
+      return;
+    }
+    if (event.key === 'ArrowUp' && opened) {
       event.preventDefault();
       listboxRef.current?.focus();
       const items = listboxRef.current?.querySelectorAll('li') ?? [];
-      setFocusedIndex(event.key === 'ArrowDown' ? 0 : items.length - 1);
+      setFocusedIndex(items.length - 1);
       return;
     }
-    handleKeyDown?.(event);
   };
 
   useEffect(() => {
@@ -150,6 +158,11 @@ const SingleSelectDropdown = ({
       }
     }
   };
+  useEffect(() => {
+    if (opened) {
+      focusTrigger();
+    }
+  }, [opened]);
 
   return (
     <Box>

--- a/front/app/components/FilterSelector/SingleSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/SingleSelectDropdown.tsx
@@ -94,8 +94,12 @@ const SingleSelectDropdown = ({
       setFocusedIndex(0);
       return;
     }
-    if (event.key === 'ArrowUp' && opened) {
+    if (event.key === 'ArrowUp') {
       event.preventDefault();
+      if (!opened) {
+        toggleValuesList();
+        return;
+      }
       listboxRef.current?.focus();
       const items = listboxRef.current?.querySelectorAll('li') ?? [];
       setFocusedIndex(items.length - 1);
@@ -133,6 +137,14 @@ const SingleSelectDropdown = ({
               ? items.length - 1
               : prevIndex - 1
           );
+          break;
+        case 'Home':
+          event.preventDefault();
+          setFocusedIndex(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          setFocusedIndex(items.length - 1);
           break;
         case 'Enter':
         case ' ':

--- a/front/app/components/FilterSelector/SingleSelectDropdown.tsx
+++ b/front/app/components/FilterSelector/SingleSelectDropdown.tsx
@@ -176,6 +176,12 @@ const SingleSelectDropdown = ({
     }
   }, [opened]);
 
+  const handleOnClickOutside = (event: React.MouseEvent) => {
+    // Skip trigger clicks — its onClick already toggles, otherwise it'd reopen immediately.
+    if (triggerRef.current?.contains(event.target as Node)) return;
+    onClickOutside?.(event);
+  };
+
   return (
     <Box>
       <Box ref={triggerRef}>
@@ -231,7 +237,7 @@ const SingleSelectDropdown = ({
         right={right}
         mobileRight={mobileRight}
         opened={opened}
-        onClickOutside={onClickOutside}
+        onClickOutside={handleOnClickOutside}
         content={
           <List
             ref={listboxRef}

--- a/front/app/components/FilterSelector/index.tsx
+++ b/front/app/components/FilterSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, KeyboardEvent, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 
 import { Box, media, isRtl } from '@citizenlab/cl2-component-library';
 import {
@@ -206,18 +206,6 @@ const FilterSelector = ({
     closeExpanded();
   };
 
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'ArrowDown' && !opened) {
-      event.preventDefault();
-      toggleValuesList();
-      return;
-    }
-    if (event.key === 'Escape' && opened) {
-      event.preventDefault();
-      closeExpanded();
-    }
-  };
-
   // We use a random id for the selectorId to ensure it doesn't conflict if multiple
   // instances of the same filter selector are rendered on the same page.
   const selectorId = useMemo(
@@ -245,7 +233,6 @@ const FilterSelector = ({
     closeExpanded,
     textColor,
     currentTitle: getTitle(selected, values, multipleSelectionAllowed, title),
-    handleKeyDown,
   };
 
   return (


### PR DESCRIPTION
- Open the list on ArrowDown / ArrowUp from the closed trigger
  (matches Enter / Space behavior)
- Focus trigger on open so arrow keys hit our handlers instead of
  scrolling the page after a mouse click
- Add Home / End to jump to first / last option
- Remove the unused shared handleKeyDown plumbing between parent
  and Single / MultiSelect children
- Fix trigger click not closing open dropdown


# Changelog
## A11y 
-  Fix dropdown keyboard navigation

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
