### PR TITLE
TAN-8051-Implement-Global-Focus

### DIFF
--- a/front/app/component-library/components/Button/index.tsx
+++ b/front/app/component-library/components/Button/index.tsx
@@ -9,6 +9,7 @@ import {
   invisibleA11yText,
   fontSizes,
   defaultStyles,
+  focusRing,
   isRtl,
   MainThemeProps,
 } from '../../utils/styleUtils';
@@ -377,8 +378,7 @@ function getButtonStyle(
 
     &:focus-visible,
     &.focus-visible {
-      outline: 2px solid #000;
-      outline-offset: 2px;
+      ${focusRing}
     }
 
     &.fullWidth {

--- a/front/app/component-library/components/Checkbox/index.tsx
+++ b/front/app/component-library/components/Checkbox/index.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { hideVisually } from 'polished';
 import styled from 'styled-components';
 
-import { Color, defaultOutline } from '../../utils/styleUtils';
+import { Color, focusRing } from '../../utils/styleUtils';
 import testEnv from '../../utils/testUtils/testEnv';
 import Box, { BoxMarginProps, BoxPaddingProps } from '../Box';
 import Icon from '../Icon';
@@ -78,7 +78,7 @@ const StyledCheckbox = styled.div<{
   transition: all 120ms ease-out;
 
   ${HiddenCheckbox}.focus-visible + & {
-    ${defaultOutline};
+    ${focusRing}
   }
 `;
 

--- a/front/app/component-library/components/CollapsibleContainer/index.tsx
+++ b/front/app/component-library/components/CollapsibleContainer/index.tsx
@@ -4,7 +4,7 @@ import { CSSTransition } from 'react-transition-group';
 import styled from 'styled-components';
 
 import useInstanceId from '../../hooks/useInstanceId';
-import { isRtl } from '../../utils/styleUtils';
+import { focusRing, isRtl } from '../../utils/styleUtils';
 import Box, { BoxProps } from '../Box';
 import Icon from '../Icon';
 import Title, { TitleProps } from '../Title';
@@ -36,7 +36,7 @@ const TitleButton = styled.button`
   }
 
   &:focus-visible {
-    outline: 2px solid black;
+    ${focusRing}
     border-radius: ${({ theme }) => theme.borderRadius};
   }
 

--- a/front/app/component-library/components/Radio/index.tsx
+++ b/front/app/component-library/components/Radio/index.tsx
@@ -5,12 +5,7 @@ import { get } from 'lodash-es';
 import { hideVisually } from 'polished';
 import styled, { useTheme } from 'styled-components';
 
-import {
-  fontSizes,
-  colors,
-  defaultOutline,
-  isRtl,
-} from '../../utils/styleUtils';
+import { fontSizes, colors, focusRing, isRtl } from '../../utils/styleUtils';
 import testEnv from '../../utils/testUtils/testEnv';
 import Box, { BoxPaddingProps, BoxMarginProps } from '../Box';
 
@@ -43,7 +38,7 @@ const CustomRadio = styled.div<{ borderColor: string | undefined }>`
   `}
 
   ${HiddenRadio}.focus-visible + & {
-    ${defaultOutline};
+    ${focusRing}
   }
 
   &.enabled:hover {

--- a/front/app/component-library/components/Toggle/index.tsx
+++ b/front/app/component-library/components/Toggle/index.tsx
@@ -3,12 +3,7 @@ import React, { PureComponent, FormEvent } from 'react';
 import { hideVisually, darken } from 'polished';
 import styled, { css } from 'styled-components';
 
-import {
-  colors,
-  fontSizes,
-  defaultOutline,
-  isRtl,
-} from '../../utils/styleUtils';
+import { colors, fontSizes, focusRing, isRtl } from '../../utils/styleUtils';
 import testEnv from '../../utils/testUtils/testEnv';
 
 const size = 21;
@@ -79,7 +74,7 @@ const StyledToggleWrapper = styled.div<{ checked: boolean; disabled: boolean }>`
     `};
 
   ${HiddenCheckbox}.focus-visible + & ${StyledToggle} {
-    ${defaultOutline};
+    ${focusRing}
   }
 `;
 

--- a/front/app/component-library/global-styles.ts
+++ b/front/app/component-library/global-styles.ts
@@ -1,6 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 
-import { fontSizes, colors } from './utils/styleUtils';
+import { fontSizes, colors, focusRing } from './utils/styleUtils';
 
 const GlobalStyle = createGlobalStyle`
   html {
@@ -17,6 +17,11 @@ const GlobalStyle = createGlobalStyle`
     &:not(.focus-visible) {
       outline: none;
     }
+  }
+
+  *:focus-visible,
+  *.focus-visible {
+    ${focusRing}
   }
 
   html,

--- a/front/app/component-library/utils/styleUtils.ts
+++ b/front/app/component-library/utils/styleUtils.ts
@@ -194,6 +194,12 @@ export const defaultOutline = css`
   border: 2px solid ${(props) => props.theme.colors.tenantPrimary};
 `;
 
+export const focusRing = css`
+  outline: 2px solid ${colors.black};
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px ${colors.white};
+`;
+
 export const stylingConsts = {
   menuHeight: 78,
   mobileMenuHeight: 72,

--- a/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/LinearScale/LinearScaleButton.tsx
@@ -41,11 +41,6 @@ const RadioOption = styled.div<{
     box-shadow: ${({ selected, borderColor }) =>
       selected ? 'none' : `0 0 0 1px ${borderColor}`};
   }
-
-  &:focus-visible {
-    outline: 2px solid ${({ selectedBorderColor }) => selectedBorderColor};
-    outline-offset: 2px;
-  }
 `;
 
 const LinearScaleOption = ({

--- a/front/app/components/FilterBoxes/StatusFilter.tsx
+++ b/front/app/components/FilterBoxes/StatusFilter.tsx
@@ -71,13 +71,6 @@ const Status = styled.button`
       color: #fff;
     }
   }
-
-  &.focus-visible,
-  &:focus-visible {
-    outline: 2px solid ${colors.black};
-    outline-offset: 2px;
-    box-shadow: 0 0 0 2px ${colors.white};
-  }
 `;
 
 const AllStatus = styled(Status)``;

--- a/front/app/components/FollowUnfollow/index.tsx
+++ b/front/app/components/FollowUnfollow/index.tsx
@@ -32,11 +32,6 @@ import tracks from './tracks';
 const UnsubscribeLink = styled.a`
   color: ${colors.white};
   text-decoration: underline;
-
-  &:focus-visible {
-    outline: 2px solid ${colors.white};
-    outline-offset: 2px;
-  }
 `;
 
 interface Props extends BoxWidthProps, BoxPaddingProps {

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -6,6 +6,7 @@ import {
   Title,
   Tooltip,
 } from '@citizenlab/cl2-component-library';
+import { focusRingInset } from 'global-styles';
 import styled from 'styled-components';
 
 import useIdeaImage from 'api/idea_images/useIdeaImage';
@@ -40,8 +41,7 @@ const StyledLink = typedStyled(Link)`
 
   &.focus-visible,
   &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.colors.tenantPrimary};
-    outline-offset: -2px;
+    ${focusRingInset}
   }
 `;
 

--- a/front/app/components/PostCardsComponents/ViewButtons.tsx
+++ b/front/app/components/PostCardsComponents/ViewButtons.tsx
@@ -66,12 +66,6 @@ const ViewButton = styled.button<{ active: boolean }>`
             color: darken(0.2, theme.colors.tenantText),
           }};
   }
-
-  &.focus-visible,
-  &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.colors.tenantPrimary};
-    outline-offset: 2px;
-  }
 `;
 
 interface Props {

--- a/front/app/components/UI/Checkbox/index.tsx
+++ b/front/app/components/UI/Checkbox/index.tsx
@@ -1,11 +1,7 @@
 import React, { PureComponent } from 'react';
 
-import {
-  colors,
-  defaultOutline,
-  isRtl,
-  Icon,
-} from '@citizenlab/cl2-component-library';
+import { colors, isRtl, Icon } from '@citizenlab/cl2-component-library';
+import { focusRing } from 'global-styles';
 import { isBoolean } from 'lodash-es';
 import { darken, hideVisually } from 'polished';
 import styled from 'styled-components';
@@ -61,7 +57,7 @@ const StyledCheckbox = styled.div<{
   transition: all 120ms ease-out;
 
   ${HiddenCheckbox}.focus-visible + & {
-    ${defaultOutline};
+    ${focusRing}
   }
 
   &.enabled {

--- a/front/app/components/UI/FilterTabs/index.tsx
+++ b/front/app/components/UI/FilterTabs/index.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, KeyboardEvent } from 'react';
 
 import { fontSizes, colors, media } from '@citizenlab/cl2-component-library';
+import { focusRingInset } from 'global-styles';
 import { rgba } from 'polished';
 import { MessageDescriptor } from 'react-intl';
 import styled from 'styled-components';
@@ -41,8 +42,7 @@ const Tab = styled.button<{ active: boolean; fullWidth: boolean }>`
 
   &.focus-visible,
   &:focus-visible {
-    outline: 2px solid ${({ theme }) => theme.colors.tenantPrimary};
-    outline-offset: -2px;
+    ${focusRingInset}
   }
 
   ${media.phone`

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -5,11 +5,11 @@ import {
   media,
   colors,
   fontSizes,
-  defaultOutline,
   viewportWidths,
   ClickOutside,
   isRtl,
 } from '@citizenlab/cl2-component-library';
+import { focusRingBorder } from 'global-styles';
 import { createPortal } from 'react-dom';
 import { FocusOn } from 'react-focus-on';
 import CSSTransition from 'react-transition-group/CSSTransition';
@@ -64,8 +64,10 @@ const StyledCloseIconButton = styled(CloseIconButton)`
     background: #e0e0e0;
   }
 
+  /* This button forces outline:none, so the global outline ring can't apply —
+     use the shared border-based ring instead. */
   &.focus-visible {
-    ${defaultOutline};
+    ${focusRingBorder}
   }
 
   ${isRtl`
@@ -99,7 +101,7 @@ const StyledCloseIconButton2 = styled(CloseIconButton)`
   }
 
   &.focus-visible {
-    ${defaultOutline};
+    ${focusRingBorder}
   }
 
   ${isRtl`

--- a/front/app/components/UI/RangeInput/index.tsx
+++ b/front/app/components/UI/RangeInput/index.tsx
@@ -1,6 +1,7 @@
 import React, { PureComponent, ReactNode } from 'react';
 
-import { colors, defaultOutline } from '@citizenlab/cl2-component-library';
+import { colors } from '@citizenlab/cl2-component-library';
+import { focusRing } from 'global-styles';
 import { Range, getTrackBackground } from 'react-range';
 import styled from 'styled-components';
 
@@ -24,7 +25,7 @@ const Container = styled.div`
     }
 
     &.focus-visible {
-      ${defaultOutline};
+      ${focusRing}
     }
   }
 `;

--- a/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
+++ b/front/app/containers/MainHeader/Components/DesktopNavItems/AdminPublicationsNavbarItem.tsx
@@ -139,12 +139,6 @@ const ProjectsListFooter = typedStyled(Link)`
     text-decoration: none;
   }
 
-  &.focus-visible,
-  &:focus-visible {
-    outline: 3px solid ${({ theme }) => theme.colors.tenantSecondary};
-    outline-offset: 3px;
-    box-shadow: 0 0 0 3px #fff;
-  }
 `;
 
 interface Props {

--- a/front/app/containers/ProjectFolderShowPage/ProjectFolderHeader.tsx
+++ b/front/app/containers/ProjectFolderShowPage/ProjectFolderHeader.tsx
@@ -1,6 +1,11 @@
 import React, { memo } from 'react';
 
-import { useWindowSize, Box, media } from '@citizenlab/cl2-component-library';
+import {
+  useWindowSize,
+  Box,
+  media,
+  colors,
+} from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import { IProjectFolderData } from 'api/project_folders/types';
@@ -19,6 +24,13 @@ const StyledProjectFolderShareButton = styled(ProjectFolderShareButton)`
     right: 10px;
     top: 10px;
   `};
+
+  && button:focus-visible,
+  && button.focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px ${colors.white}, 0 0 0 4px ${colors.black},
+      0 0 0 6px ${colors.white};
+  }
 `;
 
 interface Props {

--- a/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Timeline.tsx
@@ -145,8 +145,6 @@ const PhaseBar = styled.button<{
   }
 
   &:focus-visible {
-    outline: 2px solid ${colors.black};
-    outline-offset: 2px;
     z-index: 3;
   }
 `;

--- a/front/app/global-styles.ts
+++ b/front/app/global-styles.ts
@@ -1,5 +1,21 @@
 import { fontSizes, isRtl, colors } from '@citizenlab/cl2-component-library';
-import { createGlobalStyle } from 'styled-components';
+import { createGlobalStyle, css } from 'styled-components';
+
+export const focusRing = css`
+  outline: 2px solid ${colors.black};
+  outline-offset: 2px;
+  box-shadow: 0 0 0 2px ${colors.white};
+`;
+
+export const focusRingInset = css`
+  outline: 2px solid ${colors.black};
+  outline-offset: -2px;
+`;
+
+export const focusRingBorder = css`
+  border: 2px solid ${colors.black};
+  box-shadow: 0 0 0 2px ${colors.white};
+`;
 
 const GlobalStyle = createGlobalStyle`
   html {
@@ -22,6 +38,12 @@ const GlobalStyle = createGlobalStyle`
     &:not(.focus-visible) {
       outline: none;
     }
+  }
+
+
+  *:focus-visible,
+  *.focus-visible {
+    ${focusRing}
   }
 
   html,


### PR DESCRIPTION
Global focus ring
Focus styling was copy-pasted across ~20 components with inconsistent rings (black vs brand color, 2px vs 3px, inset vs outset, with/without halo). 

Approach
One reusable focus ring, defined once and applied globally — black outline + white halo (outline: 2px solid black; outline-offset: 2px; box-shadow: 0 0 0 2px #fff), on both :focus-visible and the .focus-visible polyfill class.


Most elements inherit the global ring automatically — no per-component code.
A component only keeps a local rule when it genuinely can't inherit, and even then it uses a shared token instead of hand-rolled CSS.
So this PR is mostly deletions of old per-component rings, plus a few necessary overrides.

What changed
focusRing — default (black outline + white halo)
focusRingInset — outline-offset: -2px, for clip-prone containers (cards, tab strips)
focusRingBorder — for elements that force outline: none
Removed redundant rings now covered globally: StatusFilter, LinearScaleButton, AdminPublicationsNavbarItem, ViewButtons, FollowUnfollow.

Kept a local override where the global ring can't reach:

Modal → focusRingBorder (forces outline: none !important)
Checkbox, RangeInput → focusRing (ring driven off a hidden input / :focus{outline:none})
IdeaCard, FilterTabs → focusRingInset (inset to avoid clipping)
Timeline → kept only z-index (ring from global; lift avoids overlap clipping)
Design system (app/component-library/) — done self-contained with its own focusRing token + global rule (no dependency on the app): Button, Checkbox, Radio, Toggle, CollapsibleContainer.

Intentionally left as-is
Colored/dark/image-background buttons keep their white / high-contrast rings — the black ring blends in there even with the halo: BannerButton, AcceptButton, SkipButton, ParticipationCTAContent, Facebook, Twitter.
Non-ring styles: MenuItem (background highlight), BaseCard (margin), form-input :focus borders.


# Changelog
## A11y 
- implement global focus

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
