### PR TITLE
[No-ticket] Bump excon conservatively

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -531,7 +531,7 @@ GEM
     erb (6.0.1.1)
     erubi (1.13.1)
     event_stream_parser (1.0.0)
-    excon (1.4.2)
+    excon (1.5.0)
       logger
     factory_bot (6.5.0)
       activesupport (>= 5.0.0)


### PR DESCRIPTION
- Advisory: GHSA-48rx-c7pg-q66r / CVE-2026-54171 — Excon's redirect-follower middleware didn't strip sensitive headers when following redirects, risking leakage of request headers to redirect targets (CVSS 6.5).
- Fix: patched in excon 1.5.0. We were on 1.4.2.
- Change: `bundle update --conservative excon` bumped only excon (`1.4.2 → 1.5.0`). The lockfile diff is a single line; no other dependencies moved. excon is a transitive dep via `fog-core` (`excon (~> 1.0)`), and `1.5.0` satisfies that constraint, so nothing else needed to change. `bundle check` confirms the lockfile is consistent.

# Changelog
## Technical
- [No-ticket] Bump excon conservatively
