### PR TITLE
 Fix dropdown cutoff in small view

### DIFF
--- a/front/app/components/UI/MoreActionsMenu/index.tsx
+++ b/front/app/components/UI/MoreActionsMenu/index.tsx
@@ -163,6 +163,7 @@ const MoreActionsMenu = forwardRef<HTMLButtonElement, Props>(
           onClickOutside={hide}
           className="e2e-more-actions-list"
           right="0px"
+          mobileRight="0px"
           content={
             <Box role="menu">
               {actions.map((action, index) => {


### PR DESCRIPTION
Before:
<img width="875" height="461" alt="Screenshot 2026-06-03 at 11 54 35" src="https://github.com/user-attachments/assets/7fe2fdfc-e0a1-472c-ab4b-9f4ac85e4059" />

After: 
<img width="831" height="477" alt="Screenshot 2026-06-03 at 11 54 24" src="https://github.com/user-attachments/assets/c18b4794-7c71-46e5-952c-5f99eeaa0774" />

# Changelog
## A11y
-  Fix dropdown cutoff in small view
# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
