### PR TITLE
[TAN-7814] Force https in OAuth and MCP metadata responses

### DIFF
--- a/back/app/controllers/oauth/metadata_controller.rb
+++ b/back/app/controllers/oauth/metadata_controller.rb
@@ -8,7 +8,7 @@ module Oauth
 
     def authorization_server
       render json: {
-        issuer: request.base_url,
+        issuer: AppConfiguration.instance.base_backend_uri,
         authorization_endpoint: oauth_authorization_url,
         token_endpoint: oauth_token_url,
         registration_endpoint: oauth_registrations_url,
@@ -27,7 +27,7 @@ module Oauth
       render json: {
         resource: mcp_server_url,
         resource_name: 'Go Vocal MCP Server',
-        authorization_servers: [request.base_url],
+        authorization_servers: [AppConfiguration.instance.base_backend_uri],
         bearer_methods_supported: ['header'],
         scopes_supported: Doorkeeper.config.scopes.to_a
       }

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -46,6 +46,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
+  # SSL is terminated at CloudFront, so request.protocol is 'http' and URL
+  # helpers inherit that. Pin the scheme to 'https' for URL generation.
+  Rails.application.routes.default_url_options[:protocol] = 'https'
+
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 

--- a/back/config/environments/staging.rb
+++ b/back/config/environments/staging.rb
@@ -49,6 +49,10 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
+  # SSL is terminated at CloudFront, so request.protocol is 'http' and URL
+  # helpers inherit that. Pin the scheme to 'https' for URL generation.
+  Rails.application.routes.default_url_options[:protocol] = 'https'
+
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -36,7 +36,7 @@ module McpServer
     # resource-metadata document via the WWW-Authenticate header so they can
     # discover the authorization server and start the OAuth flow.
     def advertise_resource_metadata
-      metadata_url = "#{request.base_url}/.well-known/oauth-protected-resource"
+      metadata_url = "#{AppConfiguration.instance.base_backend_uri}/.well-known/oauth-protected-resource"
       existing = response.headers['WWW-Authenticate'].to_s
       challenge = "Bearer resource_metadata=\"#{metadata_url}\""
       response.headers['WWW-Authenticate'] = existing.present? ? "#{existing}, #{challenge}" : challenge

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -440,6 +440,10 @@ module MultiTenancy
             phase_datetime_setup: {
               enabled: true,
               allowed: true
+            },
+            mcp_server: {
+              enabled: true,
+              allowed: true
             }
           })
         )

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -374,6 +374,10 @@ namespace :cl2_back do
         phase_datetime_setup: {
           enabled: true,
           allowed: true
+        },
+        mcp_server: {
+          enabled: true,
+          allowed: true
         }
       }
     )


### PR DESCRIPTION
SSL terminates at CloudFront and the ALB → Rails hop is HTTP, so request.protocol is 'http' and Rails URL helpers inherit that. The OAuth authorization-server / protected-resource metadata and the MCP WWW-Authenticate header were therefore advertising http:// URLs, which MCP clients (Claude Desktop) reject.

Pin URL helpers via `default_url_options[:protocol] = 'https'` in staging/production, and replace `request.base_url` with `AppConfiguration.instance.base_backend_uri` in the three call sites that bypass URL helpers.

# Changelog
## Added
- [TAN-7814] MCP server MVP

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
