### PR TITLE
Upgrade Puma to 7.2.1 (CVE-2026-47736)

### DIFF
--- a/back/Gemfile
+++ b/back/Gemfile
@@ -11,7 +11,7 @@ end
 gem 'rails', '~> 7.2.3'
 gem 'pg', '~> 1.5.6'
 gem 'strong_migrations', '~> 2.5'
-gem 'puma', '~> 6.4.3'
+gem 'puma', '~> 7.2.1'
 gem 'bcrypt', '~> 3.1.20' # Use ActiveModel has_secure_password
 gem 'csv', '~> 3.3.0'
 

--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -772,7 +772,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nkf (0.1.3)
     nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
@@ -889,7 +889,7 @@ GEM
       date
       stringio
     public_suffix (6.0.1)
-    puma (6.4.3)
+    puma (7.2.1)
       nio4r (~> 2.0)
     pundit (2.5.0)
       activesupport (>= 3.0.0)
@@ -1329,7 +1329,7 @@ DEPENDENCIES
   pry-rails
   pry-rescue
   public_api!
-  puma (~> 6.4.3)
+  puma (~> 7.2.1)
   pundit (~> 2.5.0)
   que (~> 2.4.1)
   rack-attack (~> 6)

--- a/back/config/puma.rb
+++ b/back/config/puma.rb
@@ -41,7 +41,7 @@ if web_concurrency.to_i > 1
   # process behavior so workers use less memory.
   preload_app!
 
-  on_worker_boot do
+  before_worker_boot do
     ActiveSupport.on_load(:active_record) do
       ActiveRecord::Base.establish_connection
     end


### PR DESCRIPTION
Bumps Puma 6.4.3 -> 7.2.1 to clear the bundler-audit failure for CVE-2026-47736. Renames the `on_worker_boot` hook to `before_worker_boot` per Puma 7's renamed lifecycle hooks.

Note: Puma 7 also now lowercases response header names HTTP header names are case-insensitive (RFC 9110), so this only matters where something does an exact-case match. Claude checked and it feels safe:

  - App code — the only in-process header read (mcp_controller.rb, WWW-Authenticate) goes through ActionDispatch, which is case-insensitive and runs before Puma serializes.
  - Frontend — no code reads any response header by name (getResponseHeader / response.headers['…'] → zero hits). 
  - CORS — headers: :any, no expose_headers allowlist pinning header names.
  - Tests — RSpec specs go through Rack::Test/ActionDispatch, not Puma, so this behavior never appears in CI either way.
  - CloudFront / Lambda@Edge (cl2-deployment) — no cache key or routing rule uses response headers; all keying is on request headers. The only response-header logic is HSTS injection (setHSTSResponseHeader Lambda@Edge +
  set_hsts_response_header CloudFront Function), which writes a header. AWS already lowercases response-header keys in the function event object regardless of origin casing, so it's unaffected.

Conclusion: no impact from the lowercase change. Recommended post-deploy smoke test is normal upgrade hygiene only — confirm a file download's Content-Disposition works and the health check returns 200. I will block releases whilst I deploy this.

# Changelog
  
## Technical
 - Upgrade Puma from 6.4.3 to 7.2.1 to resolve CVE-2026-47736 (PROXY protocol v1 parser memory exhaustion). The vulnerable code path was never enabled in our config, but this clears the bundler-audit failure and moves us to a newer version.
 - Rename the `on_worker_boot` hook to `before_worker_boot` per Puma 7's renamed lifecycle hooks.