### PR TITLE
[TAN-7865] Bugfix: Do not apply quarterly date filters to auto-generated AI survey answers summaries

### DIFF
--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/filters.test.ts
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/filters.test.ts
@@ -1,45 +1,45 @@
 import { getPublishedAtFromFilter, getPublishedAtToFilter } from './utils';
 
 describe('getPublishedAtFromFilter', () => {
-  it('returns the first day of Q1 when both params are provided', () => {
+  it('returns correct start date for Q1', () => {
     expect(getPublishedAtFromFilter('2025', '1')).toBe('2025-01-01');
   });
 
-  it('returns the first day of Q3 when both params are provided', () => {
+  it('returns correct start date for Q3', () => {
     expect(getPublishedAtFromFilter('2024', '3')).toBe('2024-07-01');
   });
 
-  it('returns undefined when yearParam is undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when year is missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtFromFilter(undefined, '1')).toBeUndefined();
   });
 
-  it('returns undefined when quarterParam is undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when quarter is missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtFromFilter('2025', undefined)).toBeUndefined();
   });
 
-  it('returns undefined when both params are undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when both year and quarter are missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtFromFilter(undefined, undefined)).toBeUndefined();
   });
 });
 
 describe('getPublishedAtToFilter', () => {
-  it('returns the last day of Q1 when both params are provided', () => {
+  it('returns correct end date for Q1', () => {
     expect(getPublishedAtToFilter('2025', '1')).toBe('2025-03-31');
   });
 
-  it('returns the last day of Q4 when both params are provided', () => {
+  it('returns correct end date for Q4', () => {
     expect(getPublishedAtToFilter('2023', '4')).toBe('2023-12-31');
   });
 
-  it('returns undefined when yearParam is undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when year is missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtToFilter(undefined, '1')).toBeUndefined();
   });
 
-  it('returns undefined when quarterParam is undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when quarter is missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtToFilter('2025', undefined)).toBeUndefined();
   });
 
-  it('returns undefined when both params are undefined (non-Community-Monitor flow)', () => {
+  it('returns undefined when both year and quarter are missing (non-Community-Monitor flow)', () => {
     expect(getPublishedAtToFilter(undefined, undefined)).toBeUndefined();
   });
 });

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/filters.test.ts
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/filters.test.ts
@@ -1,88 +1,45 @@
-import {
-  getQuarterFilter,
-  getYearFilter,
-} from 'containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/utils';
-
 import { getPublishedAtFromFilter, getPublishedAtToFilter } from './utils';
 
-jest.mock(
-  'containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/utils',
-  () => {
-    const actual = jest.requireActual(
-      'containers/Admin/communityMonitor/components/LiveMonitor/components/HealthScoreWidget/utils'
-    );
-    return {
-      ...actual,
-      getYearFilter: jest.fn(),
-      getQuarterFilter: jest.fn(),
-    };
-  }
-);
-
 describe('getPublishedAtFromFilter', () => {
-  it('returns correct start date for Q1', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2025');
-    (getQuarterFilter as jest.Mock).mockReturnValue('1');
-
-    const result = getPublishedAtFromFilter(undefined, undefined);
-    expect(result).toBe('2025-01-01');
+  it('returns the first day of Q1 when both params are provided', () => {
+    expect(getPublishedAtFromFilter('2025', '1')).toBe('2025-01-01');
   });
 
-  it('returns correct start date for Q3', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2024');
-    (getQuarterFilter as jest.Mock).mockReturnValue('3');
-
-    const result = getPublishedAtFromFilter(undefined, undefined);
-    expect(result).toBe('2024-07-01');
+  it('returns the first day of Q3 when both params are provided', () => {
+    expect(getPublishedAtFromFilter('2024', '3')).toBe('2024-07-01');
   });
 
-  it('returns undefined when year is missing', () => {
-    (getYearFilter as jest.Mock).mockReturnValue(null);
-    (getQuarterFilter as jest.Mock).mockReturnValue('2');
-
-    const result = getPublishedAtFromFilter(undefined, undefined);
-    expect(result).toBeUndefined();
+  it('returns undefined when yearParam is undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtFromFilter(undefined, '1')).toBeUndefined();
   });
 
-  it('returns undefined when quarter is missing', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2024');
-    (getQuarterFilter as jest.Mock).mockReturnValue(null);
+  it('returns undefined when quarterParam is undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtFromFilter('2025', undefined)).toBeUndefined();
+  });
 
-    const result = getPublishedAtFromFilter(undefined, undefined);
-    expect(result).toBeUndefined();
+  it('returns undefined when both params are undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtFromFilter(undefined, undefined)).toBeUndefined();
   });
 });
 
 describe('getPublishedAtToFilter', () => {
-  it('returns correct end date for Q1', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2025');
-    (getQuarterFilter as jest.Mock).mockReturnValue('1');
-
-    const result = getPublishedAtToFilter(undefined, undefined);
-    expect(result).toBe('2025-03-31');
+  it('returns the last day of Q1 when both params are provided', () => {
+    expect(getPublishedAtToFilter('2025', '1')).toBe('2025-03-31');
   });
 
-  it('returns correct end date for Q4', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2023');
-    (getQuarterFilter as jest.Mock).mockReturnValue('4');
-
-    const result = getPublishedAtToFilter(undefined, undefined);
-    expect(result).toBe('2023-12-31');
+  it('returns the last day of Q4 when both params are provided', () => {
+    expect(getPublishedAtToFilter('2023', '4')).toBe('2023-12-31');
   });
 
-  it('returns undefined when year is missing', () => {
-    (getYearFilter as jest.Mock).mockReturnValue(null);
-    (getQuarterFilter as jest.Mock).mockReturnValue('2');
-
-    const result = getPublishedAtToFilter(undefined, undefined);
-    expect(result).toBeUndefined();
+  it('returns undefined when yearParam is undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtToFilter(undefined, '1')).toBeUndefined();
   });
 
-  it('returns undefined when quarter is missing', () => {
-    (getYearFilter as jest.Mock).mockReturnValue('2024');
-    (getQuarterFilter as jest.Mock).mockReturnValue(null);
+  it('returns undefined when quarterParam is undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtToFilter('2025', undefined)).toBeUndefined();
+  });
 
-    const result = getPublishedAtToFilter(undefined, undefined);
-    expect(result).toBeUndefined();
+  it('returns undefined when both params are undefined (non-Community-Monitor flow)', () => {
+    expect(getPublishedAtToFilter(undefined, undefined)).toBeUndefined();
   });
 });

--- a/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/utils.ts
+++ b/front/app/components/admin/FormResults/FormResultsQuestion/TextQuestion/Analysis/utils.ts
@@ -85,15 +85,18 @@ export const filterForCommunityMonitorQuarter = ({
 
 // getPublishedAtFromFilter
 // Description: This function generates a "published_at_from" date from the URL quarter parameters.
+// Returns undefined when either yearParam or quarterParam is missing — so that
+// non-Community-Monitor flows (which don't carry ?year=/?quarter= in the URL)
+// don't get a phantom current-quarter date filter baked into their summaries.
 export const getPublishedAtFromFilter = (
   yearParam: string | undefined,
   quarterParam: Quarter | undefined
 ) => {
-  // Get the year/quarter from URL
+  if (!yearParam || !quarterParam) return undefined;
+
   const yearFilter = getYearFilter(yearParam);
   const quarterFilter = getQuarterFilter(quarterParam);
 
-  // Parse quarter and year filters
   const quarter = quarterFilter ? parseInt(quarterFilter, 10) : null;
   const year = yearFilter ? parseInt(yearFilter, 10) : null;
 
@@ -105,15 +108,16 @@ export const getPublishedAtFromFilter = (
 
 // getPublishedAtToFilter
 // Description: This function generates a "published_at_to" date from the URL quarter parameters.
+// See note on getPublishedAtFromFilter — same gating applies.
 export const getPublishedAtToFilter = (
   yearParam: string | undefined,
   quarterParam: Quarter | undefined
 ) => {
-  // Get the year/quarter from URL
+  if (!yearParam || !quarterParam) return undefined;
+
   const yearFilter = getYearFilter(yearParam);
   const quarterFilter = getQuarterFilter(quarterParam);
 
-  // Parse quarter and year filters
   const quarter = quarterFilter ? parseInt(quarterFilter, 10) : null;
   const year = yearFilter ? parseInt(yearFilter, 10) : null;
 


### PR DESCRIPTION
This only fixes the FE bug that incorrectly applied quarterly date filters to auto-generated AI summaries of survey answers, which should only occur for Community Monitor survey answers.

Finding and fixing existing survey AI summaries with these (incorrect) date filters, that should not have them, will need to be addressed separately (if confirmed as a good plan).

# Changelog
## Fixed
- [TAN-7865] Do not apply quarterly date filters to auto-generated AI survey answers summaries
