### PR TITLE
Remove temporary filter for Irish locale in locale options

### DIFF
--- a/front/app/containers/Admin/settings/general/Form.tsx
+++ b/front/app/containers/Admin/settings/general/Form.tsx
@@ -91,14 +91,14 @@ const Form = ({ defaultValues, onSubmit }: Props) => {
     }
   };
 
-  // May need memoization
-  const localeOptions = Object.entries(appLocalePairs)
-    // TEMPORARY: Quick fix to hide ga-IE (Irish) until the client has paid. Remove this filter once approved.
-    .filter(([locale]) => locale !== 'ga-IE')
-    .map(([locale, label]) => ({
-      label,
-      value: locale,
-    }));
+  const localeOptions = Object.entries(appLocalePairs).map(
+    ([locale, label]) => {
+      return {
+        label,
+        value: locale,
+      };
+    }
+  );
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
# Changelog

- Turn on Irish locale

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
