### PR TITLE
Silence sentry errors from pre-render

### DIFF
--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -26,9 +26,15 @@ import { initRouter, router } from './routes';
 // This must happen before any component renders.
 initRouter(modules.routes);
 
+// The prerender service crawls pages with a GPU-less headless Chrome that lacks
+// WebGL2, so the ArcGIS map widget fails to mount and floods Sentry with errors
+// that no real user ever hits. Don't report from prerender crawls.
+const isPrerender = /Prerender/.test(navigator.userAgent);
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   environment: process.env.SENTRY_ENV,
+  enabled: !isPrerender,
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.tanstackRouterBrowserTracingIntegration(router),


### PR DESCRIPTION
Currently it is hard to find real FE issues in Sentry as so many of them relate to Headless chrome - coming from pre-render, and more specifically, headless Chrome that lacks WebGL2, so the ArcGIS map widget fails to mount and floods Sentry with errors

# Changelog
## Technical
- Silence FE sentry errors from pre-render engine
