### PR TITLE
[TAN-7968] Bugfix: Show progress value on survey pages with no questions (was showing 'NaN')

### DIFF
--- a/front/app/components/CustomFieldsForm/util.test.ts
+++ b/front/app/components/CustomFieldsForm/util.test.ts
@@ -79,4 +79,28 @@ describe('getFormCompletionPercentage', () => {
 
     expect(result).toEqual(87);
   });
+
+  it('returns overall survey progress (no NaN) on a page with no questions', () => {
+    const result = getFormCompletionPercentage({
+      pageQuestions: [],
+      currentPageIndex: 3,
+      lastPageIndex: 4,
+      formValues: {},
+      userIsEditing: false,
+    });
+
+    expect(result).toEqual(75);
+  });
+
+  it('returns 0 (no NaN) on the first page when it has no questions', () => {
+    const result = getFormCompletionPercentage({
+      pageQuestions: [],
+      currentPageIndex: 0,
+      lastPageIndex: 4,
+      formValues: {},
+      userIsEditing: false,
+    });
+
+    expect(result).toEqual(0);
+  });
 });

--- a/front/app/components/CustomFieldsForm/util.ts
+++ b/front/app/components/CustomFieldsForm/util.ts
@@ -97,9 +97,14 @@ export function getFormCompletionPercentage({
     }
   });
 
+  // A page with no questions (e.g. a title-only page) contributes no
+  // per-page progress. Guard against dividing by zero, which would
+  // otherwise produce NaN ("NaN% complete" in the progress bar).
   const percentageOnPage =
-    ((indexOfLastFilledOutQuestion + 1) / numberOfQuestionsOnPage) *
-    percentagePerPage;
+    numberOfQuestionsOnPage === 0
+      ? 0
+      : ((indexOfLastFilledOutQuestion + 1) / numberOfQuestionsOnPage) *
+        percentagePerPage;
 
   const percentage = pageNumberPercentage + percentageOnPage;
 


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-7968] Bugfix: Show progress value on survey pages with no questions (was showing 'NaN')
