### PR TITLE
Remove accidentally created columns - Part 1

### DIFF
--- a/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/idea_import.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/idea_import.rb
@@ -9,11 +9,9 @@
 #  import_user_id  :uuid
 #  file_id         :uuid
 #  user_created    :boolean          default(FALSE)
-#  required        :boolean          default(FALSE)
 #  approved_at     :datetime
 #  page_range      :text             default([]), is an Array
 #  locale          :string
-#  string          :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  user_consent    :boolean          default(FALSE), not null
@@ -34,6 +32,9 @@
 module BulkImportIdeas
   class IdeaImport < ApplicationRecord
     self.table_name = 'idea_imports'
+
+    # Accidental columns scheduled for removal; ignored so AR stops caching/writing them.
+    self.ignored_columns += %w[string required]
 
     belongs_to :file, class_name: 'BulkImportIdeas::IdeaImportFile', optional: true
     belongs_to :idea

--- a/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/project_import.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/models/bulk_import_ideas/project_import.rb
@@ -10,7 +10,6 @@
 #  import_id      :uuid
 #  log            :string           default([]), is an Array
 #  locale         :string
-#  string         :string
 #  created_at     :datetime         not null
 #  updated_at     :datetime         not null
 #  import_type    :string
@@ -28,6 +27,9 @@
 module BulkImportIdeas
   class ProjectImport < ApplicationRecord
     self.table_name = 'project_imports'
+
+    # Accidental column scheduled for removal; ignored so AR stops caching/writing it.
+    self.ignored_columns += %w[string]
 
     IMPORT_TYPES = %w[project user preview project_copy].freeze
 


### PR DESCRIPTION
Following the advice of strong migrations to ignore first, deploy and then remove

# Changelog
## Technical
- Ignore import columns created accidentally so we can remove them in a subsequent migration
