### PR TITLE
 fix screen reader announcement of form field errors

### DIFF
--- a/front/app/components/CustomFieldsForm/Fields/CheckboxField/index.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/CheckboxField/index.tsx
@@ -27,18 +27,24 @@ const CheckboxField = ({ name, scrollErrorIntoView, ...rest }: Props) => {
 
   // If an API error with a matching name has been returned from the API response, apiError is set to an array with the error message as the only item
   const apiError = errors?.error && ([errors] as CLError[]);
+  const ariaDescribedBy =
+    validationError || apiError ? `${name}-error` : undefined;
+
   const currentValue = watch(name) ? true : false;
   return (
     <>
       <Controller
         name={name}
         control={control}
-        render={({ field: { ref: _ref, ...field } }) => (
+        render={({ field: { ref, ...field } }) => (
           <Checkbox
             {...field}
             {...rest}
             id={name}
             checked={currentValue}
+            setRef={(el) => ref(el)}
+            ariaInvalid={!!validationError || !!apiError}
+            ariaDescribedBy={ariaDescribedBy}
             onChange={() => {
               setValue(name, !currentValue);
               trigger(name);
@@ -48,14 +54,17 @@ const CheckboxField = ({ name, scrollErrorIntoView, ...rest }: Props) => {
       />
       {validationError && (
         <Error
+          id={`${name}-error`}
           marginTop="8px"
           marginBottom="8px"
           text={validationError}
           scrollIntoView={scrollErrorIntoView}
+          liveRegion={false}
         />
       )}
       {apiError && (
         <Error
+          id={`${name}-error`}
           fieldName={name as TFieldName}
           apiErrors={apiError}
           marginTop="8px"

--- a/front/app/components/HookForm/Input/index.tsx
+++ b/front/app/components/HookForm/Input/index.tsx
@@ -64,6 +64,7 @@ const Input = ({
           marginBottom="8px"
           text={validationError}
           scrollIntoView={scrollErrorIntoView}
+          liveRegion={false}
         />
       )}
       {apiError && (

--- a/front/app/components/HookForm/Select/index.tsx
+++ b/front/app/components/HookForm/Select/index.tsx
@@ -62,6 +62,7 @@ const Select = ({ name, scrollErrorIntoView, ...rest }: Props) => {
           marginBottom="8px"
           text={validationError}
           scrollIntoView={scrollErrorIntoView}
+          liveRegion={false}
         />
       )}
       {apiError && (

--- a/front/app/components/UI/Error/index.tsx
+++ b/front/app/components/UI/Error/index.tsx
@@ -15,9 +15,9 @@ import { CLError, Multiloc } from 'typings';
 
 import { IAppConfiguration } from 'api/app_configuration/types';
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
-import { IInviteError } from 'api/invites/types';
 import { IDAzureAdMethod } from 'api/id_methods/types';
 import useIdMethods from 'api/id_methods/useIdMethods';
+import { IInviteError } from 'api/invites/types';
 
 import useLocalize, { Localize } from 'hooks/useLocalize';
 
@@ -142,6 +142,7 @@ export interface ErrorProps {
   apiErrors?: (CLError | IInviteError)[] | null;
   id?: string;
   scrollIntoView?: boolean;
+  liveRegion?: boolean;
 }
 
 export interface TFieldNameMap {
@@ -263,7 +264,10 @@ const Error = (props: ErrorProps) => {
     animate = true,
     id,
     scrollIntoView = true,
+    liveRegion,
   } = props;
+
+  const isLiveRegion = liveRegion ?? true;
 
   useEffect(() => {
     if (scrollIntoView) {
@@ -297,7 +301,7 @@ const Error = (props: ErrorProps) => {
         id={id}
         marginTop={marginTop}
         marginBottom={marginBottom}
-        role="alert"
+        role={isLiveRegion ? 'alert' : undefined}
         data-testid="error-message"
       >
         <ContainerInner


### PR DESCRIPTION
Issue 1 — Safari/VoiceOver announced the field as "invalid" but never read the error text

Root cause: The error element has role="alert", and the field's aria-describedby points at that same element. Safari/VoiceOver does not expose a role="alert" (live region) element as a control's description — so on focus it reads the field's name + state and drops the describedby text. 

Fix: Added an opt-in liveRegion prop to the shared Error component (defaults to true, so standalone/API errors are unchanged). Field errors pass liveRegion={false}, which renders role={undefined} instead of role="alert" → the describedby target becomes a plain description Safari reads on focus. 
Applied in Input & Select & CheckboxField


Issue 2 — Safari announced two fields' errors at once on submit

Root cause: Every field error was a role="alert" assertive live region. On submit they all mounted at once → multiple live regions fired simultaneously. The checkbox was the worst offender because it was an orphan alert (no aria-describedby linking it to its input).

Fix: The same liveRegion={false} change — field errors are no longer live regions, so on submit only the focused (first-invalid) field's error is announced via describedby; the rest are read as you tab to them. Plus the checkbox gained the missing aria-describedby + matching id so it's properly associated.

Issue 3 — Checkbox wasn't focused when it was the first invalid field

Fix: Forward field.ref to the checkbox input via the Checkbox setRef prop (same pattern as Input/Select). 


# Changelog
## A11y 
- fix screen reader announcement of form field errors

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
