### PR TITLE
[No-ticket] Conservative bump of faraday and jwt

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -80,7 +80,7 @@ end
 gem 'pundit', '~> 2.5.0'
 gem 'active_model_serializers', '~> 0.10.15'
 
-gem 'jwt', '~> 2.9.2'
+gem 'jwt', '~> 2.10.3'
 gem 'que', '~> 2.4.1'
 
 gem 'activerecord-import', '~> 1.7'
@@ -139,7 +139,7 @@ gem 'omniauth-google-oauth2', '~> 1.2.1'
 
 # Libraries for PDF generation /reading
 gem 'pdf-reader'
-gem 'faraday', '~>  2.14.0'
+gem 'faraday', '~>  2.14.2'
 gem 'faraday-multipart'
 
 # AI

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -648,7 +648,7 @@ GEM
       railties (>= 5.0.0)
     faker (3.5.1)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -788,7 +788,7 @@ GEM
     jsonapi-renderer (0.2.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
-    jwt (2.9.3)
+    jwt (2.10.3)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -1375,7 +1375,7 @@ DEPENDENCIES
   email_campaigns!
   factory_bot_rails
   faker
-  faraday (~> 2.14.0)
+  faraday (~> 2.14.2)
   faraday-jwt (~> 0.1.0)
   faraday-multipart
   flag_inappropriate_content!
@@ -1412,7 +1412,7 @@ DEPENDENCIES
   intercom (~> 4.2)
   json-schema (~> 4.3)
   jsonapi-serializer
-  jwt (~> 2.9.2)
+  jwt (~> 2.10.3)
   kaminari (~> 1.2)
   license_finder
   liquid (~> 5.8)


### PR DESCRIPTION
Resolves [back-bundle-audit failures](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/338995/workflows/09790a0e-6441-444f-a087-72d2e39fbe9a/jobs/752517)

Preferring a conservative bump over the 2 Dependabot PRs: #13911 && #13916

2 changes to Gemfile +
`docker compose run --rm web bundle update --conservative faraday jwt`

# Changelog
## Technical
- Conservative bump of faraday and jwt
