### PR TITLE
TAN-8022-a11y-map-improvements-at-400-zoom

### DIFF
--- a/front/app/components/EventCards/messages.ts
+++ b/front/app/components/EventCards/messages.ts
@@ -45,6 +45,10 @@ export default defineMessages({
     id: 'app.containers.EventsShow.locationIconAltText',
     defaultMessage: 'Location',
   },
+  viewLocationOnGoogleMaps: {
+    id: 'app.containers.EventsShow.viewLocationOnGoogleMaps',
+    defaultMessage: 'View {location} on Google Maps (opens in a new window)',
+  },
   onlineLinkIconAltText: {
     id: 'app.containers.EventsShow.onlineLinkIconAltText',
     defaultMessage: 'Online meeting link',

--- a/front/app/containers/EventsShowPage/components/MetadataInformation/Location.tsx
+++ b/front/app/containers/EventsShowPage/components/MetadataInformation/Location.tsx
@@ -36,6 +36,7 @@ const Location = ({ event }: Props) => {
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   const address2 = event?.attributes?.address_2_multiloc[currentLocale];
+  const locationName = address1.slice(0, address1.indexOf(','));
 
   if (address1) {
     return (
@@ -55,6 +56,9 @@ const Location = ({ event }: Props) => {
                 buttonStyle="text"
                 linkTo={`https://www.google.com/maps/search/?api=1&query=${position.coordinates[1]},${position.coordinates[0]}`}
                 openLinkInNewTab={isPhoneOrSmaller ? false : true} // On mobile, this will open the app instead
+                ariaLabel={formatMessage(messages.viewLocationOnGoogleMaps, {
+                  location: locationName,
+                })}
                 pl="0px"
                 style={{
                   textDecoration: 'underline',
@@ -64,7 +68,7 @@ const Location = ({ event }: Props) => {
                 id="e2e-location-with-coordinates-button"
               >
                 <Text mt="4px" color="coolGrey600" m="0px" p="0px" fontSize="s">
-                  {address1.slice(0, address1.indexOf(','))}
+                  {locationName}
                 </Text>
               </ButtonWithLink>
             </Box>
@@ -88,11 +92,13 @@ const Location = ({ event }: Props) => {
               {address2}
             </Text>
           )}
-          {position && ( // Using a negative margin here so we can extend the map outside of the container
-            <Box ml="-30px" width="300" mt="8px" id="e2e-location-map">
-              <LocationMap eventLocation={position} />
-            </Box>
-          )}
+
+          {position &&
+            !isPhoneOrSmaller && ( // Negative margin extends the map outside the container
+              <Box ml="-30px" width="300" mt="8px" id="e2e-location-map">
+                <LocationMap eventLocation={position} />
+              </Box>
+            )}
         </Content>
       </Container>
     );

--- a/front/app/translations/.polyglit.da-DK.json.json
+++ b/front/app/translations/.polyglit.da-DK.json.json
@@ -7149,6 +7149,11 @@
     "verified_at": "2026-03-18T12:49:36.657470Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-18T11:54:01.688274Z",
+    "verified_by": "kielgast@govocal.com"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T12:49:36.657470Z",

--- a/front/app/translations/.polyglit.de-AT.json.json
+++ b/front/app/translations/.polyglit.de-AT.json.json
@@ -7149,6 +7149,11 @@
     "verified_at": "2026-03-30T12:57:38.368694Z",
     "verified_by": "Edwin Kato"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-18T11:53:51.177677Z",
+    "verified_by": "Jelena"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-30T12:57:38.368694Z",

--- a/front/app/translations/.polyglit.de-DE.json.json
+++ b/front/app/translations/.polyglit.de-DE.json.json
@@ -7149,6 +7149,11 @@
     "verified_at": "2026-03-18T15:41:17.347666Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-18T11:53:51.051174Z",
+    "verified_by": "Jelena"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T15:41:17.347666Z",

--- a/front/app/translations/.polyglit.fr-BE.json.json
+++ b/front/app/translations/.polyglit.fr-BE.json.json
@@ -7149,6 +7149,11 @@
     "verified_at": "2026-03-18T11:50:36.653533Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-19T09:35:34.347153Z",
+    "verified_by": "Cindy EB"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.653533Z",

--- a/front/app/translations/.polyglit.fr-FR.json.json
+++ b/front/app/translations/.polyglit.fr-FR.json.json
@@ -7149,6 +7149,11 @@
     "verified_at": "2026-03-18T11:50:36.510849Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-19T09:35:34.178166Z",
+    "verified_by": "Cindy EB"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T11:50:36.510849Z",

--- a/front/app/translations/.polyglit.it-IT.json.json
+++ b/front/app/translations/.polyglit.it-IT.json.json
@@ -7139,6 +7139,11 @@
     "verified_at": "2026-03-18T16:40:24.277483Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-18T13:20:37.756136Z",
+    "verified_by": "Roger"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T16:40:24.277483Z",

--- a/front/app/translations/.polyglit.nl-BE.json.json
+++ b/front/app/translations/.polyglit.nl-BE.json.json
@@ -7144,6 +7144,11 @@
     "verified_at": "2026-03-18T16:34:36.118563Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-19T12:47:48.796308Z",
+    "verified_by": "Pauline"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.481338Z",

--- a/front/app/translations/.polyglit.nl-NL.json.json
+++ b/front/app/translations/.polyglit.nl-NL.json.json
@@ -7144,6 +7144,11 @@
     "verified_at": "2026-03-18T11:49:32.340815Z",
     "verified_by": "Admin"
   },
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": {
+    "state": "verified",
+    "verified_at": "2026-06-19T12:47:48.644010Z",
+    "verified_by": "Pauline"
+  },
   "app.containers.EventsShow.xParticipants": {
     "state": "verified",
     "verified_at": "2026-03-18T11:49:32.340815Z",

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} المسجلين",
   "app.containers.EventsShow.registrantsIconAltText": "المسجلين",
   "app.containers.EventsShow.socialMediaSharingMessage": "حضور هذا الحدث: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "عرض {location} على خرائط Google (يفتح في نافذة جديدة)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# مشارك} other {# مشاركون}}",
   "app.containers.EventsViewer.allTime": "كل الوقت",
   "app.containers.EventsViewer.date": "تاريخ",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} المسجلين",
   "app.containers.EventsShow.registrantsIconAltText": "المسجلين",
   "app.containers.EventsShow.socialMediaSharingMessage": "حضور هذا الحدث: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "عرض {location} على خرائط Google (يفتح في نافذة جديدة)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# مشارك} other {# مشاركون}}",
   "app.containers.EventsViewer.allTime": "كل الوقت",
   "app.containers.EventsViewer.date": "تاريخ",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} inscrits",
   "app.containers.EventsShow.registrantsIconAltText": "Registrats",
   "app.containers.EventsShow.socialMediaSharingMessage": "Assisteix a aquest esdeveniment: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Veure {location} a Google Maps (s'obre en una finestra nova)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {#participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "Tot el temps",
   "app.containers.EventsViewer.date": "Data",

--- a/front/app/translations/cy-GB.json
+++ b/front/app/translations/cy-GB.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} cofrestrwyr",
   "app.containers.EventsShow.registrantsIconAltText": "Cofrestrwyr",
   "app.containers.EventsShow.socialMediaSharingMessage": "Mynychwch y digwyddiad hwn: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Gweld {location} ar Google Maps (yn agor mewn ffenestr newydd)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# cyfranogwr} other {# cyfranogwr}}",
   "app.containers.EventsViewer.allTime": "Trwy'r amser",
   "app.containers.EventsViewer.date": "Dyddiad",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} deltagere",
   "app.containers.EventsShow.registrantsIconAltText": "Deltagere",
   "app.containers.EventsShow.socialMediaSharingMessage": "Deltag i dette arrangement: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Se {location} på Google Maps (åbner i et nyt vindue)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# deltager} other {# deltagere}}",
   "app.containers.EventsViewer.allTime": "Hele tiden",
   "app.containers.EventsViewer.date": "Dato",

--- a/front/app/translations/de-AT.json
+++ b/front/app/translations/de-AT.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} Teilnehmende",
   "app.containers.EventsShow.registrantsIconAltText": "Teilnehmende",
   "app.containers.EventsShow.socialMediaSharingMessage": "An Veranstaltung teilnehmen: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} auf Google Maps anzeigen (öffnet in neuem Fenster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# Teilnehmer*in} other {# Teilnehmende}}",
   "app.containers.EventsViewer.allTime": "Alle Zeiträume",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} Teilnehmende",
   "app.containers.EventsShow.registrantsIconAltText": "Teilnehmende",
   "app.containers.EventsShow.socialMediaSharingMessage": "An Veranstaltung teilnehmen: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} auf Google Maps anzeigen (öffnet in neuem Fenster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# Teilnehmer*in} other {# Teilnehmende}}",
   "app.containers.EventsViewer.allTime": "Alle Zeiträume",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} εγγεγραμμένοι",
   "app.containers.EventsShow.registrantsIconAltText": "Καταχωρούμενοι",
   "app.containers.EventsShow.socialMediaSharingMessage": "Παρακολουθήστε αυτή την εκδήλωση: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Προβολή της τοποθεσίας {location} στους Χάρτες Google (ανοίγει σε νέο παράθυρο)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "Όλη την ώρα",
   "app.containers.EventsViewer.date": "Ημερομηνία",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrants",
   "app.containers.EventsShow.registrantsIconAltText": "Registrants",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "View {location} on Google Maps (opens in a new window)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "All time",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrants",
   "app.containers.EventsShow.registrantsIconAltText": "Registrants",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "View {location} on Google Maps (opens in a new window)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "All time",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrants",
   "app.containers.EventsShow.registrantsIconAltText": "Registrants",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "View {location} on Google Maps (opens in a new window)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "All time",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrants",
   "app.containers.EventsShow.registrantsIconAltText": "Registrants",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "View {location} on Google Maps (opens in a new window)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "All time",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} inscritos",
   "app.containers.EventsShow.registrantsIconAltText": "Inscritos",
   "app.containers.EventsShow.socialMediaSharingMessage": "Asiste a este acto: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Ver {location} en Google Maps (se abre en una ventana nueva)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# Participante} other {# Participantes}}",
   "app.containers.EventsViewer.allTime": "Todo el tiempo",
   "app.containers.EventsViewer.date": "Fecha",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} inscritos",
   "app.containers.EventsShow.registrantsIconAltText": "Inscritos",
   "app.containers.EventsShow.socialMediaSharingMessage": "Asiste a este acto: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Ver {location} en Google Maps (se abre en una ventana nueva)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# Participante} other {# Participantes}}",
   "app.containers.EventsViewer.allTime": "Todas las fechas",
   "app.containers.EventsViewer.date": "Fecha",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} rekisteröitynyttä",
   "app.containers.EventsShow.registrantsIconAltText": "Rekisteröityjä",
   "app.containers.EventsShow.socialMediaSharingMessage": "Osallistu tähän tapahtumaan: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Näytä {location} Google Mapsissa (avautuu uuteen ikkunaan)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# osallistuja} other {# osallistuja}}",
   "app.containers.EventsViewer.allTime": "Koko ajan",
   "app.containers.EventsViewer.date": "Päivämäärä",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} inscriptions",
   "app.containers.EventsShow.registrantsIconAltText": "Personne inscrites",
   "app.containers.EventsShow.socialMediaSharingMessage": "Participez à cet événement : {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Voir {location} sur Google Maps (s’ouvre dans une nouvelle fenêtre)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# participants} one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "Tout le temps",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} inscriptions",
   "app.containers.EventsShow.registrantsIconAltText": "Personne inscrites",
   "app.containers.EventsShow.socialMediaSharingMessage": "Participez à cet événement : {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Voir {location} sur Google Maps (s’ouvre dans une nouvelle fenêtre)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# participants} one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "Tout le temps",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/ga-IE.json
+++ b/front/app/translations/ga-IE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} cláraithe",
   "app.containers.EventsShow.registrantsIconAltText": "Cláraitheoirí",
   "app.containers.EventsShow.socialMediaSharingMessage": "Freastal ar an ócáid seo: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Féach ar {location} ar Google Maps (osclaíonn sé i bhfuinneog nua)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# rannpháirtí} other {# rannpháirtithe}}",
   "app.containers.EventsViewer.allTime": "Gach am",
   "app.containers.EventsViewer.date": "Dáta",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registriranih",
   "app.containers.EventsShow.registrantsIconAltText": "Registranti",
   "app.containers.EventsShow.socialMediaSharingMessage": "Prisustvujte ovom događaju: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Prikaži {location} na Google kartama (otvara se u novom prozoru)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# sudionik} other {# sudionika}}",
   "app.containers.EventsViewer.allTime": "Cijelo vrijeme",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} regisztrálók",
   "app.containers.EventsShow.registrantsIconAltText": "Regisztráltak",
   "app.containers.EventsShow.socialMediaSharingMessage": "Vegyen részt ezen az eseményen: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} megtekintése a Google Térképen (új ablakban nyílik meg)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# résztvevő} other {# résztvevő}}",
   "app.containers.EventsViewer.allTime": "Minden alkalommal",
   "app.containers.EventsViewer.date": "Dátum",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} partecipanti",
   "app.containers.EventsShow.registrantsIconAltText": "Partecipanti",
   "app.containers.EventsShow.socialMediaSharingMessage": "Partecipa a questo evento: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Visualizza {location} su Google Maps (si apre in una nuova finestra)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# partecipante} other {# partecipanti}}",
   "app.containers.EventsViewer.allTime": "Tutti gli eventi",
   "app.containers.EventsViewer.date": "Data",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrants",
   "app.containers.EventsShow.registrantsIconAltText": "Registrants",
   "app.containers.EventsShow.socialMediaSharingMessage": "Attend this event: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} Google Maps-imi takuuk (igalaami nutaami ammassaaq)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# participant} other {# participants}}",
   "app.containers.EventsViewer.allTime": "All time",
   "app.containers.EventsViewer.date": "Date",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} Umeldungen",
   "app.containers.EventsShow.registrantsIconAltText": "Registréiert",
   "app.containers.EventsShow.socialMediaSharingMessage": "Bei dësem Event deelhuelen: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} op Google Maps uweisen (mécht an enger neier Fënster op)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {#Participant} other {#Participanten}}",
   "app.containers.EventsViewer.allTime": "Ëmmer",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/lt-LT.json
+++ b/front/app/translations/lt-LT.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registruotojų",
   "app.containers.EventsShow.registrantsIconAltText": "Registruotojai",
   "app.containers.EventsShow.socialMediaSharingMessage": "Dalyvaukite šiame renginyje: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Peržiūrėti {location} „Google“ žemėlapiuose (atsidaro naujame lange)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# dalyvis} other {# dalyviai}}",
   "app.containers.EventsViewer.allTime": "Visą laiką",
   "app.containers.EventsViewer.date": "Data",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} reģistrējušies",
   "app.containers.EventsShow.registrantsIconAltText": "Reģistrētāji",
   "app.containers.EventsShow.socialMediaSharingMessage": "Apmeklējiet šo pasākumu: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Skatīt {location} Google Maps (atveras jaunā logā)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# dalībnieks} other {# dalībnieki}}",
   "app.containers.EventsViewer.allTime": "Visu laiku",
   "app.containers.EventsViewer.date": "Datums",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registranter",
   "app.containers.EventsShow.registrantsIconAltText": "Registranter",
   "app.containers.EventsShow.socialMediaSharingMessage": "Delta på dette arrangementet: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Se {location} på Google Maps (åpnes i et nytt vindu)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {~ # deltaker} other {# deltakere}}",
   "app.containers.EventsViewer.allTime": "Hele tiden",
   "app.containers.EventsViewer.date": "Dato",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -1426,7 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} geregistreerden",
   "app.containers.EventsShow.registrantsIconAltText": "Geregistreerden",
   "app.containers.EventsShow.socialMediaSharingMessage": "Woon dit evenement bij: {eventTitle}",
-  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} op Google Maps (opent in een nieuw venster)",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} in Google Maps (opent in een nieuw venster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# deelnemers} one {# deelnemer} other {# deelnemers}}",
   "app.containers.EventsViewer.allTime": "Altijd",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} geregistreerden",
   "app.containers.EventsShow.registrantsIconAltText": "Geregistreerden",
   "app.containers.EventsShow.socialMediaSharingMessage": "Woon dit evenement bij: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} op Google Maps (opent in een nieuw venster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# deelnemers} one {# deelnemer} other {# deelnemers}}",
   "app.containers.EventsViewer.allTime": "Altijd",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} geregistreerden",
   "app.containers.EventsShow.registrantsIconAltText": "Geregistreerden",
   "app.containers.EventsShow.socialMediaSharingMessage": "Woon deze activiteit bij: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} op Google Maps (opent in een nieuw venster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# deelnemers} one {# deelnemer} other {# deelnemers}}",
   "app.containers.EventsViewer.allTime": "Altijd",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -1426,7 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} geregistreerden",
   "app.containers.EventsShow.registrantsIconAltText": "Geregistreerden",
   "app.containers.EventsShow.socialMediaSharingMessage": "Woon deze activiteit bij: {eventTitle}",
-  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} op Google Maps (opent in een nieuw venster)",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Bekijk {location} in Google Maps (opent in een nieuw venster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, no {# deelnemers} one {# deelnemer} other {# deelnemers}}",
   "app.containers.EventsViewer.allTime": "Altijd",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} ਰਜਿਸਟਰ ਕਰਨ ਵਾਲੇ",
   "app.containers.EventsShow.registrantsIconAltText": "ਰਜਿਸਟਰ ਕਰਨ ਵਾਲੇ",
   "app.containers.EventsShow.socialMediaSharingMessage": "ਇਸ ਇਵੈਂਟ ਵਿੱਚ ਸ਼ਾਮਲ ਹੋਵੋ: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "ਗੂਗਲ ਮੈਪਸ 'ਤੇ {location} ਦੇਖੋ (ਨਵੀਂ ਵਿੰਡੋ ਵਿੱਚ ਖੁੱਲ੍ਹਦਾ ਹੈ)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# ਭਾਗੀਦਾਰ} other {# ਭਾਗੀਦਾਰ}}",
   "app.containers.EventsViewer.allTime": "ਸਾਰਾ ਸਮਾਂ",
   "app.containers.EventsViewer.date": "ਮਿਤੀ",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} rejestrujących",
   "app.containers.EventsShow.registrantsIconAltText": "Rejestrujący",
   "app.containers.EventsShow.socialMediaSharingMessage": "Weź udział w tym wydarzeniu: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Zobacz {location} w Mapach Google (otwiera się w nowym oknie)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# uczestnik} other {# uczestnicy}}",
   "app.containers.EventsViewer.allTime": "Cały czas",
   "app.containers.EventsViewer.date": "Data",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrantes",
   "app.containers.EventsShow.registrantsIconAltText": "Registradores",
   "app.containers.EventsShow.socialMediaSharingMessage": "Participe deste evento: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Ver {location} no Google Maps (abre em uma nova janela)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# Participante} other {# participantes}}",
   "app.containers.EventsViewer.allTime": "Todo o tempo",
   "app.containers.EventsViewer.date": "Data",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} registrerade",
   "app.containers.EventsShow.registrantsIconAltText": "Registrerade",
   "app.containers.EventsShow.socialMediaSharingMessage": "Delta i detta evenemang: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "Visa {location} på Google Maps (öppnas i ett nytt fönster)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# deltagare} other {# deltagare}}",
   "app.containers.EventsViewer.allTime": "Hela tiden",
   "app.containers.EventsViewer.date": "Datum",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} kayıt yaptıranlar",
   "app.containers.EventsShow.registrantsIconAltText": "Kayıt yaptıranlar",
   "app.containers.EventsShow.socialMediaSharingMessage": "Bu etkinliğe katılın: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "{location} konumunu Google Haritalar'da görüntüle (yeni pencerede açılır)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# katılımcı} other {# katılımcılar}}",
   "app.containers.EventsViewer.allTime": "Her zaman",
   "app.containers.EventsViewer.date": "Tarih",

--- a/front/app/translations/ur-PK.json
+++ b/front/app/translations/ur-PK.json
@@ -1426,6 +1426,7 @@
   "app.containers.EventsShow.registrantCountWithMaximum": "{attendeesCount} / {maximumNumberOfAttendees} رجسٹر کرنے والے",
   "app.containers.EventsShow.registrantsIconAltText": "رجسٹر کرنے والے",
   "app.containers.EventsShow.socialMediaSharingMessage": "اس تقریب میں شرکت کریں: {eventTitle}",
+  "app.containers.EventsShow.viewLocationOnGoogleMaps": "گوگل میپس پر {location} دیکھیں (نئی ونڈو میں کھلتا ہے)",
   "app.containers.EventsShow.xParticipants": "{count, plural, one {# شریک} other {# شرکاء}}",
   "app.containers.EventsViewer.allTime": "ہر وقت",
   "app.containers.EventsViewer.date": "تاریخ",


### PR DESCRIPTION


# Changelog
## A11y 
-  hide events location map on mobile and add accessible label to Google map link

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
