### PR TITLE
[No-ticket] Security fix: bump concurrent-ruby (CVE-2026-54904)

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -488,7 +488,7 @@ GEM
     combine_pdf (1.0.26)
       matrix
       ruby-rc4 (>= 0.1.5)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (2.5.5)
     counter_culture (3.5.3)
       activerecord (>= 4.2)

--- a/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
@@ -238,19 +238,33 @@ RSpec.describe Analysis::AutoTaggingTask do
       att = create(:auto_tagging_task, analysis: analysis, state: 'queued', auto_tagging_method: 'label_classification', tags_ids: [tags[0].id, tags[1].id])
       create_list(:idea, 3, project: project)
 
-      allow_any_instance_of(Analysis::LLM::GPT4oMini)
-        .to receive(:chat)
-        .and_return(tags[0].name)
+      # Record the (monotonic) time at which each LLM request actually fires from the
+      # pool threads, so we can assert concurrent-ruby honoured the scheduled delays.
+      mutex = Mutex.new
+      call_times = []
+      allow_any_instance_of(Analysis::LLM::GPT4oMini).to receive(:chat) do
+        mutex.synchronize { call_times << Process.clock_gettime(Process::CLOCK_MONOTONIC) }
+        tags[0].name
+      end
       allow(Concurrent::ScheduledTask).to receive(:execute).and_call_original
 
       att.execute
 
-      # Each input should be scheduled with an increasing delay (idx * TASK_INTERVAL)
-      # so the LLM requests are spread out rather than fired all at once.
       interval = Analysis::AutoTaggingMethod::Base::TASK_INTERVAL
+
+      # We scheduled each input with an increasing delay (idx * TASK_INTERVAL) so the
+      # LLM requests are spread out rather than fired all at once.
       expect(Concurrent::ScheduledTask).to have_received(:execute).with(0 * interval, executor: anything)
       expect(Concurrent::ScheduledTask).to have_received(:execute).with(1 * interval, executor: anything)
       expect(Concurrent::ScheduledTask).to have_received(:execute).with(2 * interval, executor: anything)
+
+      # ...and concurrent-ruby actually honoured those delays at runtime: the requests
+      # were genuinely spread out over time. A ScheduledTask never fires *before* its
+      # delay, so this lower bound is safe from timing flakiness. If a gem bump broke
+      # the delay semantics, all three would fire ~immediately and this would fail.
+      expect(call_times.size).to eq(3)
+      span = call_times.max - call_times.min
+      expect(span).to be >= (2 * interval * 0.9)
     end
 
     it 'includes the topics field for ideation' do

--- a/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/auto_tagging_task_spec.rb
@@ -230,6 +230,29 @@ RSpec.describe Analysis::AutoTaggingTask do
       })
     end
 
+    it 'staggers classification requests over time to avoid LLM rate limits' do
+      project = create(:single_phase_ideation_project)
+      custom_form = create(:custom_form, :with_default_fields, participation_context: project)
+      analysis = create(:analysis, main_custom_field: nil, additional_custom_fields: custom_form.custom_fields, project: project)
+      tags = create_list(:tag, 3, analysis: analysis)
+      att = create(:auto_tagging_task, analysis: analysis, state: 'queued', auto_tagging_method: 'label_classification', tags_ids: [tags[0].id, tags[1].id])
+      create_list(:idea, 3, project: project)
+
+      allow_any_instance_of(Analysis::LLM::GPT4oMini)
+        .to receive(:chat)
+        .and_return(tags[0].name)
+      allow(Concurrent::ScheduledTask).to receive(:execute).and_call_original
+
+      att.execute
+
+      # Each input should be scheduled with an increasing delay (idx * TASK_INTERVAL)
+      # so the LLM requests are spread out rather than fired all at once.
+      interval = Analysis::AutoTaggingMethod::Base::TASK_INTERVAL
+      expect(Concurrent::ScheduledTask).to have_received(:execute).with(0 * interval, executor: anything)
+      expect(Concurrent::ScheduledTask).to have_received(:execute).with(1 * interval, executor: anything)
+      expect(Concurrent::ScheduledTask).to have_received(:execute).with(2 * interval, executor: anything)
+    end
+
     it 'includes the topics field for ideation' do
       topic = create(:input_topic, title_multiloc: { 'en' => 'Bananas' })
       project = create(:single_phase_ideation_project)


### PR DESCRIPTION
Fix for [3 related back-bundle-audit failures](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/341336/workflows/4016873f-251b-47b0-a7da-931e39ed6261/jobs/766566)

All 3 related to concurrent-ruby gem

Claude summarises the gem and our usage of it: "It's a general-purpose Ruby concurrency library that mostly arrives via Rails, but we use it directly in exactly one place — to run AI auto-tagging classifications concurrently while throttling them to stay under the LLM API's rate limits."

Adding the test exercises and asserts the `Concurrent::ScheduledTask/FixedThreadPool` scheduling behavior in `classify_many!` — our only direct use of concurrent-ruby — so CI now fails if the bumped gem version changes that timing/scheduling semantics, turning the version bump from an untested-path risk into a verified one.

# Changelog
## Technical
- [No-ticket] Security fix: bump concurrent-ruby (CVE-2026-54904)
