### PR TITLE
Bump crass to version 1.0.7

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -496,7 +496,7 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
-    crass (1.0.6)
+    crass (1.0.7)
     crawler_detect (1.2.9)
       qonfig (>= 0.24)
     css_parser (1.22.0)


### PR DESCRIPTION
Low risk dependency of Loofah used when scrubbing CSS attributes. Security hardening and and no risk to legitimate code.

# Changelog
## Technical
- Bumped crass gem to 1.0.7
