### PR TITLE
TAN-8066-A11y-Improvements-7

### DIFF
--- a/front/app/containers/PlatformFooter/index.tsx
+++ b/front/app/containers/PlatformFooter/index.tsx
@@ -237,6 +237,17 @@ const PlatformFooter = ({ className }: Props) => {
     eventEmitter.emit('openConsentManager');
   };
 
+  // focus the main content after navigation
+  // preventScroll: the link already scrolls to top
+  const focusMainContent = () => {
+    requestAnimationFrame(() => {
+      const mainContent = document.getElementById('main-content');
+      if (!mainContent) return;
+      mainContent.setAttribute('tabindex', '-1');
+      mainContent.focus({ preventScroll: true });
+    });
+  };
+
   /* 
     Likely not the most reliable way to determine if the bar is present.
     Context would probably be better, but this is a quick fix.
@@ -325,6 +336,7 @@ const PlatformFooter = ({ className }: Props) => {
                         params={{ slug }}
                         className={index === 0 ? 'first' : ''}
                         scrollToTop={true}
+                        onClick={focusMainContent}
                       >
                         <FormattedMessage {...MESSAGES_MAP[slug]} />
                       </StyledLink>
@@ -339,7 +351,11 @@ const PlatformFooter = ({ className }: Props) => {
               </StyledButton>
             </PagesNavListItem>
             <PagesNavListItem>
-              <StyledLink to="/site-map" id="site-map-link">
+              <StyledLink
+                to="/site-map"
+                id="site-map-link"
+                onClick={focusMainContent}
+              >
                 <FormattedMessage {...messages.siteMap} />
               </StyledLink>
             </PagesNavListItem>

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectInfoSideBar/index.tsx
@@ -82,8 +82,8 @@ const ProjectInfoSideBar = memo<Props>(
                 disabled={!isAdmin(authUser)}
                 // Needs to be "left" at the time of writing
                 // to ensure the tooltip doesn't slip under the project CTA bar.
-                placement={isSmallerThanPhone ? 'bottom' : 'left'}
-                maxWidth={isSmallerThanPhone ? '90vw' : undefined}
+                placement={isSmallerThanPhone ? 'top' : 'left'}
+                maxWidth={isSmallerThanPhone ? '90vw' : '300px'}
                 content={formatMessage(messages.liveDataMessage)}
                 aria-hidden={true}
               >

--- a/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
+++ b/front/app/containers/UsersShowPage/Following/UserFollowingList.tsx
@@ -81,6 +81,7 @@ const UserFollowingList = ({ value }: Props) => {
                   key={follower.id}
                   projectId={follower.relationships.followable.data.id}
                   size="small"
+                  layout="threecolumns"
                 />
               );
             } else if (


### PR DESCRIPTION
# Changelog
## A11y 
- Fix following project cards layout
- Fix footer link focus order for keyboard users
- Fix participants tooltip placement

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
