### PR TITLE
[TAN-7982] Bugfix: Replace link to inspiration hub in new project form

### DIFF
--- a/front/app/containers/Admin/projects/new/ProjectSetupForm.tsx
+++ b/front/app/containers/Admin/projects/new/ProjectSetupForm.tsx
@@ -302,16 +302,21 @@ const ProjectSetupForm = ({ authUser }: Props) => {
           {isProjectLibraryEnabled && (
             <Box mb="20px">
               <Warning>
-                <FormattedMessage
-                  {...messages.needInspiration}
-                  values={{
-                    inspirationHubLink: (
-                      <Link to="/admin/inspiration-hub" target="_blank">
-                        <FormattedMessage {...messages.inspirationHub} />
-                      </Link>
-                    ),
-                  }}
-                />
+                <>
+                  <strong>
+                    <FormattedMessage {...messages.needInspiration} />
+                  </strong>{' '}
+                  <FormattedMessage
+                    {...messages.needInspirationDescription}
+                    values={{
+                      inspirationHubLink: (
+                        <Link to="/admin/inspiration-hub" target="_blank">
+                          <FormattedMessage {...messages.inspirationHub} />
+                        </Link>
+                      ),
+                    }}
+                  />
+                </>
               </Warning>
             </Box>
           )}

--- a/front/app/containers/Admin/projects/project/general/setUp/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/setUp/index.tsx
@@ -459,16 +459,21 @@ const AdminProjectsProjectGeneral = ({ project }: Props) => {
           {isProjectLibraryEnabled && (
             <Box mb="20px">
               <Warning>
-                <FormattedMessage
-                  {...messages.needInspiration}
-                  values={{
-                    inspirationHubLink: (
-                      <Link to="/admin/inspiration-hub" target="_blank">
-                        <FormattedMessage {...messages.inspirationHub} />
-                      </Link>
-                    ),
-                  }}
-                />
+                <>
+                  <strong>
+                    <FormattedMessage {...messages.needInspiration} />
+                  </strong>{' '}
+                  <FormattedMessage
+                    {...messages.needInspirationDescription}
+                    values={{
+                      inspirationHubLink: (
+                        <Link to="/admin/inspiration-hub" target="_blank">
+                          <FormattedMessage {...messages.inspirationHub} />
+                        </Link>
+                      ),
+                    }}
+                  />
+                </>
               </Warning>
             </Box>
           )}


### PR DESCRIPTION
The `needInspirationDescription` had been removed (probably accidentally), so I replaced it.

I chose to inline the 2 messages (`needInspiration` + `needInspirationDescription`) as it seemed to be the least worse looking layout with the default vertically centered 'i' icon.

Inline version I chose:
<img width="604" height="611" alt="Screenshot 2026-06-12 at 10 20 48" src="https://github.com/user-attachments/assets/39c859ea-ee43-4704-94f9-aef54bc1fc44" />

2 paragraph version I rejected as even more ugly:
<img width="604" height="707" alt="Screenshot 2026-06-12 at 10 17 23" src="https://github.com/user-attachments/assets/c02b0f46-1681-44aa-82e8-643836585b15" />

# Changelog
## Fixed
- [TAN-7982] Bugfix: Replace link to inspiration hub in new project form
