### PR TITLE
[TAN-7955] Remove redundant `AdminApi::UsersController` `bulk_delete_by_emails` endpoint, route and tests

### DIFF
--- a/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
+++ b/back/engines/commercial/admin_api/app/controllers/admin_api/users_controller.rb
@@ -19,11 +19,6 @@ module AdminApi
       render json: @user
     end
 
-    def bulk_delete_by_emails
-      AdminApi::BulkDeleteUsersJob.perform_later(params[:emails])
-      head :ok
-    end
-
     def bulk_delete_by_emails_or_ids
       AdminApi::BulkDeleteUsersJob.perform_later(params[:emails], params[:ids])
       head :ok

--- a/back/engines/commercial/admin_api/config/routes.rb
+++ b/back/engines/commercial/admin_api/config/routes.rb
@@ -21,7 +21,6 @@ AdminApi::Engine.routes.draw do
   resources :users, only: %i[index create update show] do
     get :by_email, on: :collection
     get :jwt_token, on: :member
-    delete :bulk_delete_by_emails, on: :collection
     delete :bulk_delete_by_emails_or_ids, on: :collection
   end
 

--- a/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
+++ b/back/engines/commercial/admin_api/spec/acceptance/users_spec.rb
@@ -73,21 +73,6 @@ resource 'User', admin_api: true do
     end
   end
 
-  delete 'admin_api/users/bulk_delete_by_emails', active_job_inline_adapter: true do
-    parameter :emails, 'Array of user emails'
-
-    let(:emails) { [user.email, 'not-existing-email@example.com'] }
-
-    before do
-      expect(DeleteUserJob).to receive(:perform_later).with(user).once
-      expect(Sentry).to receive(:capture_message).once
-    end
-
-    example_request 'Delete users by emails' do
-      expect(status).to eq 200
-    end
-  end
-
   delete 'admin_api/users/bulk_delete_by_emails_or_ids', active_job_inline_adapter: true do
     parameter :emails, 'Array of user emails'
     parameter :ids, 'Array of user ids'


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-7955] Remove redundant `AdminApi::UsersController#bulk_delete_by_emails` endpoint
