### PR TITLE
TAN-7465 fix text color in custom pages to follow branding color

### DIFF
--- a/front/app/components/LandingPages/citizen/InfoSection.tsx
+++ b/front/app/components/LandingPages/citizen/InfoSection.tsx
@@ -30,12 +30,12 @@ interface Props {
 }
 
 const InfoSection = ({ multilocContent }: Props) => {
+  const theme = useTheme();
   // TODO: Fix this the next time the file is edited.
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (!multilocContent || isEmptyMultiloc(multilocContent)) {
     return null;
   }
-  const theme = useTheme();
 
   // needed for backwards compatibility with old-style custom pages
   // see PagesShowPage/index.tsx on an older commit for more info

--- a/front/app/components/LandingPages/citizen/InfoSection.tsx
+++ b/front/app/components/LandingPages/citizen/InfoSection.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { media } from '@citizenlab/cl2-component-library';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Multiloc } from 'typings';
 
 import ContentContainer from 'components/ContentContainer';
@@ -35,6 +35,7 @@ const InfoSection = ({ multilocContent }: Props) => {
   if (!multilocContent || isEmptyMultiloc(multilocContent)) {
     return null;
   }
+  const theme = useTheme();
 
   // needed for backwards compatibility with old-style custom pages
   // see PagesShowPage/index.tsx on an older commit for more info
@@ -47,7 +48,7 @@ const InfoSection = ({ multilocContent }: Props) => {
 
   return (
     <StyledContentContainer>
-      <QuillEditedContent>{pageContent}</QuillEditedContent>
+      <QuillEditedContent textColor={theme.colors.tenantText}>{pageContent}</QuillEditedContent>
     </StyledContentContainer>
   );
 };


### PR DESCRIPTION
# Changelog
## Fixed
- text color in custom pages to follow branding color

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
