### PR TITLE
Fixed layout of main admin menu

### DIFF
--- a/front/app/containers/Admin/sideBar/RailTooltip.tsx
+++ b/front/app/containers/Admin/sideBar/RailTooltip.tsx
@@ -12,6 +12,10 @@ interface Props {
  * Hover/focus tooltip surfacing a nav item's name when the admin rail is
  * collapsed (icon-only). `appendTo` body so it escapes the sidebar's stacking
  * context (z-index 10) and isn't painted under the project header (z-index 1001).
+ *
+ * Expanded: force the wrapper to full width so `width: 100%` rows fill the rail
+ * and stay left-aligned (Tooltip's `fit-content` default would shrink and center
+ * them). Collapsed: keep `fit-content` so the 56px icon rows stay centered.
  */
 const RailTooltip = ({ label, disabled, children }: Props) => (
   <Tooltip
@@ -19,6 +23,7 @@ const RailTooltip = ({ label, disabled, children }: Props) => (
     placement="right"
     theme="dark"
     disabled={disabled}
+    width={disabled ? '100%' : undefined}
     appendTo={() => document.body}
   >
     {children}


### PR DESCRIPTION
A change Edwin released today, messed up the indentation of the bottom left menu - this fixes it:
 
<img width="200" height="246" alt="image" src="https://github.com/user-attachments/assets/5a6ca4ea-ed43-499e-90bc-54e9e0091d4b" />

# Changelog
## Fixed
- Fixed admin menu indentation