### PR TITLE
[TAN-7831] Remove redundant guard + tests, now areas_static_pages using UUID pk

### DIFF
--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/apply_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/templates/apply_service.rb
@@ -104,14 +104,6 @@ module MultiTenancy
 
         serialized_models['models'].each do |klass, models|
           next unless klass.attribute_names.include?('id')
-          # Only pre-generate identifiers for models with a UUID primary key. A bigint
-          # sequence PK (e.g. the areas_static_pages join table) would cast the UUID
-          # string to a garbage/colliding integer ('cbd4...'.to_i == 0), so leave its id
-          # unset and let the database sequence assign it.
-          # Temporary fix to avoid errors when processing AreasStaticPage records,
-          # which have a bigint PK but are included in the template with UUIDs as ids.
-          # See TAN-7831 ticket for details.
-          next unless klass.columns_hash['id']&.sql_type == 'uuid'
 
           models.each do |id, attributes|
             raise "Template contains duplicate id: #{id}" if id_mapping.key?(id)

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/templates/apply_service_spec.rb
@@ -36,38 +36,4 @@ describe MultiTenancy::Templates::ApplyService do
         .to raise_error(MultiTenancy::Templates::Utils::UnknownTemplateError)
     end
   end
-
-  describe '#generate_model_identifiers!' do
-    it 'assigns a fresh SecureRandom uuid to each UUID-keyed record, including areas_static_pages' do
-      new_ids = [SecureRandom.uuid, SecureRandom.uuid, SecureRandom.uuid]
-      allow(SecureRandom).to receive(:uuid).and_return(*new_ids)
-
-      serialized_models = {
-        'models' => {
-          Area => { 'area-1' => { 'title_multiloc' => { 'en' => 'Area' } } },
-          # areas_static_pages now has a uuid PK (TAN-7831), so its join rows each get a
-          # distinct uuid instead of colliding when cast to the old bigint id.
-          AreasStaticPage => { 'asp-1' => {}, 'asp-2' => {} }
-        }
-      }
-
-      mapping = service.send(:generate_model_identifiers!, serialized_models)
-
-      expect(serialized_models['models'][Area]['area-1']['id']).to eq(new_ids[0])
-      expect(serialized_models['models'][AreasStaticPage]['asp-1']['id']).to eq(new_ids[1])
-      expect(serialized_models['models'][AreasStaticPage]['asp-2']['id']).to eq(new_ids[2])
-      expect(mapping).to eq('area-1' => new_ids[0], 'asp-1' => new_ids[1], 'asp-2' => new_ids[2])
-    end
-
-    it 'skips models whose primary key is not a UUID, leaving the id for the database' do
-      column = instance_double(ActiveRecord::ConnectionAdapters::Column, sql_type: 'bigint')
-      non_uuid_model = class_double(Area, attribute_names: ['id'], columns_hash: { 'id' => column })
-      serialized_models = { 'models' => { non_uuid_model => { 'row-1' => {} } } }
-
-      mapping = service.send(:generate_model_identifiers!, serialized_models)
-
-      expect(serialized_models['models'][non_uuid_model]['row-1']).not_to have_key('id')
-      expect(mapping).to be_empty
-    end
-  end
 end


### PR DESCRIPTION
Reverts #13934, now that UUID pk migrated in #13941

# Changelog
## Technical
- [TAN-7831] Remove redundant guard + tests, now areas_static_pages using UUID pk
