### PR TITLE
 Fix Spotlight widget showing platform-wide avatars

### DIFF
--- a/front/app/components/AvatarBubbles/index.tsx
+++ b/front/app/components/AvatarBubbles/index.tsx
@@ -36,12 +36,14 @@ export const AvatarImageBubble = styled.img<{
   object-position: center;
 `;
 
+export type AvatarBubblesContext = {
+  type: 'project' | 'group';
+  id: string;
+};
+
 interface Props {
   limit?: number;
-  context?: {
-    type: 'project' | 'group';
-    id: string;
-  };
+  context?: AvatarBubblesContext;
   size?: number;
   overlap?: number;
   avatarIds?: string[];

--- a/front/app/components/AvatarBubbles/index.tsx
+++ b/front/app/components/AvatarBubbles/index.tsx
@@ -72,7 +72,7 @@ export const AvatarBubbles = ({
     enabled: !avatarIds,
   });
 
-  const currentUserCount = userCount || randomAvatars?.meta.total;
+  const currentUserCount = userCount ?? randomAvatars?.meta.total;
   const avatarsWithIdsQueries = useAvatarsWithIds(avatarIds);
 
   const avatarsWithIds = avatarsWithIdsQueries

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
@@ -91,7 +91,7 @@ const Spotlight = ({
             </Box>
           )}
 
-          {!hideAvatars && (loading || (avatarIds && avatarIds.length > 0)) && (
+          {!hideAvatars && (
             <Box
               mt="16px"
               w="100%"

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
@@ -32,6 +32,10 @@ interface Props {
   avatarIds?: string[];
   hideAvatars?: boolean;
   userCount?: number;
+  avatarsContext?: {
+    type: 'project' | 'group';
+    id: string;
+  };
 }
 
 const Spotlight = ({
@@ -44,6 +48,7 @@ const Spotlight = ({
   avatarIds,
   hideAvatars,
   userCount,
+  avatarsContext,
 }: Props) => {
   const isSmallerThanPhone = useBreakpoint('phone');
   const craftComponentDefaultPadding = useCraftComponentDefaultPadding();
@@ -104,6 +109,7 @@ const Spotlight = ({
                 <AvatarBubbles
                   avatarIds={avatarIds}
                   userCount={userCount ?? 4}
+                  context={avatarsContext}
                 />
               )}
             </Box>

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
@@ -15,7 +15,7 @@ import { useTheme } from 'styled-components';
 import { CARD_IMAGE_ASPECT_RATIO_STR } from 'api/project_images/useProjectImages';
 
 import useCraftComponentDefaultPadding from 'components/admin/ContentBuilder/useCraftComponentDefaultPadding';
-import AvatarBubbles from 'components/AvatarBubbles';
+import AvatarBubbles, { AvatarBubblesContext } from 'components/AvatarBubbles';
 import Skeleton from 'components/AvatarBubbles/Skeleton';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 import QuillEditedContent from 'components/UI/QuillEditedContent';
@@ -32,10 +32,7 @@ interface Props {
   avatarIds?: string[];
   hideAvatars?: boolean;
   userCount?: number;
-  avatarsContext?: {
-    type: 'project' | 'group';
-    id: string;
-  };
+  avatarsContext?: AvatarBubblesContext;
 }
 
 const Spotlight = ({

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/Spotlight.tsx
@@ -91,7 +91,7 @@ const Spotlight = ({
             </Box>
           )}
 
-          {!hideAvatars && (
+          {!hideAvatars && (loading || (avatarIds && avatarIds.length > 0)) && (
             <Box
               mt="16px"
               w="100%"

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
@@ -109,6 +109,11 @@ const Spotlight = ({
       avatarIds={avatarIds}
       hideAvatars={hideAvatars}
       userCount={publication?.data.attributes.participants_count}
+      avatarsContext={
+        publicationType === 'project' && publicationId
+          ? { type: 'project', id: publicationId }
+          : undefined
+      }
     />
   );
 };

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
@@ -78,7 +78,7 @@ const Spotlight = ({
 
   const avatarIds =
     publication?.data.relationships.avatars?.data?.map((avatar) => avatar.id) ??
-    [];
+    undefined;
 
   const link = publication
     ? `/${publicationType}s/${publication.data.attributes.slug}`

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/Spotlight/index.tsx
@@ -78,7 +78,7 @@ const Spotlight = ({
 
   const avatarIds =
     publication?.data.relationships.avatars?.data?.map((avatar) => avatar.id) ??
-    undefined;
+    [];
 
   const link = publication
     ? `/${publicationType}s/${publication.data.attributes.slug}`


### PR DESCRIPTION
- AvatarBubbles used `userCount || randomAvatars.meta.total`, so a real
  participant count of 0 fell through to the platform-wide total. Switched
  to `??` so an explicit 0 is respected.
- When a project had no avatars, the random-avatar fetch ran without a
  context and pulled platform-wide data. Spotlight now passes a project
  context so both the avatars and the count fallback stay project-scoped.


# Changelog
## Fixed 
-  Fix Spotlight widget showing platform-wide avatars

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
