### PR TITLE
TAN-7693-a11y/add-accessible-name-to-format-options-2

### DIFF
--- a/front/app/components/UI/QuillEditor/Toolbar.tsx
+++ b/front/app/components/UI/QuillEditor/Toolbar.tsx
@@ -141,6 +141,47 @@ const Toolbar = ({
     }
   };
 
+  const handleDropdownKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    const target = event.target as HTMLElement;
+    const onLabel = target.classList.contains('ql-picker-label');
+    const onItem = target.classList.contains('ql-picker-item');
+    if (!onLabel && !onItem) return;
+
+    const picker = event.currentTarget.querySelector('.ql-picker');
+    const items = Array.from(
+      picker?.querySelectorAll<HTMLElement>('.ql-picker-item') ?? []
+    );
+    if (items.length === 0) return;
+
+    const focusItem = (index: number) =>
+      items[(index + items.length) % items.length].focus();
+
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowUp':
+        event.preventDefault();
+        if (onLabel) {
+          picker?.classList.add('ql-expanded');
+          target.setAttribute('aria-expanded', 'true');
+          picker
+            ?.querySelector('.ql-picker-options')
+            ?.setAttribute('aria-hidden', 'false');
+          focusItem(0);
+        } else {
+          focusItem(
+            items.indexOf(target) + (event.key === 'ArrowDown' ? 1 : -1)
+          );
+        }
+        break;
+      case 'Enter':
+        if (onItem) {
+          picker?.querySelector<HTMLElement>('.ql-picker-label')?.focus();
+        }
+        break;
+      default:
+    }
+  };
+
   const trackBasic =
     (type: 'bold' | 'italic' | 'custom-link' | 'link') =>
     (_event: React.MouseEvent<HTMLElement>) => {
@@ -160,7 +201,13 @@ const Toolbar = ({
   return (
     <div id={id}>
       {!limitedTextFormatting && (
-        <span className="ql-formats" role="button" onClick={trackClickDropdown}>
+        // remove role="button" from span to allow native keyboard interactions with the dropdown in safari browser
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        <span
+          className="ql-formats"
+          onClick={trackClickDropdown}
+          onKeyDown={handleDropdownKeyDown}
+        >
           <select className="ql-header" defaultValue={''}>
             <option value="2" aria-selected={false}>
               {formatMessage(messages.title)}

--- a/front/app/components/UI/QuillEditor/createQuill.ts
+++ b/front/app/components/UI/QuillEditor/createQuill.ts
@@ -224,6 +224,28 @@ export const createQuill = (
         btn.appendChild(span);
       }
     });
+
+    // Close when focus moves outside the picker for keyboard and screen reader users.
+    toolbarElement.querySelectorAll('.ql-picker').forEach((picker) => {
+      picker
+        .querySelectorAll<HTMLElement>('.ql-picker-item')
+        .forEach((item) => {
+          item.tabIndex = -1;
+        });
+
+      picker.addEventListener('focusout', (event) => {
+        const nextFocused = (event as FocusEvent).relatedTarget as Node | null;
+        if (nextFocused && picker.contains(nextFocused)) return;
+
+        picker.classList.remove('ql-expanded');
+        picker
+          .querySelector('.ql-picker-label')
+          ?.setAttribute('aria-expanded', 'false');
+        picker
+          .querySelector('.ql-picker-options')
+          ?.setAttribute('aria-hidden', 'true');
+      });
+    });
   }
 
   return quill;


### PR DESCRIPTION
- Remove role="button" from the .ql-formats wrapper. button has ARIA
  "children presentational: true", so Safari/VoiceOver collapsed the whole
  dropdown into one button and never announced the inner label/option
  names. Without it, the accessible names are read.
- Navigate the open dropdown with the arrow keys instead of Tab
- Close the dropdown when focus leaves it


# Changelog
## A11y 
- make format option keyboard accessible by arrow keys and readable in Safari

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
