### PR TITLE
Set clear heading title on 404 page

### DIFF
--- a/front/app/components/PageNotFound/index.tsx
+++ b/front/app/components/PageNotFound/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Title, Text, media, Spinner } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
+import HelmetIntl from 'components/HelmetIntl';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 import Centerer from 'components/UI/Centerer';
 
@@ -48,6 +49,7 @@ const PageNotFound = () => {
 
   return (
     <main>
+      <HelmetIntl title={messages.notFoundTitle} />
       <PageNotFoundWrapper>
         <Title mb="0">{formatMessage(messages.notFoundTitle)}</Title>
         <Text fontSize="l" color={'textSecondary'} mb="36px">


### PR DESCRIPTION
# Changelog
## A11y 
- Set clear heading title on 404 page

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
