### PR TITLE
[No-ticket] Fix rubocop pollution of global namespace

### DIFF
--- a/back/spec/rubocop_spec_helper.rb
+++ b/back/spec/rubocop_spec_helper.rb
@@ -1,6 +1,18 @@
 require 'rubocop'
-require 'rubocop/rspec/support'
+
+# NOTE: We deliberately do NOT `require 'rubocop/rspec/support'`. That file runs
+# an `RSpec.configure` block that does a *global* `config.include CopHelper`
+# (and others), which leaks CopHelper#configuration -> RuboCop::Config into every
+# example group in the process. Depending on spec-file load order that shadows
+# unrelated specs' own `let(:configuration)` and breaks them (only on CI, where
+# files share a process). Instead we require the helper files directly (no global
+# side effects) and include everything scoped to `:config`-tagged cop specs.
+require 'rubocop/rspec/cop_helper'
+require 'rubocop/rspec/expect_offense'
+require 'rubocop/rspec/shared_contexts'
 
 RSpec.configure do |config|
-  config.include RuboCop::RSpec::ExpectOffense
+  config.include CopHelper, :config
+  config.include RuboCop::RSpec::ExpectOffense, :config
+  config.include_context 'config', :config
 end


### PR DESCRIPTION
# Changelog
## Technical
- [No-ticket] Fix rubocop pollution of global namespace
