### PR TITLE
[TAN-7883] Bugfix: Show analyses (including survey results) in phase insights for future phases

### DIFF
--- a/front/app/containers/Admin/projects/project/insights/index.tsx
+++ b/front/app/containers/Admin/projects/project/insights/index.tsx
@@ -23,7 +23,6 @@ import PageBreakBox from 'components/admin/ContentBuilder/Widgets/PageBreakBox';
 
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
-import { pastPresentOrFuture } from 'utils/dateUtils';
 import { captureAllMapScreenshots } from 'utils/mapViewRegistry';
 import { useParams } from 'utils/router';
 
@@ -145,10 +144,6 @@ const InsightsContent = () => {
   };
 
   const participationMethod = phase?.data.attributes.participation_method;
-  const { start_at, end_at } = phase?.data.attributes || {};
-  const isFuturePhase = start_at
-    ? pastPresentOrFuture([start_at, end_at ?? null]) === 'future'
-    : false;
   const supportsAiAnalysis =
     participationMethod &&
     AI_ANALYSIS_SUPPORTED_METHODS.includes(participationMethod);
@@ -321,24 +316,18 @@ const InsightsContent = () => {
             <ParticipationMetrics phase={phase.data} />
           </PageBreakBox>
 
-          {!isFuturePhase && (
-            <>
-              <PageBreakBox>
-                <ParticipantsTimeline phaseId={phase.data.id} />
-              </PageBreakBox>
+          <PageBreakBox>
+            <ParticipantsTimeline phaseId={phase.data.id} />
+          </PageBreakBox>
 
-              <DemographicsSection phase={phase.data} />
+          <DemographicsSection phase={phase.data} />
 
-              <PageBreakBox>
-                <MethodSpecificInsights
-                  phaseId={phase.data.id}
-                  participationMethod={
-                    phase.data.attributes.participation_method
-                  }
-                />
-              </PageBreakBox>
-            </>
-          )}
+          <PageBreakBox>
+            <MethodSpecificInsights
+              phaseId={phase.data.id}
+              participationMethod={phase.data.attributes.participation_method}
+            />
+          </PageBreakBox>
         </Box>
       </Box>
 


### PR DESCRIPTION
This was an intentional guard in the FE, added when we developed the phase insights feature, (to not show any analytics / results for future phases), but what it does is prevent admins from seeing the results of their tests when developing their future phase.

e.g. I am developing a future survey phase, and I take the survey myself, but I cannot see the results reflected in the phase insights tab.

On balance, showing such info in the phase insights tab probably makes admins more aware of the need to clean up their test data before the phase goes live, as well as also facilitating their own testing.

# Changelog
## Fixed
- [TAN-7883] Bugfix: Show analyses (including survey results) in phase insights for future phases. This makes it possible for admins to see survey results when testing their future phases.
