### PR TITLE
 make button focus rings clear

### DIFF
--- a/front/app/component-library/utils/styleUtils.ts
+++ b/front/app/component-library/utils/styleUtils.ts
@@ -493,6 +493,11 @@ export function quillEditedContent(
         text-decoration: none;
         background-color: ${darken(0.15, buttonColor)};
       }
+
+      &:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: -4px;
+      }
     }
   `;
 }

--- a/front/app/components/LandingPages/citizen/BannerButton.tsx
+++ b/front/app/components/LandingPages/citizen/BannerButton.tsx
@@ -1,5 +1,8 @@
 import React, { MouseEvent, KeyboardEvent } from 'react';
 
+import { colors } from '@citizenlab/cl2-component-library';
+import styled from 'styled-components';
+
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
 import { type TypedLinkProps } from 'utils/cl-router/Link';
@@ -15,8 +18,17 @@ type Props = {
   openLinkInNewTab?: boolean;
 } & TypedLinkProps;
 
+const StyledButtonWithLink = styled(ButtonWithLink)`
+  && button:focus-visible,
+  && button.focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${colors.white}, 0 0 0 4px ${colors.black},
+      0 0 0 6px ${colors.white};
+  }
+`;
+
 const BannerButton = ({ buttonStyle, ...props }: Props) => (
-  <ButtonWithLink
+  <StyledButtonWithLink
     // TODO: Fix this the next time the file is edited.
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     buttonStyle={buttonStyle || 'primary-inverse'}

--- a/front/app/components/ParticipationCTABars/ParticipationCTAContent/index.tsx
+++ b/front/app/components/ParticipationCTABars/ParticipationCTAContent/index.tsx
@@ -1,13 +1,21 @@
 import React from 'react';
 
-import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
-import { useTheme } from 'styled-components';
+import { Box, colors, useBreakpoint } from '@citizenlab/cl2-component-library';
+import styled, { useTheme } from 'styled-components';
 
 import { IPhaseData } from 'api/phases/types';
 
 import { maxPageWidth } from 'containers/ProjectsShowPage/styles';
 
 import TimeIndicator from './TimeIndicator';
+
+const CTAButtonWrapper = styled(Box)`
+  && button:focus-visible,
+  && button.focus-visible {
+    outline: 2px solid ${colors.white};
+    outline-offset: 3px;
+  }
+`;
 
 type Props = {
   hasUserParticipated?: boolean;
@@ -41,7 +49,7 @@ const ParticipationCTAContent = ({
         />
         <Box ml="auto">{participationState}</Box>
       </Box>
-      {CTAButton}
+      <CTAButtonWrapper>{CTAButton}</CTAButtonWrapper>
     </Box>
   ) : (
     <Box
@@ -77,7 +85,9 @@ const ParticipationCTAContent = ({
         </Box>
 
         <Box display="flex" alignItems="center" ml="auto">
-          <Box ml={CTAButton !== undefined ? '12px' : '0'}>{CTAButton}</Box>
+          <CTAButtonWrapper ml={CTAButton !== undefined ? '12px' : '0'}>
+            {CTAButton}
+          </CTAButtonWrapper>
         </Box>
       </Box>
     </Box>

--- a/front/app/components/Sharing/buttons/Facebook.tsx
+++ b/front/app/components/Sharing/buttons/Facebook.tsx
@@ -30,6 +30,16 @@ const StyledBox = styled(Box)`
   &:hover {
     background-color: ${darken(0.1, colors.facebook)};
   }
+
+  button:focus-visible,
+  button:focus {
+    outline: none;
+  }
+
+  &:has(:focus-visible) {
+    outline: 2px solid #000;
+    outline-offset: 2px;
+  }
 `;
 
 const Facebook = ({

--- a/front/app/components/Sharing/buttons/Twitter.tsx
+++ b/front/app/components/Sharing/buttons/Twitter.tsx
@@ -30,6 +30,16 @@ const StyledBox = styled(Box)`
   &:hover {
     background-color: ${lighten(0.3, colors.black)};
   }
+
+  button:focus-visible,
+  button:focus {
+    outline: none;
+  }
+
+  &:has(:focus-visible) {
+    outline: 2px solid #000;
+    outline-offset: 2px;
+  }
 `;
 
 const Twitter = ({ url, twitterMessage }: Props) => {

--- a/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/AcceptButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { media } from '@citizenlab/cl2-component-library';
+import { media, colors } from '@citizenlab/cl2-component-library';
 import styled, { useTheme } from 'styled-components';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
@@ -17,6 +17,15 @@ const StyledButton = styled(ButtonWithLink)`
   margin-bottom: 10px;
   margin-right: 0px;
 `}
+
+  && button:focus-visible,
+  && button.focus-visible,
+  && a:focus-visible,
+  && a.focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${colors.white}, 0 0 0 4px ${colors.black},
+      0 0 0 6px ${colors.white};
+  }
 `;
 
 interface Props extends TypedLinkProps {

--- a/front/app/containers/HomePage/SignedInHeader/SkipButton.tsx
+++ b/front/app/containers/HomePage/SignedInHeader/SkipButton.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { media, isRtl } from '@citizenlab/cl2-component-library';
+import { media, isRtl, colors } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import ButtonWithLink from 'components/UI/ButtonWithLink';
@@ -21,6 +21,13 @@ const StyledButton = styled(ButtonWithLink)`
     margin-right: 0px;
     margin-left: 10px;
   `}
+
+  && button:focus-visible,
+  && button.focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${colors.white}, 0 0 0 4px ${colors.black},
+      0 0 0 6px ${colors.white};
+  }
 `;
 
 interface Props {


### PR DESCRIPTION
Fix faint, low-contrast, clipped, and inconsistent keyboard focus rings:

- Sharing (Facebook, X): add a consistent ring 
- Quill .custom-button: inset ring so it isn't clipped on the full-width button
- CTA bars: white ring in shared ParticipationCTAContent (covers all bars)
- Banner buttons: 3-layer white/black/white ring for unknown bg/button tones;
  AcceptButton also matches <a> link variant

<img width="382" height="117" alt="Screenshot 2026-06-03 at 09 57 01" src="https://github.com/user-attachments/assets/35864106-6062-401a-af55-e65786d12d8d" />

<img width="381" height="113" alt="Screenshot 2026-06-03 at 09 57 09" src="https://github.com/user-attachments/assets/f88e8d53-5a9f-4abc-b0a5-4837b0c66153" />

<img width="391" height="110" alt="Screenshot 2026-06-03 at 09 57 17" src="https://github.com/user-attachments/assets/fa27551f-19cb-4302-a56f-0098a077172b" />

<img width="393" height="114" alt="Screenshot 2026-06-03 at 09 57 23" src="https://github.com/user-attachments/assets/72c1a1a7-b952-4230-af79-7d865776a380" />


<img width="420" height="118" alt="Screenshot 2026-06-03 at 09 22 11" src="https://github.com/user-attachments/assets/b8e165ad-1db5-4b56-a51e-fbd3d907be1f" />
<img width="355" height="110" alt="Screenshot 2026-06-03 at 09 22 57" src="https://github.com/user-attachments/assets/e992b57d-35ba-4e80-b55a-a7e3f588994e" />


<img width="666" height="114" alt="Screenshot 2026-06-03 at 09 23 57" src="https://github.com/user-attachments/assets/d5f9616b-de11-4be6-bdb2-eb82c58cf291" />
<img width="304" height="127" alt="Screenshot 2026-06-03 at 09 24 03" src="https://github.com/user-attachments/assets/ee63edc3-ede8-45ec-96c9-a821604dad6d" />
<img width="289" height="125" alt="Screenshot 2026-06-03 at 09 23 38" src="https://github.com/user-attachments/assets/59af7428-8dd5-4566-99d7-f17457e456ea" />
<img width="218" height="70" alt="Screenshot 2026-06-03 at 09 49 27" src="https://github.com/user-attachments/assets/c972a0a8-ae22-474d-ba0f-fae2a7ba8e66" />
<img width="390" height="79" alt="Screenshot 2026-06-03 at 09 49 22" src="https://github.com/user-attachments/assets/6a08eb8e-484e-43b0-b53d-439d354391da" />

# Changelog
## A11y
-  make button focus rings clear 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
