### PR TITLE
[TAN-7814] Force https via controller-level default_url_options override

### DIFF
--- a/back/app/controllers/oauth/metadata_controller.rb
+++ b/back/app/controllers/oauth/metadata_controller.rb
@@ -6,6 +6,13 @@ module Oauth
     skip_before_action :authenticate_user
     skip_after_action :verify_authorized
 
+    # Force https in URL helpers — these responses are consumed by external
+    # OAuth/MCP clients that require https authorization endpoints. TLS
+    # terminates at CloudFront, so request.protocol is 'http' inside Rails.
+    def default_url_options
+      Rails.env.local? ? super : super.merge(protocol: 'https')
+    end
+
     def authorization_server
       render json: {
         issuer: AppConfiguration.instance.base_backend_uri,

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -46,10 +46,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # SSL is terminated at CloudFront, so request.protocol is 'http' and URL
-  # helpers inherit that. Pin the scheme to 'https' for URL generation.
-  Rails.application.routes.default_url_options[:protocol] = 'https'
-
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
 

--- a/back/config/environments/staging.rb
+++ b/back/config/environments/staging.rb
@@ -49,10 +49,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # SSL is terminated at CloudFront, so request.protocol is 'http' and URL
-  # helpers inherit that. Pin the scheme to 'https' for URL generation.
-  Rails.application.routes.default_url_options[:protocol] = 'https'
-
   # "info" includes generic and useful information about system operation, but avoids logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII). If you
   # want to log everything, set the level to "debug".


### PR DESCRIPTION
The previous attempt set `Rails.application.routes.default_url_options[:protocol] = 'https'`, which doesn't reach controller URL helpers — `ActionController::UrlFor#url_options` merges over the controller class's `default_url_options`, not the routes'. Override at the metadata controller instead, with `super.merge(...)` to preserve inherited keys.


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
