### PR TITLE
TAN-8008-A11y/fix-error-msg-in-ProfileForm

### DIFF
--- a/front/app/components/UserCustomFields/index.tsx
+++ b/front/app/components/UserCustomFields/index.tsx
@@ -35,7 +35,10 @@ const UserCustomFieldsForm = ({
   useEffect(() => {
     if (triggerValidation && onValidationResult) {
       const validateForm = async () => {
-        const isValid = await methods.trigger();
+        // shouldFocus moves focus to the first invalid field on submit so the
+        // associated error (role="alert") is surfaced. trigger() does not honor
+        // the form-level shouldFocusError option, so it must be passed here.
+        const isValid = await methods.trigger(undefined, { shouldFocus: true });
         onValidationResult(isValid);
       };
       validateForm();

--- a/front/app/containers/UsersEditPage/ProfileForm.tsx
+++ b/front/app/containers/UsersEditPage/ProfileForm.tsx
@@ -136,7 +136,9 @@ const ProfileForm = () => {
     event.preventDefault();
 
     // First validate the main form
-    const isMainFormValid = await methods.trigger();
+    const isMainFormValid = await methods.trigger(undefined, {
+      shouldFocus: true,
+    });
     if (!isMainFormValid) {
       return;
     }
@@ -212,7 +214,7 @@ const ProfileForm = () => {
   return (
     <FormSection>
       <FormProvider {...methods}>
-        <form onSubmit={handleDisclaimer}>
+        <form noValidate onSubmit={handleDisclaimer}>
           <FormSectionTitle
             message={messages.h1}
             subtitleMessage={messages.h1sub}


### PR DESCRIPTION
- Add `noValidate` to the form so RHF handles validation and the error
  (role="alert") renders on the first submit, matching the pattern used
  in the auth forms.
- Pass `{ shouldFocus: true }` to trigger() so focus still lands on the
  first invalid field — trigger() ignores the form-level
  shouldFocusError option that usePageForm already sets.


# Changelog
## A11y 
- show validation errors on first submit in ProfileForm

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
