### PR TITLE
Fix Que `enqueue_after_transaction_commit?` patch breaking reload in dev

### DIFF
--- a/back/config/initializers/que.rb
+++ b/back/config/initializers/que.rb
@@ -11,15 +11,11 @@ end
 # Rails 7.2 introduced transaction-aware job enqueueing, which requires queue adapters
 # to implement the `enqueue_after_transaction_commit?` method. The Que gem has not yet
 # implemented this method, causing an error.
-Rails.application.config.to_prepare do
-  if defined?(ActiveJob::QueueAdapters::QueAdapter)
-    adapter = ActiveJob::QueueAdapters::QueAdapter
-    raise 'This patch can be deleted.' if adapter.instance_methods.include?(:enqueue_after_transaction_commit?)
+ActiveSupport.on_load(:active_job) do
+  adapter = ActiveJob::QueueAdapters::QueAdapter
+  raise 'This patch can be deleted.' if adapter.instance_methods.include?(:enqueue_after_transaction_commit?)
 
-    adapter.class_eval do
-      def enqueue_after_transaction_commit?
-        false
-      end
-    end
+  adapter.class_eval do
+    def enqueue_after_transaction_commit? = false
   end
 end


### PR DESCRIPTION
The patch lived inside `Rails.application.config.to_prepare`, which re-runs on every code reload. The first pass installed the method, the second pass saw it and raised "This patch can be deleted." — `reload!` in the console blew up. 


# Changelog
## Technical
- Fix Rails autoreloading in the dev environment.

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
