### PR TITLE
[TAN-8027] Bugfix: Editing cosponsors of an idea results in invitation notifications (and emails, if possible)

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -503,7 +503,7 @@ class WebApi::V1::IdeasController < ApplicationController
 
   def assign_deferred_relationship_ids(input, phase_ids, cosponsor_ids)
     input.phase_ids = phase_ids if phase_ids
-    input.cosponsor_ids = cosponsor_ids unless cosponsor_ids.nil?
+    input.cosponsor_ids = cosponsor_ids if cosponsor_ids
   end
 
   def params_service

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -265,12 +265,9 @@ class WebApi::V1::IdeasController < ApplicationController
       end
     end
 
-    phase_ids = update_params.delete(:phase_ids) if update_params[:phase_ids]
-    # Pull cosponsor_ids out of update_params so it can be assigned after before_update
-    # (below), like phase_ids. If it were assigned via assign_attributes, before_update
-    # would snapshot the already-updated cosponsor set, making the "newly added" diff
-    # empty and suppressing the invite notification for cosponsors added on update.
-    cosponsor_ids = update_params.delete(:cosponsor_ids) if update_params.key?(:cosponsor_ids)
+    # phase_ids/cosponsor_ids are assigned after before_update (below), not via
+    # assign_attributes, so the side-fx can snapshot the previous associations first.
+    phase_ids, cosponsor_ids = extract_deferred_relationship_ids(update_params)
     update_params[:custom_field_values] = params_service.updated_custom_field_values(input.custom_field_values, update_params[:custom_field_values])
     CustomFieldService.new.compact_custom_field_values! update_params[:custom_field_values]
     input.set_manual_votes(update_params[:manual_votes_amount], current_user) if update_params[:manual_votes_amount]
@@ -307,8 +304,7 @@ class WebApi::V1::IdeasController < ApplicationController
     ActiveRecord::Base.transaction do # Assigning relationships cause database changes
       input.assign_attributes(update_params)
       sidefx.before_update(input, current_user)
-      input.phase_ids = phase_ids if phase_ids
-      input.cosponsor_ids = cosponsor_ids unless cosponsor_ids.nil?
+      assign_deferred_relationship_ids(input, phase_ids, cosponsor_ids)
 
       authorize(input)
       validate_update!(input)
@@ -493,6 +489,21 @@ class WebApi::V1::IdeasController < ApplicationController
 
   def sidefx
     @sidefx ||= SideFxIdeaService.new
+  end
+
+  # phase_ids/cosponsor_ids must be assigned *after* SideFxIdeaService#before_update so it
+  # can snapshot the prior associations. Assigning them via assign_attributes (which mutates
+  # the persisted record immediately) would make the before/after diff empty — e.g. no
+  # newly-added cosponsors would be detected, so their invite notifications wouldn't be sent.
+  def extract_deferred_relationship_ids(update_params)
+    phase_ids = update_params.delete(:phase_ids) if update_params[:phase_ids]
+    cosponsor_ids = update_params.delete(:cosponsor_ids) if update_params.key?(:cosponsor_ids)
+    [phase_ids, cosponsor_ids]
+  end
+
+  def assign_deferred_relationship_ids(input, phase_ids, cosponsor_ids)
+    input.phase_ids = phase_ids if phase_ids
+    input.cosponsor_ids = cosponsor_ids unless cosponsor_ids.nil?
   end
 
   def params_service

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -266,6 +266,11 @@ class WebApi::V1::IdeasController < ApplicationController
     end
 
     phase_ids = update_params.delete(:phase_ids) if update_params[:phase_ids]
+    # Pull cosponsor_ids out of update_params so it can be assigned after before_update
+    # (below), like phase_ids. If it were assigned via assign_attributes, before_update
+    # would snapshot the already-updated cosponsor set, making the "newly added" diff
+    # empty and suppressing the invite notification for cosponsors added on update.
+    cosponsor_ids = update_params.delete(:cosponsor_ids) if update_params.key?(:cosponsor_ids)
     update_params[:custom_field_values] = params_service.updated_custom_field_values(input.custom_field_values, update_params[:custom_field_values])
     CustomFieldService.new.compact_custom_field_values! update_params[:custom_field_values]
     input.set_manual_votes(update_params[:manual_votes_amount], current_user) if update_params[:manual_votes_amount]
@@ -303,6 +308,7 @@ class WebApi::V1::IdeasController < ApplicationController
       input.assign_attributes(update_params)
       sidefx.before_update(input, current_user)
       input.phase_ids = phase_ids if phase_ids
+      input.cosponsor_ids = cosponsor_ids unless cosponsor_ids.nil?
 
       authorize(input)
       validate_update!(input)

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -598,6 +598,25 @@ resource 'Ideas' do
             expect(json_response.dig(:data, :relationships, :cosponsors, :data).pluck(:id)).to include new_cosponsor.id
           end
         end
+
+        describe do
+          let(:input) { create(:proposal) }
+          let(:new_cosponsor) { create(:user) }
+          let(:cosponsor_ids) { [new_cosponsor.id] }
+
+          before { CustomField.find_by(code: 'cosponsor_ids').update!(enabled: true) }
+
+          # Adding a cosponsor via an idea update must log a `Cosponsorship 'created'`
+          # activity, which is what drives the InvitationToCosponsorIdea notification.
+          example 'Adding a cosponsor logs the activity that drives the invite notification', document: false do
+            expect { do_request }
+              .to have_enqueued_job(LogActivityJob)
+              .with(an_instance_of(Cosponsorship), 'created', anything, anything)
+
+            assert_status 200
+            expect(input.reload.cosponsors).to include(new_cosponsor)
+          end
+        end
       end
 
       context 'when admin' do


### PR DESCRIPTION
When `cosponsorship`(s) created via an `idea` _create_, everything seems to work fine.

However, when `cosponsorship`(s) were edited via an `idea` _update_, the `LogActivityJob`(s) needed to create the `activities`, in turn needed to trigger the `notifications` inviting the `user`(s) to accept the `cosponsorship`, were never created. 😬 

# Changelog
## Fixed
- [TAN-8027] Bugfix: Editing cosponsors of an idea results in invitation notifications (and emails, if possible)
