### PR TITLE
TAN-7946-a11y-improvements

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -8,7 +8,7 @@ import Box from '../Box';
 
 export type TooltipProps = Omit<
   React.ComponentProps<typeof Tippy>,
-  'interactive' | 'plugins' | 'role' | 'aria'
+  'interactive' | 'plugins' | 'aria'
 > & {
   width?: string;
   useContentWrapper?: boolean;
@@ -50,6 +50,7 @@ const Tooltip = ({
   width,
   // This prop is used to determine if the native Tippy component content should be wrapped in a Box component
   useContentWrapper = true,
+  role = 'tooltip',
   ...rest
 }: TooltipProps) => {
   const tooltipId = useRef(
@@ -144,7 +145,7 @@ const Tooltip = ({
         key={key}
         plugins={PLUGINS}
         interactive={true}
-        role="tooltip"
+        role={role}
         visible={isFocused}
         // Ensures tippy works with both keyboard and mouse
         onHidden={handleOnHidden}
@@ -164,7 +165,7 @@ const Tooltip = ({
           key={key}
           plugins={PLUGINS}
           interactive={true}
-          role="tooltip"
+          role={role}
           visible={isFocused}
           // Ensures tippy works with both keyboard and mouse
           onHidden={handleOnHidden}

--- a/front/app/components/AvatarBubbles/AvatarBubbles.test.tsx
+++ b/front/app/components/AvatarBubbles/AvatarBubbles.test.tsx
@@ -20,7 +20,7 @@ describe('AvatarBubbles Component', () => {
   });
 
   describe('when showParticipantText is on', () => {
-    it('displays user count of 999 correctly as "995 participants"', () => {
+    it('displays user count of 999 correctly as "999 participants"', () => {
       render(
         <AvatarBubbles
           avatarIds={['sample']}
@@ -30,7 +30,7 @@ describe('AvatarBubbles Component', () => {
         />
       );
       expect(screen.getByTestId('userCountBubbleInner')).toHaveTextContent(
-        /995 participants/
+        /999 participants/
       );
     });
 
@@ -93,7 +93,7 @@ describe('AvatarBubbles Component', () => {
   });
 
   describe('when showParticipantText is off', () => {
-    it('displays user count of 995 as "995"', () => {
+    it('displays user count of 999 as "999"', () => {
       render(
         <AvatarBubbles
           avatarIds={['sample']}
@@ -103,7 +103,7 @@ describe('AvatarBubbles Component', () => {
         />
       );
       expect(screen.getByTestId('userCountBubbleInner')).toHaveTextContent(
-        /995/
+        /999/
       );
     });
 

--- a/front/app/components/AvatarBubbles/index.tsx
+++ b/front/app/components/AvatarBubbles/index.tsx
@@ -112,23 +112,22 @@ export const AvatarBubbles = ({
     }
 
     const avatarImagesCount = avatarsToShow.length;
-    const remainingUsers = currentUserCount - avatarImagesCount;
 
     let letterAbbreviation = '';
-    let truncatedUserCount = remainingUsers;
+    let truncatedUserCount = currentUserCount;
 
     switch (true) {
-      case remainingUsers >= 1000000:
+      case currentUserCount >= 1000000:
         letterAbbreviation = 'M';
-        truncatedUserCount = Math.round((remainingUsers / 1000000) * 10) / 10;
+        truncatedUserCount = Math.round((currentUserCount / 1000000) * 10) / 10;
         break;
-      case remainingUsers >= 100000:
+      case currentUserCount >= 100000:
         letterAbbreviation = 'k';
-        truncatedUserCount = Math.floor(remainingUsers / 1000);
+        truncatedUserCount = Math.floor(currentUserCount / 1000);
         break;
-      case remainingUsers >= 10000:
+      case currentUserCount >= 10000:
         letterAbbreviation = 'k';
-        truncatedUserCount = Math.round((remainingUsers / 1000) * 10) / 10;
+        truncatedUserCount = Math.round((currentUserCount / 1000) * 10) / 10;
         break;
     }
 
@@ -154,7 +153,7 @@ export const AvatarBubbles = ({
               />
             ))}
           </BubbleContainer>
-          {remainingUsers > 0 &&
+          {currentUserCount > 0 &&
             (showParticipantText ? (
               <Box
                 data-testid="userCountBubbleInner"
@@ -169,7 +168,7 @@ export const AvatarBubbles = ({
                   aria-hidden="true"
                   color="coolGrey600"
                 >
-                  +{truncatedUserCount}
+                  {truncatedUserCount}
                   {letterAbbreviation}&nbsp;
                   {formatMessage(
                     truncatedUserCount > 1 || letterAbbreviation
@@ -206,11 +205,11 @@ export const AvatarBubbles = ({
                         userCountBubbleFontSize ??
                         getFontSize(
                           bubbleSize,
-                          remainingUsers.toString().length
+                          currentUserCount.toString().length
                         ),
                     }}
                   >
-                    +{truncatedUserCount}
+                    {truncatedUserCount}
                     {letterAbbreviation}
                   </Text>
                 </Box>

--- a/front/app/components/FollowUnfollow/index.tsx
+++ b/front/app/components/FollowUnfollow/index.tsx
@@ -139,45 +139,50 @@ const FollowUnfollow = ({
   };
 
   const getTooltipContent = () => {
+    const unsubscribeLink = (
+      <a
+        href={'/profile/edit'}
+        target="_blank"
+        rel="noreferrer"
+        tabIndex={0}
+        style={{ textDecoration: 'underline', color: colors.white }}
+      >
+        <FormattedMessage {...messages.unsubscribe} />
+      </a>
+    );
+
     if (toolTipType === 'input') {
       return (
         <FormattedMessage
           {...messages.followTooltipInputPage}
-          values={{
-            unsubscribeLink: (
-              <a
-                href={'/profile/edit'}
-                target="_blank"
-                rel="noreferrer"
-                style={{ textDecoration: 'underline', color: colors.white }}
-              >
-                <FormattedMessage {...messages.unsubscribe} />
-              </a>
-            ),
-          }}
+          values={{ unsubscribeLink }}
         />
       );
     } else if (toolTipType === 'projectOrFolder') {
       return (
         <FormattedMessage
           {...messages.followTooltipProjects}
-          values={{
-            unsubscribeLink: (
-              <a
-                href={'/profile/edit'}
-                target="_blank"
-                rel="noreferrer"
-                style={{ textDecoration: 'underline', color: colors.white }}
-              >
-                <FormattedMessage {...messages.unsubscribe} />
-              </a>
-            ),
-          }}
+          values={{ unsubscribeLink }}
         />
       );
     }
     return null;
   };
+
+  const buttonText = followersCount
+    ? `${followUnfollowText} (${followersCount})`
+    : followUnfollowText;
+
+  const tooltipSentence =
+    toolTipType === 'input'
+      ? formatMessage(messages.followTooltipInputPage, {
+          unsubscribeLink: formatMessage(messages.unsubscribe),
+        })
+      : toolTipType === 'projectOrFolder'
+      ? formatMessage(messages.followTooltipProjects, {
+          unsubscribeLink: formatMessage(messages.unsubscribe),
+        })
+      : undefined;
 
   return (
     <Tooltip
@@ -187,6 +192,7 @@ const FollowUnfollow = ({
       placement="bottom"
       content={getTooltipContent()}
       useContentWrapper={false}
+      role="presentation"
     >
       <Button
         buttonStyle={buttonStyle}
@@ -195,12 +201,13 @@ const FollowUnfollow = ({
         iconSize={iconSize}
         px="12px"
         processing={isLoading}
+        ariaLabel={
+          tooltipSentence ? `${buttonText}. ${tooltipSentence}` : undefined
+        }
         {...otherButtonProps}
         data-cy={isFollowing ? 'e2e-unfollow-button' : 'e2e-follow-button'}
       >
-        {followersCount
-          ? `${followUnfollowText} (${followersCount})`
-          : followUnfollowText}
+        {buttonText}
       </Button>
     </Tooltip>
   );

--- a/front/app/components/ProjectCard/index.tsx
+++ b/front/app/components/ProjectCard/index.tsx
@@ -541,6 +541,12 @@ const ProjectCard = memo<InputProps>(
               onClick={() => {
                 handleCTAOnClick(project.data.id);
               }}
+              onFocus={(event) => {
+                event.currentTarget.scrollIntoView({
+                  block: 'center',
+                  behavior: 'smooth',
+                });
+              }}
               aria-label={formatMessage(messages.a11y_ctaForProject, {
                 cta: ctaMessage,
                 projectTitle: localize(project.data.attributes.title_multiloc),

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseNavigation.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseNavigation.tsx
@@ -1,4 +1,10 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 
 import {
   Button,
@@ -24,6 +30,8 @@ import { isValidPhase } from '../phaseParam';
 
 import setPhaseURL from './setPhaseURL';
 import tracks from './tracks';
+
+let pendingFocusAction: 'previous' | 'current' | 'next' | null = null;
 
 const Container = styled.div`
   display: flex;
@@ -71,6 +79,10 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
   };
   const { data: project } = useProjectById(projectId);
 
+  const previousButtonRef = useRef<HTMLButtonElement>(null);
+  const currentButtonRef = useRef<HTMLButtonElement>(null);
+  const nextButtonRef = useRef<HTMLButtonElement>(null);
+
   const selectedPhase = useMemo(() => {
     if (!phases) return;
 
@@ -94,6 +106,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
 
   const goToNextPhase = useCallback(() => {
     trackEventByName(tracks.clickNextPhaseButton);
+    pendingFocusAction = 'next';
 
     if (phases) {
       const selectedPhaseId = selectedPhase ? selectedPhase.id : null;
@@ -112,6 +125,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
 
   const goToPreviousPhase = useCallback(() => {
     trackEventByName(tracks.clickPreviousPhaseButton);
+    pendingFocusAction = 'previous';
 
     if (phases) {
       const selectedPhaseId = selectedPhase ? selectedPhase.id : null;
@@ -131,6 +145,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
   const goToCurrentPhase = useCallback(() => {
     if (phases) {
       trackEventByName(tracks.clickCurrentPhaseButton);
+      pendingFocusAction = 'current';
       const currentPhase = getCurrentPhase(phases.data);
 
       if (currentPhase) {
@@ -138,6 +153,31 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
       }
     }
   }, [phases, selectPhase]);
+
+  // keep focus on the same button for a11y
+  useLayoutEffect(() => {
+    const action = pendingFocusAction;
+    if (!action) return;
+    pendingFocusAction = null;
+
+    const refsByAction = {
+      previous: previousButtonRef,
+      current: currentButtonRef,
+      next: nextButtonRef,
+    };
+
+    const isEnabled = (el: HTMLButtonElement | null) =>
+      !!el && el.getAttribute('aria-disabled') !== 'true';
+
+    const candidates = [
+      refsByAction[action].current,
+      previousButtonRef.current,
+      currentButtonRef.current,
+      nextButtonRef.current,
+    ];
+
+    candidates.find(isEnabled)?.focus();
+  }, [selectedPhase?.id]);
 
   if (phases && phases.data.length > 1) {
     const navButtonSize = '34px';
@@ -158,6 +198,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
         >
           <div>
             <PreviousPhaseButton
+              ref={previousButtonRef}
               onClick={goToPreviousPhase}
               icon="chevron-left"
               iconColor={colors.textSecondary}
@@ -183,6 +224,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
           >
             <div>
               <Button
+                ref={currentButtonRef}
                 onClick={goToCurrentPhase}
                 icon="dot"
                 iconSize="16px"
@@ -209,6 +251,7 @@ const PhaseNavigation = memo<Props>(({ projectId, buttonStyle, className }) => {
         >
           <div>
             <NextPhaseButton
+              ref={nextButtonRef}
               onClick={goToNextPhase}
               icon="chevron-right"
               iconColor={colors.textSecondary}

--- a/front/app/routes.tsx
+++ b/front/app/routes.tsx
@@ -653,6 +653,11 @@ export const createAppRouter = (moduleRoutes: Partial<Routes> = {}) =>
   createRouter({
     routeTree: buildRouteTree(moduleRoutes),
     trailingSlash: 'preserve',
+    defaultNotFoundComponent: () => (
+      <PageLoading>
+        <PageNotFound />
+      </PageLoading>
+    ),
   });
 
 export let router = createAppRouter();


### PR DESCRIPTION
**1- fix scroll project CTA into view on keyboard focus
2-keep focus on phase nav button after phase change
3-render custom PageNotFound for all unmatched routes
4- make follow tooltip announce consistently in Chrome and Safari** 
      - Put the tooltip text in the button's accessible name so it's announced once on focus. Make the tooltip  role="presentation" to avoid duplicate announcements in Chrome.
**5- show total participant count in avatar bubbles text**


# Changelog
## A11y 
1- fix scroll project CTA into view on keyboard focus
2-keep focus on phase nav button after phase change
3-render custom PageNotFound for all unmatched routes
4- make follow tooltip announce consistently in Chrome and Safari
5- show total participant count in avatar bubbles text

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
