### PR TITLE
[TAN-7814] Tell Rails to assume SSL behind CloudFront

### DIFF
--- a/back/app/controllers/oauth/metadata_controller.rb
+++ b/back/app/controllers/oauth/metadata_controller.rb
@@ -6,13 +6,6 @@ module Oauth
     skip_before_action :authenticate_user
     skip_after_action :verify_authorized
 
-    # Force https in URL helpers — these responses are consumed by external
-    # OAuth/MCP clients that require https authorization endpoints. TLS
-    # terminates at CloudFront, so request.protocol is 'http' inside Rails.
-    def default_url_options
-      Rails.env.local? ? super : super.merge(protocol: 'https')
-    end
-
     def authorization_server
       render json: {
         issuer: AppConfiguration.instance.base_backend_uri,

--- a/back/config/environments/production.rb
+++ b/back/config/environments/production.rb
@@ -39,9 +39,10 @@ Rails.application.configure do
   # config.action_cable.url = "wss://example.com/cable"
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  # TLS terminates at CloudFront; the ALB → Rails hop is HTTP. Tell Rails to
+  # treat requests as HTTPS so request.scheme, request.base_url, URL helpers,
+  # and CSRF Origin checks all see the public-facing scheme.
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/back/config/environments/staging.rb
+++ b/back/config/environments/staging.rb
@@ -42,9 +42,10 @@ Rails.application.configure do
   # config.action_cable.url = 'wss://example.com/cable'
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  # config.assume_ssl = true
+  # TLS terminates at CloudFront; the ALB → Rails hop is HTTP. Tell Rails to
+  # treat requests as HTTPS so request.scheme, request.base_url, URL helpers,
+  # and CSRF Origin checks all see the public-facing scheme.
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -5,8 +5,7 @@ module McpServer
     include Pundit::Authorization
     rescue_from(Pundit::NotAuthorizedError) { head :forbidden }
 
-    before_action -> { doorkeeper_authorize! 'mcp:access' }
-    after_action :advertise_resource_metadata, if: -> { response.unauthorized? }
+    around_action :authorize_mcp_access
 
     def create
       authorize(%i[mcp_server mcp])
@@ -31,6 +30,18 @@ module McpServer
     end
 
     private
+
+    # Authorize via Doorkeeper, and append the RFC 9728 resource_metadata parameter to the
+    # WWW-Authenticate header on 401s so MCP clients can discover the OAuth authorization
+    # server. Uses around_action to add the header (instead of a simpler after_action)
+    # because doorkeeper_authorize! responds with head :unauthorized on invalid tokens,
+    # which causes Rails to skip after_actions.
+    def authorize_mcp_access
+      doorkeeper_authorize! 'mcp:access'
+      yield unless performed?
+    ensure
+      advertise_resource_metadata if response.unauthorized?
+    end
 
     # RFC 9728 §5.1: a 401 from a protected resource must point clients to the
     # resource-metadata document via the WWW-Authenticate header so they can


### PR DESCRIPTION
## Why

The user-facing symptom on staging was: in Claude Desktop, clicking "Authorize" in the OAuth consent screen did nothing (blank page after redirect). Root cause: Rails' CSRF check rejected `POST /oauth/authorize` with 422 because the browser's `Origin` header (`https://demo.stg.govocal.com`) didn't match `request.base_url` (`http://demo.stg.govocal.com`).

Same root cause was also producing `http://` URLs in the OAuth/MCP metadata responses — `request.scheme` returns `'http'` inside Rails because CloudFront terminates TLS and the ALB → Rails hop is HTTP.

## What

`config.assume_ssl = true` (Rails 7.1+) is the documented middleware for exactly this scenario: it tells Rails the request is HTTPS even though the underlying socket is HTTP. Fixes `request.scheme`, `request.base_url`, URL helpers, and the CSRF Origin check in one place.

Also drops the now-redundant `default_url_options[:protocol] = 'https'` override in the OAuth metadata controller — `assume_ssl` makes URL helpers emit `https://` naturally.