### PR TITLE
TAN-8076 - Fixed surveys/new when no phase ID is in params

### DIFF
--- a/front/app/api/authentication/singleSignOn.ts
+++ b/front/app/api/authentication/singleSignOn.ts
@@ -61,7 +61,13 @@ export const redirectToSSOProvider = (
     );
   }
   localStorage.setItem('auth_context', JSON.stringify(metaData.context));
-  localStorage.setItem('auth_path', window.location.pathname);
+  // Store the full path *and* query (e.g. ?phase_id=...&idea_id=...) so the
+  // user's participation params survive the SSO round trip and they land back
+  // exactly where they were.
+  localStorage.setItem(
+    'auth_path',
+    `${window.location.pathname}${window.location.search}`
+  );
 
   // Track the SSO click as a pageView
   trackVirtualPageView(`${window.location.pathname}/auth/sso/${provider}`);

--- a/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
+++ b/front/app/containers/Authentication/steps/Verification/VerificationSteps.tsx
@@ -62,7 +62,12 @@ const VerificationSteps = memo<Props>(
             JSON.stringify(authenticationData.successAction)
           );
         }
-        localStorage.setItem('auth_path', window.location.pathname);
+        // Store the full path *and* query so any participation params survive
+        // the verification round trip and the user returns where they were.
+        localStorage.setItem(
+          'auth_path',
+          `${window.location.pathname}${window.location.search}`
+        );
       }
 
       setMethod(selectedMethod);

--- a/front/app/containers/Authentication/useSteps/index.ts
+++ b/front/app/containers/Authentication/useSteps/index.ts
@@ -31,6 +31,7 @@ import {
   VerificationError,
 } from '../typings';
 
+import { restoreLocationAfterAuthReturn } from './restoreLocationAfterAuthReturn';
 import { getStepConfig } from './stepConfig';
 
 let initialized = false;
@@ -324,10 +325,6 @@ export default function useSteps() {
       const contextFromLocalStorage = localStorage.getItem('auth_context');
       localStorage.removeItem('auth_context');
 
-      // Check if there is a path in local storage
-      const pathFromLocalStorage = localStorage.getItem('auth_path');
-      localStorage.removeItem('auth_path');
-
       const context = contextFromLocalStorage
         ? JSON.parse(contextFromLocalStorage)
         : {
@@ -350,13 +347,7 @@ export default function useSteps() {
       updateState({ flow, email: emailInCaseUserNeedsToConfirm });
       transition(currentStep, 'RESUME_FLOW_AFTER_SSO')(flow);
 
-      // Check that the path is the same as the one stored in local storage
-      if (pathFromLocalStorage && pathname !== pathFromLocalStorage) {
-        clHistory.push(pathFromLocalStorage);
-      } else {
-        // Remove query string from URL as params already been captured
-        window.history.replaceState(null, '', pathname);
-      }
+      restoreLocationAfterAuthReturn(pathname);
     }
   }, [
     pathname,

--- a/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.test.ts
+++ b/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.test.ts
@@ -1,0 +1,50 @@
+import clHistory from 'utils/cl-router/history';
+
+import { restoreLocationAfterAuthReturn } from './restoreLocationAfterAuthReturn';
+
+jest.mock('utils/cl-router/history', () => ({
+  __esModule: true,
+  default: { replace: jest.fn(), push: jest.fn() },
+}));
+
+const mockReplace = clHistory.replace as jest.Mock;
+
+const SURVEY_PATH_WITH_QUERY =
+  '/en/projects/my-project/surveys/new?phase_id=phase-1';
+const CURRENT_PATHNAME = '/en/projects/my-project/surveys/new';
+
+describe('restoreLocationAfterAuthReturn (SSO/verification return navigation)', () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+    localStorage.clear();
+  });
+
+  it('navigates back to the stored full path, restoring its query params', () => {
+    // The full path + query the user was on before the SSO round trip.
+    localStorage.setItem('auth_path', SURVEY_PATH_WITH_QUERY);
+
+    restoreLocationAfterAuthReturn(CURRENT_PATHNAME);
+
+    // phase_id is restored; the auth params the back-end appended are dropped.
+    expect(mockReplace).toHaveBeenCalledWith(SURVEY_PATH_WITH_QUERY);
+  });
+
+  it('consumes auth_path from localStorage so it is not reused', () => {
+    localStorage.setItem('auth_path', SURVEY_PATH_WITH_QUERY);
+
+    restoreLocationAfterAuthReturn(CURRENT_PATHNAME);
+
+    expect(localStorage.getItem('auth_path')).toBeNull();
+  });
+
+  it('strips the query string off the current URL when no path was stored', () => {
+    const replaceStateSpy = jest.spyOn(window.history, 'replaceState');
+
+    restoreLocationAfterAuthReturn(CURRENT_PATHNAME);
+
+    expect(mockReplace).not.toHaveBeenCalled();
+    expect(replaceStateSpy).toHaveBeenCalledWith(null, '', CURRENT_PATHNAME);
+
+    replaceStateSpy.mockRestore();
+  });
+});

--- a/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.ts
+++ b/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.ts
@@ -2,7 +2,7 @@ import clHistory from 'utils/cl-router/history';
 
 /**
  * Returns the user to where they were before a third-party auth/verification
- * round trip. Before redirecting we stored the full path *and* query (e.g.
+ * round trip. Before redirecting we store the full path *and* query (e.g.
  * /projects/x/surveys/new?phase_id=...) in localStorage; navigating back to it
  * restores those params and drops the auth params the back-end appended to the
  * return URL (sso_success, sso_flow, ...). A full-page redirect already wiped

--- a/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.ts
+++ b/front/app/containers/Authentication/useSteps/restoreLocationAfterAuthReturn.ts
@@ -1,0 +1,23 @@
+import clHistory from 'utils/cl-router/history';
+
+/**
+ * Returns the user to where they were before a third-party auth/verification
+ * round trip. Before redirecting we stored the full path *and* query (e.g.
+ * /projects/x/surveys/new?phase_id=...) in localStorage; navigating back to it
+ * restores those params and drops the auth params the back-end appended to the
+ * return URL (sso_success, sso_flow, ...). A full-page redirect already wiped
+ * any in-memory state, so returning to the stored location is always correct.
+ * Falls back to stripping the query off the current URL when nothing was
+ * stored.
+ */
+export const restoreLocationAfterAuthReturn = (currentPathname: string) => {
+  const pathFromLocalStorage = localStorage.getItem('auth_path');
+  localStorage.removeItem('auth_path');
+
+  if (pathFromLocalStorage) {
+    clHistory.replace(pathFromLocalStorage);
+  } else {
+    // Remove query string from URL as params have already been captured.
+    window.history.replaceState(null, '', currentPathname);
+  }
+};

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -80,20 +80,14 @@ const IdeasNewSurveyPage = () => {
       authUser: authUser?.data,
     });
 
-  // Hard to understand why this is needed without context.
-  // The phase id checks are also unclear.
-  // Please replace this text and add a comment if you know.
+  // Block non-managers from taking a survey for a phase that isn't the current
+  // one (e.g. a stale link to a past/future phase). We compare against the
+  // resolved `phaseId`, which falls back to the current phase when no `phase_id`
+  // is in the URL — so a dropped `phase_id` (e.g. lost across an SSO round trip)
+  // on a still-current phase resolves to the current phase and is NOT blocked,
+  // matching what the form-rendering path below does.
   const userCannotViewSurvey =
-    !canModerateProject(project.data, authUser) &&
-    /* Something I could deduct: when this code was added, we made the (wrong)
-    assumption that `phase_id` was always a string (we were type casting the phase_id param).
-    So I _think_ we are checking here whether phase_id from the search params is differnet from
-    currentPhase?.id when both are strings.
-
-    I've added back undefined as a fallback, so the check remains the same as when we were using parse
-    to get the phase_id from the search params.
-    */
-    (phaseIdFromSearchParams || undefined) !== currentPhase?.id;
+    !canModerateProject(project.data, authUser) && phaseId !== currentPhase?.id;
 
   if (disabledReason === 'posting_limited_max_reached' || hadIdeaIdOnMount) {
     return <SurveySubmittedNotice project={project.data} />;


### PR DESCRIPTION
Looks like the last SSO fix was partial and wasn't actually the issue they were always seeing.

# Changelog
## Fixed
- Fixed surveys/new when no phase ID is passed to use current phase (if there is one)
- Fixed all SSO passthrough params so that current path is maintained