### PR TITLE
[TAN-8087] Fix bug with phase reports - text question without AI summaries caused blank report

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PhaseTemplate/usePrefetchSummaries.test.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PhaseTemplate/usePrefetchSummaries.test.tsx
@@ -1,0 +1,142 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { IAnalysisData } from 'api/analyses/types';
+import useAnalyses from 'api/analyses/useAnalyses';
+import { summaryData } from 'api/analysis_summaries/__mocks__/useAnalysisSummary';
+import { IFlatCustomField } from 'api/custom_fields/types';
+import useCustomFields from 'api/custom_fields/useCustomFields';
+
+import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
+import { renderHook, waitFor } from 'utils/testUtils/rtl';
+
+import usePrefetchSummaries from './usePrefetchSummaries';
+
+jest.mock('api/analyses/useAnalyses');
+jest.mock('api/custom_fields/useCustomFields');
+
+const REPORT_BUILDER_PATH =
+  '/en/admin/reporting/report-builder/projects/p1/editor';
+
+jest.mock('utils/router', () => ({
+  ...jest.requireActual('utils/router'),
+  useLocation: () => ({ pathname: REPORT_BUILDER_PATH }),
+}));
+
+// The hook reads only `id` and `input_type` off each custom field, so we build
+// minimal survey questions and cast at this trusted test boundary rather than
+// constructing the full IFlatCustomField shape.
+const surveyQuestions = [
+  { id: 'q1', input_type: 'text' },
+  { id: 'q2', input_type: 'text' },
+] as unknown as IFlatCustomField[];
+
+const buildAnalysis = (
+  id: string,
+  questionId: string,
+  summaryId?: string
+): IAnalysisData => ({
+  id,
+  type: 'analysis',
+  attributes: {
+    created_at: '2021-06-01T08:00:00.000Z',
+    updated_at: '2021-06-01T08:00:00.000Z',
+    participation_method: 'native_survey',
+    show_insights: true,
+    auto_insights_too_many_fields: false,
+  },
+  relationships: {
+    project: { data: { id: 'p1', type: 'project' } },
+    all_custom_fields: { data: [{ id: questionId, type: 'custom_field' }] },
+    additional_custom_fields: { data: [] },
+    main_custom_field: { data: { id: questionId, type: 'custom_field' } },
+    insightables: {
+      data: summaryId ? [{ id: summaryId, type: 'summary' }] : [],
+    },
+  },
+});
+
+const apiPath = '*/analyses/:analysisId/summaries/:id';
+const server = setupServer(
+  http.get(apiPath, () =>
+    HttpResponse.json({ data: summaryData }, { status: 200 })
+  )
+);
+
+const mockAnalyses = (analyses: IAnalysisData[]) => {
+  (useAnalyses as jest.Mock).mockReturnValue({
+    data: { data: analyses },
+    isLoading: false,
+  });
+};
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+beforeEach(() => {
+  (useCustomFields as jest.Mock).mockReturnValue({ data: surveyQuestions });
+});
+
+describe('usePrefetchSummaries', () => {
+  // Regression test for the blank phase report: a survey question whose analysis
+  // exists but has no summary must not block the template forever.
+  it('becomes ready when one analysis has a summary and another does not', async () => {
+    mockAnalyses([
+      buildAnalysis('a1', 'q1', 'sum-1'),
+      buildAnalysis('a2', 'q2'), // analysis exists, no summary
+    ]);
+
+    const { result } = renderHook(
+      () => usePrefetchSummaries({ phaseId: 'ph1' }),
+      {
+        wrapper: createQueryClientWrapper(),
+      }
+    );
+
+    await waitFor(() => expect(result.current.summariesReady).toBe(true));
+
+    // The summarised question shows up; the one without a summary is simply absent.
+    expect(result.current.summaries.q1).toContain(
+      summaryData.attributes.summary
+    );
+    expect(result.current.summaries.q2).toBeUndefined();
+  });
+
+  it('becomes ready when every analysis has a summary', async () => {
+    mockAnalyses([
+      buildAnalysis('a1', 'q1', 'sum-1'),
+      buildAnalysis('a2', 'q2', 'sum-2'),
+    ]);
+
+    const { result } = renderHook(
+      () => usePrefetchSummaries({ phaseId: 'ph1' }),
+      {
+        wrapper: createQueryClientWrapper(),
+      }
+    );
+
+    await waitFor(() => expect(result.current.summariesReady).toBe(true));
+
+    expect(result.current.summaries.q1).toContain(
+      summaryData.attributes.summary
+    );
+    expect(result.current.summaries.q2).toContain(
+      summaryData.attributes.summary
+    );
+  });
+
+  it('is ready immediately when there are no relevant analyses', () => {
+    mockAnalyses([]);
+
+    const { result } = renderHook(
+      () => usePrefetchSummaries({ phaseId: 'ph1' }),
+      {
+        wrapper: createQueryClientWrapper(),
+      }
+    );
+
+    expect(result.current.summariesReady).toBe(true);
+    expect(result.current.summaries).toEqual({});
+  });
+});

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PhaseTemplate/usePrefetchSummaries.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Templates/PhaseTemplate/usePrefetchSummaries.tsx
@@ -51,8 +51,13 @@ const usePrefetchSummaries = ({
     enabled: shouldFetchSummaries,
   });
 
+  // Questions whose analysis has no summary yet produce a *disabled* query
+  // (see useAnalysisSummaries — enabled is gated on summaryId). In react-query
+  // v4 a disabled query reports isLoading === true, so checking isLoading here
+  // would leave summariesReady false forever and blank the whole report. Use
+  // isInitialLoading, which is false for disabled queries.
   const allSummariesLoaded = summariesResults.every(
-    (result) => !result.isLoading
+    (result) => !result.isInitialLoading
   );
 
   const hasNoSummaries = relevantAnalyses.length === 0;


### PR DESCRIPTION
Produced with Claude in `/plan` mode, using plan: [TAN-8087-fix-bug-with-phase-report.md](https://github.com/CitizenLabDotCo/citizenlab-claude/blob/main/plans/TAN-8087-fix-bug-with-phase-report.md)

### Fix: phase reports of survey phases rendered blank

- Symptom: Creating a phase report based on a survey phase sometimes produced a completely blank report — no widgets, no spinner, no error.
- Root cause: `PhaseTemplate` only renders once `summariesReady` is `true`. `usePrefetchSummaries` computed readiness with `!result.isLoading`, but in TanStack Query v4 a disabled query reports `isLoading: true`. A survey question whose analysis has no summary yet produces a disabled query (`useAnalysisSummaries` gates enabled on `summaryId`), so `summariesReady` stayed `false` forever and the template rendered nothing — which then got saved as an empty report.
- Why now: #14100 didn't touch this code, but it changed when summaries auto-generate, making "analysis exists without a summary" far more common and exposing this latent bug.
- Fix: Use `!result.isInitialLoading` (`false` for disabled queries) so questions without a summary no longer block the template. They simply render an empty summary block instead of blanking the whole report.
- Test: Added a unit test for `usePrefetchSummaries` (MSW + real query hooks) covering the mixed case (one analysis with a summary, one without) plus all-summaries and no-analyses controls. Fails before the fix, passes after.

### Why a unit test, not e2e:
- The bug is a precise data-state decision (`summariesReady`); a unit test pins it deterministically at the exact failure point.
- Existing e2e survey-template tests can't trigger it without an AI analysis, and creating an analysis-without-a-summary in e2e relies on the insights UI, which kicks off real LLM summary generation — flaky and costly (the existing survey+AI e2e test is already skipped for this reason).

# Changelog
## Fixed
- [TAN-8087] Fix bug with phase reports - text question without AI summaries caused blank report
