### PR TITLE
  fix carousel scroll button focus order

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/ScrollButton.tsx
@@ -10,6 +10,9 @@ interface Props {
   onClick: () => void;
   onMouseEnter: () => void;
   onMouseLeave: () => void;
+  onFocus: () => void;
+  onBlur: () => void;
+  disabled: boolean;
 }
 
 const ScrollButton = ({
@@ -17,6 +20,9 @@ const ScrollButton = ({
   onClick,
   onMouseEnter,
   onMouseLeave,
+  onFocus,
+  onBlur,
+  disabled,
 }: Props) => {
   const { formatMessage } = useIntl();
 
@@ -34,15 +40,21 @@ const ScrollButton = ({
       w="52px"
       h="52px"
       zIndex="3"
+      cursor={disabled ? 'not-allowed' : 'pointer'}
       border={`1px solid ${colors.divider}`}
       onClick={(e) => {
         e.preventDefault();
         e.stopPropagation();
+        if (disabled) return;
         onClick();
       }}
+      onMouseDown={(e) => e.preventDefault()}
       tabIndex={0}
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      aria-disabled={disabled}
       aria-label={
         variant === 'left'
           ? formatMessage(messages.scrollLeft)

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/_shared/BaseCarrousel/ScrollableCarrousel/index.tsx
@@ -32,6 +32,7 @@ const ScrollableCarrousel = ({
   const [showPreviousButton, setShowPreviousButton] = useState(false);
   const [showPreviousGradient, setShowPreviousGradient] = useState(false);
   const [mouseOverPreviousButton, setMouseOverPreviousButton] = useState(false);
+  const [previousButtonFocused, setPreviousButtonFocused] = useState(false);
   const [
     previousButtonShouldDisappearAfterMouseMove,
     setPreviousButtonShouldDisappearAfterMouseMove,
@@ -41,6 +42,7 @@ const ScrollableCarrousel = ({
   const [showNextButton, setShowNextButton] = useState(false);
   const [showNextGradient, setShowNextGradient] = useState(false);
   const [mouseOverNextButton, setMouseOverNextButton] = useState(false);
+  const [nextButtonFocused, setNextButtonFocused] = useState(false);
   const [
     nextButtonShouldDisappearAfterMouseMove,
     setNextButtonShouldDisappearAfterMouseMove,
@@ -111,9 +113,10 @@ const ScrollableCarrousel = ({
       </HorizontalScroll>
       {!isTouchDevice && (
         <>
-          {showPreviousButton && (
+          {(showPreviousButton || previousButtonFocused) && (
             <ScrollButton
               variant="left"
+              disabled={!showPreviousButton}
               onClick={() => {
                 if (!scrollContainerRef) return;
                 scrollContainerRef.scrollLeft -= cardWidth + CARD_GAP;
@@ -126,6 +129,8 @@ const ScrollableCarrousel = ({
                   setPreviousButtonShouldDisappearAfterMouseMove(false);
                 }
               }}
+              onFocus={() => setPreviousButtonFocused(true)}
+              onBlur={() => setPreviousButtonFocused(false)}
             />
           )}
           {showPreviousGradient && <Gradient variant="left" />}
@@ -133,9 +138,10 @@ const ScrollableCarrousel = ({
       )}
       {!isTouchDevice && (
         <>
-          {showNextButton && (
+          {(showNextButton || nextButtonFocused) && (
             <ScrollButton
               variant="right"
+              disabled={!showNextButton}
               onClick={() => {
                 if (!scrollContainerRef) return;
                 scrollContainerRef.scrollLeft += cardWidth + CARD_GAP;
@@ -148,6 +154,8 @@ const ScrollableCarrousel = ({
                   setNextButtonShouldDisappearAfterMouseMove(false);
                 }
               }}
+              onFocus={() => setNextButtonFocused(true)}
+              onBlur={() => setNextButtonFocused(false)}
             />
           )}
           {showNextGradient && <Gradient variant="right" />}


### PR DESCRIPTION
**Problem: When a keyboard user scrolled to the last/first card via the scroll button, the focused button was removed from the DOM. Browsers reset focus to document.body when the focused element disappears, so the next Tab restarted from the top of the page.
Fix: Keep the button mounted while it has keyboard focus (showButton || buttonFocused); at the boundary it becomes inert (Enter no-ops, dimmed + aria-disabled). Focus stays put, and Tab moves forward as expected. Mouse behavior unchanged.**


# Changelog
## A11y 
- Fix carousel scroll button focus order

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
