### PR TITLE
 add IdeaSharingButton to small view

### DIFF
--- a/front/app/containers/IdeasShow/index.tsx
+++ b/front/app/containers/IdeasShow/index.tsx
@@ -30,6 +30,8 @@ import { FormattedMessage } from 'utils/cl-intl';
 import { usePermission } from 'utils/permissions';
 
 import AuthoringAssistanePrototype from './components/AuthoringAssistanePrototype';
+import IdeaSharingButton from './components/Buttons/IdeaSharingButton';
+import SharingButtonComponent from './components/Buttons/SharingButtonComponent';
 import Container from './components/Container';
 import Cosponsorship from './components/Cosponsorship';
 import IdeaTitle from './components/IdeaTitle';
@@ -209,6 +211,12 @@ export const IdeasShow = ({
                 width="100%"
                 toolTipType="input"
               />
+              <Box mt="16px">
+                <IdeaSharingButton
+                  ideaId={ideaId}
+                  buttonComponent={<SharingButtonComponent />}
+                />
+              </Box>
             </Box>
           )}
         </Box>


### PR DESCRIPTION

<img width="947" height="278" alt="Screenshot 2026-06-04 at 11 21 40" src="https://github.com/user-attachments/assets/5ac667f4-f473-4054-bacf-0de2aca5dbba" />


# Changelog
## A11y
-  add IdeaSharingButton to small view

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
