### PR TITLE
TAN-7910 - Make cosponsor profiles public again

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -329,12 +329,15 @@ class User < ApplicationRecord
 
   def show_public_profile?
     # Only show the public profile if the user has contributed publicly to the platform,
-    # either by posting ideas or comments in phases with public participation methods.
+    # either by posting ideas or comments in phases with public participation methods,
+    # or by accepting an invitation to co-sponsor a proposal.
     # This is to avoid exposing personal data of users who have not actively used the platform.
     ideas
       .joins(:ideas_phases)
       .joins(:phases)
-      .exists?(ideas_phases: { phases: { participation_method: %w[ideation proposals] } }) || comments.exists?
+      .exists?(ideas_phases: { phases: { participation_method: %w[ideation proposals] } }) ||
+      comments.exists? ||
+      cosponsorships.where(status: 'accepted').exists?
   end
 
   private

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -337,7 +337,7 @@ class User < ApplicationRecord
       .joins(:phases)
       .exists?(ideas_phases: { phases: { participation_method: %w[ideation proposals] } }) ||
       comments.exists? ||
-      cosponsorships.where(status: 'accepted').exists?
+      cosponsorships.exists?(status: 'accepted')
   end
 
   private

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -128,6 +128,16 @@ RSpec.describe User do
       create(:comment, author: user, anonymous: true)
       expect(user.show_public_profile?).to be false
     end
+
+    it 'returns true when user has accepted a proposal co-sponsorship' do
+      create(:cosponsorship, user: user, status: 'accepted')
+      expect(user.show_public_profile?).to be true
+    end
+
+    it 'returns false when user only has a pending proposal co-sponsorship' do
+      create(:cosponsorship, user: user, status: 'pending')
+      expect(user.show_public_profile?).to be false
+    end
   end
 
   describe 'creating an invited user' do


### PR DESCRIPTION
# Changelog
## Fixed
- Make co-sponsors visible again on proposals if they have not posted anything
