### PR TITLE
[TAN-7955] Add bulk_delete_by_emails_or_ids admin API users endpoint

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
@@ -24,6 +24,11 @@ module AdminApi
       head :ok
     end
 
+    def bulk_delete_by_emails_or_ids
+      AdminApi::BulkDeleteUsersJob.perform_later(params[:emails], params[:ids])
+      head :ok
+    end
+
     def show
       # This uses default model serialization
       render json: @user

--- a/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
+++ b/back/engines/commercial/admin_api/app/jobs/admin_api/bulk_delete_users_job.rb
@@ -1,24 +1,52 @@
 # frozen_string_literal: true
 
 class AdminApi::BulkDeleteUsersJob < ApplicationJob
-  def run(emails)
+  def run(emails = [], ids = [])
+    emails = Array.wrap(emails)
+    ids = Array.wrap(ids)
+
+    if emails.empty? && ids.empty?
+      ErrorReporter.report_msg('BulkDeleteUsersJob called with no emails or ids.')
+      return
+    end
+
+    users_by_email = []
     emails_of_not_found_users = []
 
     emails.each do |email|
       user = User.find_by_cimail(email)
 
       if user
-        DeleteUserJob.perform_later(user)
+        users_by_email << user
       else
         emails_of_not_found_users << email
       end
     end
 
-    return unless emails_of_not_found_users.count.positive?
+    users_by_id = User.where(id: ids).to_a
+    ids_of_not_found_users = ids.map(&:to_s) - users_by_id.map { |user| user.id.to_s }
+
+    (users_by_email + users_by_id).uniq.each do |user|
+      DeleteUserJob.perform_later(user)
+    end
+
+    report_not_found(emails_of_not_found_users, ids_of_not_found_users)
+  end
+
+  private
+
+  def report_not_found(emails_of_not_found_users, ids_of_not_found_users)
+    emails_of_not_found_users = emails_of_not_found_users.uniq
+    ids_of_not_found_users = ids_of_not_found_users.uniq
+
+    return if emails_of_not_found_users.empty? && ids_of_not_found_users.empty?
 
     ErrorReporter.report_msg(
-      'One or more users not found with given email(s). See additional data for email(s).',
-      extra: { emails_of_not_found_users: emails_of_not_found_users.to_s }
+      'One or more users not found with given email(s) or id(s). See additional data for the email(s) and id(s).',
+      extra: {
+        emails_of_not_found_users: emails_of_not_found_users.to_s,
+        ids_of_not_found_users: ids_of_not_found_users.to_s
+      }
     )
   end
 end

--- a/back/engines/commercial/admin_api/config/routes.rb
+++ b/back/engines/commercial/admin_api/config/routes.rb
@@ -22,6 +22,7 @@ AdminApi::Engine.routes.draw do
     get :by_email, on: :collection
     get :jwt_token, on: :member
     delete :bulk_delete_by_emails, on: :collection
+    delete :bulk_delete_by_emails_or_ids, on: :collection
   end
 
   resources :jobs, only: [:show]

--- a/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
@@ -88,6 +88,54 @@ resource 'User', admin_api: true do
     end
   end
 
+  delete 'admin_api/users/bulk_delete_by_emails_or_ids', active_job_inline_adapter: true do
+    parameter :emails, 'Array of user emails'
+    parameter :ids, 'Array of user ids'
+
+    let!(:user_by_id) { create(:user) }
+
+    context 'when all emails and ids match a user' do
+      let(:emails) { [user.email] }
+      let(:ids) { [user_by_id.id] }
+
+      before do
+        expect(DeleteUserJob).to receive(:perform_later).with(user).once
+        expect(DeleteUserJob).to receive(:perform_later).with(user_by_id).once
+        expect(Sentry).not_to receive(:capture_message)
+      end
+
+      example_request 'Delete users by emails and ids' do
+        expect(status).to eq 200
+      end
+    end
+
+    context 'when some emails or ids do not match a user' do
+      let(:emails) { [user.email, 'not-existing-email@example.com'] }
+      let(:ids) { [user_by_id.id, SecureRandom.uuid] }
+
+      before do
+        expect(DeleteUserJob).to receive(:perform_later).with(user).once
+        expect(DeleteUserJob).to receive(:perform_later).with(user_by_id).once
+        expect(Sentry).to receive(:capture_message).once
+      end
+
+      example_request 'Delete the matching users and report the rest' do
+        expect(status).to eq 200
+      end
+    end
+
+    context 'when neither emails nor ids are given' do
+      before do
+        expect(DeleteUserJob).not_to receive(:perform_later)
+        expect(Sentry).to receive(:capture_message).once
+      end
+
+      example_request 'Reports an error and deletes nothing' do
+        expect(status).to eq 200
+      end
+    end
+  end
+
   get 'admin_api/users/:id' do
     let(:id) { user.id }
 

--- a/back/engines/commercial/admin_api/spec/jobs/admin_api/bulk_delete_users_job_spec.rb
+++ b/back/engines/commercial/admin_api/spec/jobs/admin_api/bulk_delete_users_job_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdminApi::BulkDeleteUsersJob do
+  subject(:job) { described_class.new }
+
+  describe '#run' do
+    it 'enqueues a DeleteUserJob for each user found by email' do
+      user1 = create(:user)
+      user2 = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user1)
+      expect(DeleteUserJob).to receive(:perform_later).with(user2)
+
+      job.run([user1.email, user2.email])
+    end
+
+    it 'matches emails case-insensitively' do
+      user = create(:user, email: 'someone@example.com')
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user)
+
+      job.run(['SomeOne@Example.com'])
+    end
+
+    it 'enqueues a DeleteUserJob for each user found by id' do
+      user1 = create(:user)
+      user2 = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user1)
+      expect(DeleteUserJob).to receive(:perform_later).with(user2)
+
+      job.run([], [user1.id, user2.id])
+    end
+
+    it 'enqueues deletions for users found by either email or id' do
+      user_by_email = create(:user)
+      user_by_id = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user_by_email)
+      expect(DeleteUserJob).to receive(:perform_later).with(user_by_id)
+
+      job.run([user_by_email.email], [user_by_id.id])
+    end
+
+    it 'enqueues a DeleteUserJob only once when a user is referenced by both email and id' do
+      user = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user).once
+
+      job.run([user.email], [user.id])
+    end
+
+    it 'enqueues a DeleteUserJob only once when the same email appears in multiple rows' do
+      user = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user).once
+
+      job.run([user.email, user.email])
+    end
+
+    it 'enqueues a DeleteUserJob only once when the same id appears in multiple rows' do
+      user = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user).once
+
+      job.run([], [user.id, user.id])
+    end
+
+    it 'reports an error and does not enqueue when an email is not found' do
+      expect(DeleteUserJob).not_to receive(:perform_later)
+      expect(ErrorReporter).to receive(:report_msg).with(
+        'One or more users not found with given email(s) or id(s). See additional data for the email(s) and id(s).',
+        extra: {
+          emails_of_not_found_users: ['unknown@example.com'].to_s,
+          ids_of_not_found_users: [].to_s
+        }
+      )
+
+      job.run(['unknown@example.com'])
+    end
+
+    it 'reports an error and does not enqueue when an id is not found' do
+      missing_id = SecureRandom.uuid
+
+      expect(DeleteUserJob).not_to receive(:perform_later)
+      expect(ErrorReporter).to receive(:report_msg).with(
+        'One or more users not found with given email(s) or id(s). See additional data for the email(s) and id(s).',
+        extra: {
+          emails_of_not_found_users: [].to_s,
+          ids_of_not_found_users: [missing_id].to_s
+        }
+      )
+
+      job.run([], [missing_id])
+    end
+
+    it 'enqueues deletions for found users and reports only the missing ones' do
+      user = create(:user)
+      missing_id = SecureRandom.uuid
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user)
+      expect(ErrorReporter).to receive(:report_msg).with(
+        'One or more users not found with given email(s) or id(s). See additional data for the email(s) and id(s).',
+        extra: {
+          emails_of_not_found_users: ['unknown@example.com'].to_s,
+          ids_of_not_found_users: [missing_id].to_s
+        }
+      )
+
+      job.run([user.email, 'unknown@example.com'], [missing_id])
+    end
+
+    it 'deduplicates the reported not-found emails and ids' do
+      missing_id = SecureRandom.uuid
+
+      expect(DeleteUserJob).not_to receive(:perform_later)
+      expect(ErrorReporter).to receive(:report_msg).with(
+        'One or more users not found with given email(s) or id(s). See additional data for the email(s) and id(s).',
+        extra: {
+          emails_of_not_found_users: ['unknown@example.com'].to_s,
+          ids_of_not_found_users: [missing_id].to_s
+        }
+      )
+
+      job.run(['unknown@example.com', 'unknown@example.com'], [missing_id, missing_id])
+    end
+
+    it 'treats nil emails as an empty list' do
+      user = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user).once
+      expect(ErrorReporter).not_to receive(:report_msg)
+
+      job.run(nil, [user.id])
+    end
+
+    it 'treats nil ids as an empty list' do
+      user = create(:user)
+
+      expect(DeleteUserJob).to receive(:perform_later).with(user).once
+      expect(ErrorReporter).not_to receive(:report_msg)
+
+      job.run([user.email], nil)
+    end
+
+    it 'reports an error and deletes nothing when both arguments are nil' do
+      expect(DeleteUserJob).not_to receive(:perform_later)
+      expect(ErrorReporter).to receive(:report_msg)
+        .with('BulkDeleteUsersJob called with no emails or ids.')
+
+      expect { job.run(nil, nil) }.not_to raise_error
+    end
+
+    it 'reports an error and deletes nothing when both arguments are empty' do
+      expect(DeleteUserJob).not_to receive(:perform_later)
+      expect(ErrorReporter).to receive(:report_msg)
+        .with('BulkDeleteUsersJob called with no emails or ids.')
+
+      job.run([], [])
+    end
+
+    it 'does not report an error when all users are found' do
+      user = create(:user)
+
+      allow(DeleteUserJob).to receive(:perform_later)
+      expect(ErrorReporter).not_to receive(:report_msg)
+
+      job.run([user.email], [user.id])
+    end
+  end
+end


### PR DESCRIPTION
Add `bulk_delete_by_emails_or_ids` admin API endpoint

New admin API endpoint DELETE `admin_api/users/bulk_delete_by_emails_or_ids` to bulk-delete users by email and/or id, in preparation for use via AdminHQ delete users tool (now that we cannot get user emails from Metabase).

## Key changes

  - New endpoint + route forwarding emails and ids to BulkDeleteUsersJob.
  - Job now looks users up by email (case-insensitive) and/or ID, and de-duplicates so each user is deleted once.
  - nil/empty inputs no longer raise; a call with no emails or IDs is reported via `ErrorReporter`.
  - Added job spec + acceptance tests.

## Original functionality preserved

The existing `bulk_delete_by_emails` endpoint is unchanged — same route, same behavior, existing test still passes. The new endpoint is added alongside it (old one can be removed later).

## Plan
1. Merge & release these changes
2. Merge & release related changes to `cl2-admin` repo in PR [#179](https://github.com/CitizenLabDotCo/cl2-admin/pull/179)
3. Functionally test on demo production platform
4. Remove redundant `AdminApi::UsersController#bulk_delete_by_emails endpoint` & route from `citizenlab` repo.

# Changelog
## Technical
- [TAN-7955] Add `bulk_delete_by_emails_or_ids` admin API users endpoint
