### PR TITLE
[TAN-7802] Make keyboard focus ring clearly visible on every Button

### DIFF
--- a/front/app/component-library/components/Button/index.tsx
+++ b/front/app/component-library/components/Button/index.tsx
@@ -375,6 +375,13 @@ function getButtonStyle(
       }
     }
 
+    &:focus-visible,
+    &.focus-visible {
+      outline: 2px solid #000;
+      outline-offset: 4px;
+      box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
+    }
+
     &.fullWidth {
       flex: 1;
       width: 100%;

--- a/front/app/component-library/components/Button/index.tsx
+++ b/front/app/component-library/components/Button/index.tsx
@@ -378,8 +378,7 @@ function getButtonStyle(
     &:focus-visible,
     &.focus-visible {
       outline: 2px solid #000;
-      outline-offset: 4px;
-      box-shadow: 0 0 0 2px #000, 0 0 0 4px #fff;
+      outline-offset: 2px;
     }
 
     &.fullWidth {


### PR DESCRIPTION
# Changelog

## Fixed
- The keyboard focus indicator on Buttons is now clearly visible on every background. Previously the browser default focus ring blended in with tenant primary colors and white button backgrounds

# For translators
N/A — no copy changes.