### PR TITLE
TAN-7997 - Allow email case change when accepting invites

### DIFF
--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -379,6 +379,10 @@ class User < ApplicationRecord
                   (new_email_changed? || email_changed?) &&
                   email_was.present?
 
+    # Ignore changes that only differ in letter-case (e.g. accepting an invite with
+    # `small@big.com` for an address stored as `SMALL@BIG.COM`)
+    return if email_changed_only_in_case? && !new_email_changed?
+
     if no_password? && confirmation_required # only for light registration
       # Avoid security hole where passwordless user can change when they are authenticated without confirmation
       errors.add :email, :change_not_permitted, value: email, message: 'change not permitted - user not active'
@@ -415,6 +419,10 @@ class User < ApplicationRecord
 
   def email_or_new_email_changed?
     new_record? || email_changed? || new_email_changed?
+  end
+
+  def email_changed_only_in_case?
+    email_changed? && email.present? && email_was.present? && email.casecmp?(email_was)
   end
 
   def validate_email_domains_blacklist

--- a/back/spec/acceptance/invites_spec.rb
+++ b/back/spec/acceptance/invites_spec.rb
@@ -163,6 +163,18 @@ resource 'Invites' do
         ).exactly(1).times
       end
 
+      example 'Accept an invite with a different-case email', document: false do
+        # Changing only the letter-case of the invited email must make no
+        # difference and still be valid (emails are matched case-insensitively).
+        invite.invitee.update!(email: 'Super.Boulette@Hotmail.com')
+
+        do_request(invite: { email: 'super.boulette@hotmail.com' })
+
+        assert_status(200)
+        expect(invite.reload.accepted_at).to be_present
+        expect(invite.invitee.invite_status).to eq('accepted')
+      end
+
       example '[error] Accept an invite with an invalid token', document: false do
         invite.destroy!
         do_request


### PR DESCRIPTION
# Changelog
## Fixed
- Allow users to change the case of their email address (eg from TEST@GOVOCAL.COM to test@govocal.com) when accepting invites
