### PR TITLE
bump: gems savon and msgpack

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -80,7 +80,7 @@ PATH
       omniauth-saml (~> 2.2.0)
       omniauth_openid_connect (~> 0.8.0)
       rails (~> 7.2)
-      savon (>= 2.12, < 2.15)
+      savon (~> 2.17.2)
 
 PATH
   remote: engines/commercial/custom_maps
@@ -641,11 +641,11 @@ GEM
       multi_xml (>= 0.5.2)
     httpclient (2.9.0)
       mutex_m
-    httpi (3.0.2)
+    httpi (4.0.4)
       base64
       mutex_m
       nkf
-      rack (< 3)
+      rack (>= 2.0, < 4)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     icalendar (2.12.2)
@@ -752,7 +752,7 @@ GEM
     mrml (1.7.0-arm64-darwin)
     mrml (1.7.0-x86_64-darwin)
     mrml (1.7.0-x86_64-linux)
-    msgpack (1.7.2)
+    msgpack (1.8.3)
     multi_json (1.21.1)
     multi_xml (0.8.1)
       bigdecimal (>= 3.1, < 5)
@@ -1099,15 +1099,15 @@ GEM
     rubyzip (1.3.0)
     saharspec (0.0.10)
       ruby2_keywords
-    savon (2.14.0)
+    savon (2.17.3)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
-      httpi (>= 2.4.5)
+      httpi (>= 4, < 5)
       mail (~> 2.5)
       nokogiri (>= 1.8.1)
-      nori (~> 2.4)
-      wasabi (~> 3.4)
+      nori (~> 2.7)
+      wasabi (>= 5.1.0, < 6)
     scenic (1.8.0)
       activerecord (>= 4.0.0)
       railties (>= 4.0.0)
@@ -1198,10 +1198,10 @@ GEM
       public_suffix
     vcr (6.2.0)
     version_gem (1.1.11)
-    wasabi (3.8.0)
+    wasabi (5.1.0)
       addressable
-      httpi (~> 3.0)
-      nokogiri (>= 1.4.2)
+      faraday (>= 1.9, < 3)
+      nokogiri (>= 1.13.9)
     webfinger (2.1.2)
       activesupport
       faraday (~> 2.0)
@@ -1228,6 +1228,7 @@ PLATFORMS
   arm64-darwin-24
   x86_64-darwin-21
   x86_64-darwin-23
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES

--- a/back/engines/commercial/custom_id_methods/custom_id_methods.gemspec
+++ b/back/engines/commercial/custom_id_methods/custom_id_methods.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'omniauth_openid_connect', '~> 0.8.0'
   s.add_dependency 'omniauth-saml', '~> 2.2.0'
   s.add_dependency 'rails', '~> 7.2'
-  s.add_dependency 'savon', '>= 2.12', '< 2.15'
+  s.add_dependency 'savon', '~> 2.17.2'
 
   s.add_development_dependency 'rspec_api_documentation'
   s.add_development_dependency 'rspec-rails'


### PR DESCRIPTION
# Changelog
## Technical
- update gems msgpack to 1.8.3 to avoid CVE-2026-54522
- update savon to 2.17.3, to avoid CVE-2026-53510

bundle-audit check --update is ok
# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
