### PR TITLE
TAN-5558 - Properly improve FE deploy speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,6 +651,15 @@ jobs:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run:
+          # Immutable per-build asset prefix (Vite `base`) + content-hashed twemoji
+          # prefix. Both are exported via BASH_ENV so the build and the deploy step
+          # below agree on them. The twemoji hash changes iff a glyph changes.
+          name: Compute content-hashed asset + twemoji prefixes
+          command: |
+            echo "export ASSET_BASE_URL=/$CIRCLE_SHA1/" >> "$BASH_ENV"
+            TWEMOJI_HASH=$(find app/public/twemoji -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -c1-12)
+            echo "export TWEMOJI_BASE_URL=/twemoji/$TWEMOJI_HASH/" >> "$BASH_ENV"
+      - run:
           command: SEGMENT_API_KEY=$SEGMENT_API_KEY_STAGING SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_DSN=$SENTRY_DSN SENTRY_ENV=$SENTRY_ENV_STAGING POSTHOG_API_KEY=$POSTHOG_API_KEY_STAGING npm run build
           no_output_timeout: "30m"
       - run:
@@ -658,7 +667,20 @@ jobs:
       - run:
           name: Deploy to S3 if tests pass and branch is Master
           command: |
-            aws s3 sync build/ s3://cl2-front-staging/ --acl public-read --exclude "index.html"
+            # Twemoji: ~4k immutable SVGs served from a content-hashed prefix. Upload
+            # them only when that prefix doesn't exist yet, so steady-state cost is a
+            # single LIST — not the 4k-file diff that made the old sync slow. The hash
+            # guarantees a fresh prefix (and thus a re-upload) whenever a glyph changes.
+            if [ -z "$(aws s3 ls "s3://cl2-front-staging${TWEMOJI_BASE_URL}")" ]; then
+              aws s3 sync app/public/twemoji/ "s3://cl2-front-staging${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
+            fi
+            rm -rf build/twemoji
+            # Upload the build into a fresh, EMPTY per-build prefix. cp --recursive
+            # never lists the bucket root, so deploy time no longer grows with the
+            # thousands of files left there by past deploys. Everything under /<sha>/
+            # is immutable (new prefix each build) -> cache for a year.
+            aws s3 cp build/ "s3://cl2-front-staging/$CIRCLE_SHA1/" --recursive --acl public-read --exclude "index.html" --cache-control "public, max-age=31536000, immutable"
+            # Flip the root index.html to the new prefix — the atomic release switch.
             aws s3 cp build/index.html s3://cl2-front-staging/index.html --acl public-read --cache-control no-cache
             aws s3 cp .well-known/security.txt s3://cl2-front-staging/.well-known/security.txt --acl public-read --content-type text/plain
 
@@ -678,6 +700,13 @@ jobs:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run:
+          # See the staging job for rationale.
+          name: Compute content-hashed asset + twemoji prefixes
+          command: |
+            echo "export ASSET_BASE_URL=/$CIRCLE_SHA1/" >> "$BASH_ENV"
+            TWEMOJI_HASH=$(find app/public/twemoji -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -c1-12)
+            echo "export TWEMOJI_BASE_URL=/twemoji/$TWEMOJI_HASH/" >> "$BASH_ENV"
+      - run:
           command: SEGMENT_API_KEY=$SEGMENT_API_KEY_PRODUCTION SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_DSN=$SENTRY_DSN SENTRY_ENV=$SENTRY_ENV_PRODUCTION POSTHOG_API_KEY=$POSTHOG_API_KEY_PRODUCTION npm run build
           no_output_timeout: "30m"
       - run:
@@ -685,12 +714,19 @@ jobs:
       - run:
           name: Deploy production version
           command: |
-            aws s3 sync build/ s3://cl2-front-production-benelux/ --acl public-read --exclude "index.html"
+            # See the staging job for rationale.
+            if [ -z "$(aws s3 ls "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}")" ]; then
+              aws s3 sync app/public/twemoji/ "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
+            fi
+            rm -rf build/twemoji
+            aws s3 cp build/ "s3://cl2-front-production-benelux/$CIRCLE_SHA1/" --recursive --acl public-read --exclude "index.html" --cache-control "public, max-age=31536000, immutable"
             aws s3 cp build/index.html s3://cl2-front-production-benelux/index.html --acl public-read --cache-control no-cache
             aws s3 cp .well-known/security.txt s3://cl2-front-production-benelux/.well-known/security.txt --acl public-read --content-type text/plain
       - run:
           name: Invalidate the static assets on the CDN
-          command: aws cloudfront create-invalidation --distribution-id E2MY732QC516J3 --paths '/*'
+          # Assets live at immutable /<sha>/ URLs, so only the root index.html (the
+          # release pointer) needs busting — far cheaper than invalidating /*.
+          command: aws cloudfront create-invalidation --distribution-id E2MY732QC516J3 --paths '/index.html'
 
   front-test-lighthouse:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -717,7 +717,7 @@ jobs:
             aws s3 cp .well-known/security.txt s3://cl2-front-production-benelux/.well-known/security.txt --acl public-read --content-type text/plain
           # NEW: Keep commented until validated on staging.
           # command: |
-          #   if [ -z "$(aws s3 ls "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}")" ]; then
+          #   if [ "$(aws s3api list-objects-v2 --bucket cl2-front-production-benelux --prefix "${TWEMOJI_BASE_URL#/}" --max-keys 1 --query 'KeyCount' --output text)" = "0" ]; then
           #    aws s3 sync app/public/twemoji/ "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
           #   fi
           #   rm -rf build/twemoji

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -670,7 +670,7 @@ jobs:
           # 3. Flip the root index.html to the new prefix — the atomic release switch.
           name: Deploy to S3 if tests pass and branch is Master
           command: |
-            if [ -z "$(aws s3 ls "s3://cl2-front-staging${TWEMOJI_BASE_URL}")" ]; then
+            if [ "$(aws s3api list-objects-v2 --bucket cl2-front-staging --prefix "${TWEMOJI_BASE_URL#/}" --max-keys 1 --query 'KeyCount' --output text)" = "0" ]; then
               aws s3 sync app/public/twemoji/ "s3://cl2-front-staging${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
             fi
             rm -rf build/twemoji

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,9 +651,7 @@ jobs:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run:
-          # Immutable per-build asset prefix (Vite `base`) + content-hashed twemoji
-          # prefix. Both are exported via BASH_ENV so the build and the deploy step
-          # below agree on them. The twemoji hash changes iff a glyph changes.
+          # Set immutable per-build asset prefix (Vite `base`) + content-hashed twemoji prefix
           name: Compute content-hashed asset + twemoji prefixes
           command: |
             echo "export ASSET_BASE_URL=/$CIRCLE_SHA1/" >> "$BASH_ENV"
@@ -663,24 +661,20 @@ jobs:
           command: SEGMENT_API_KEY=$SEGMENT_API_KEY_STAGING SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_DSN=$SENTRY_DSN SENTRY_ENV=$SENTRY_ENV_STAGING POSTHOG_API_KEY=$POSTHOG_API_KEY_STAGING npm run build
           no_output_timeout: "30m"
       - run:
-          command: rm build/*.map
+          command: |
+            rm -f build/*.map
+            rm -f build/assets/*.map
       - run:
+          # 1. Only upload ~4k Twemoji if anything changes.
+          # 2. Upload the build into a fresh, EMPTY per-build prefix.
+          # 3. Flip the root index.html to the new prefix — the atomic release switch.
           name: Deploy to S3 if tests pass and branch is Master
           command: |
-            # Twemoji: ~4k immutable SVGs served from a content-hashed prefix. Upload
-            # them only when that prefix doesn't exist yet, so steady-state cost is a
-            # single LIST — not the 4k-file diff that made the old sync slow. The hash
-            # guarantees a fresh prefix (and thus a re-upload) whenever a glyph changes.
             if [ -z "$(aws s3 ls "s3://cl2-front-staging${TWEMOJI_BASE_URL}")" ]; then
               aws s3 sync app/public/twemoji/ "s3://cl2-front-staging${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
             fi
             rm -rf build/twemoji
-            # Upload the build into a fresh, EMPTY per-build prefix. cp --recursive
-            # never lists the bucket root, so deploy time no longer grows with the
-            # thousands of files left there by past deploys. Everything under /<sha>/
-            # is immutable (new prefix each build) -> cache for a year.
             aws s3 cp build/ "s3://cl2-front-staging/$CIRCLE_SHA1/" --recursive --acl public-read --exclude "index.html" --cache-control "public, max-age=31536000, immutable"
-            # Flip the root index.html to the new prefix — the atomic release switch.
             aws s3 cp build/index.html s3://cl2-front-staging/index.html --acl public-read --cache-control no-cache
             aws s3 cp .well-known/security.txt s3://cl2-front-staging/.well-known/security.txt --acl public-read --content-type text/plain
 
@@ -699,34 +693,43 @@ jobs:
           paths:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
-      - run:
-          # See the staging job for rationale.
-          name: Compute content-hashed asset + twemoji prefixes
-          command: |
-            echo "export ASSET_BASE_URL=/$CIRCLE_SHA1/" >> "$BASH_ENV"
-            TWEMOJI_HASH=$(find app/public/twemoji -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -c1-12)
-            echo "export TWEMOJI_BASE_URL=/twemoji/$TWEMOJI_HASH/" >> "$BASH_ENV"
+      # NEW: Keep commented until validated on staging.
+      # - run:
+      #     # See the staging job for rationale.
+      #     name: Compute content-hashed asset + twemoji prefixes
+      #     command: |
+      #       echo "export ASSET_BASE_URL=/$CIRCLE_SHA1/" >> "$BASH_ENV"
+      #       TWEMOJI_HASH=$(find app/public/twemoji -type f -print0 | sort -z | xargs -0 sha1sum | sha1sum | cut -c1-12)
+      #       echo "export TWEMOJI_BASE_URL=/twemoji/$TWEMOJI_HASH/" >> "$BASH_ENV"
       - run:
           command: SEGMENT_API_KEY=$SEGMENT_API_KEY_PRODUCTION SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN SENTRY_DSN=$SENTRY_DSN SENTRY_ENV=$SENTRY_ENV_PRODUCTION POSTHOG_API_KEY=$POSTHOG_API_KEY_PRODUCTION npm run build
           no_output_timeout: "30m"
       - run:
-          command: rm build/*.map
+          command: |
+            rm -f build/*.map
+            rm -f build/assets/*.map
       - run:
           name: Deploy production version
+          # OLD: Keep until validated on staging.
           command: |
-            # See the staging job for rationale.
-            if [ -z "$(aws s3 ls "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}")" ]; then
-              aws s3 sync app/public/twemoji/ "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
-            fi
-            rm -rf build/twemoji
-            aws s3 cp build/ "s3://cl2-front-production-benelux/$CIRCLE_SHA1/" --recursive --acl public-read --exclude "index.html" --cache-control "public, max-age=31536000, immutable"
+            aws s3 sync build/ s3://cl2-front-production-benelux/ --acl public-read --exclude "index.html"
             aws s3 cp build/index.html s3://cl2-front-production-benelux/index.html --acl public-read --cache-control no-cache
             aws s3 cp .well-known/security.txt s3://cl2-front-production-benelux/.well-known/security.txt --acl public-read --content-type text/plain
+          # NEW: Keep commented until validated on staging.
+          # command: |
+          #   if [ -z "$(aws s3 ls "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}")" ]; then
+          #    aws s3 sync app/public/twemoji/ "s3://cl2-front-production-benelux${TWEMOJI_BASE_URL}" --acl public-read --cache-control "public, max-age=31536000, immutable"
+          #   fi
+          #   rm -rf build/twemoji
+          #   aws s3 cp build/ "s3://cl2-front-production-benelux/$CIRCLE_SHA1/" --recursive --acl public-read --exclude "index.html" --cache-control "public, max-age=31536000, immutable"
+          #   aws s3 cp build/index.html s3://cl2-front-production-benelux/index.html --acl public-read --cache-control no-cache
+          #   aws s3 cp .well-known/security.txt s3://cl2-front-production-benelux/.well-known/security.txt --acl public-read --content-type text/plain
       - run:
           name: Invalidate the static assets on the CDN
-          # Assets live at immutable /<sha>/ URLs, so only the root index.html (the
-          # release pointer) needs busting — far cheaper than invalidating /*.
-          command: aws cloudfront create-invalidation --distribution-id E2MY732QC516J3 --paths '/index.html'
+          # OLD: Keep until validated on staging.
+          command: aws cloudfront create-invalidation --distribution-id E2MY732QC516J3 --paths '/*'
+          # NEW: Wait until validated on staging.
+          # command: aws cloudfront create-invalidation --distribution-id E2MY732QC516J3 --paths '/index.html'
 
   front-test-lighthouse:
     docker:

--- a/front/app/index.html
+++ b/front/app/index.html
@@ -7,12 +7,15 @@
 
     <script type="module">
       if (import.meta.env.MODE === 'production') {
+        // Runtime hrefs aren't rewritten by Vite's `base` (unlike CSS url()s),
+        // so prefix them with BASE_URL to match where the fonts are deployed.
+        const base = import.meta.env.BASE_URL;
         document.write(`
-          <link rel="preload" crossorigin="anonymous" href="/PublicSans-Light.woff2" as="font" type="font/woff2" />
-          <link rel="preload" crossorigin="anonymous" href="/PublicSans-Regular.woff2" as="font" type="font/woff2" />
-          <link rel="preload" crossorigin="anonymous" href="/PublicSans-Medium.woff2" as="font" type="font/woff2" />
-          <link rel="preload" crossorigin="anonymous" href="/PublicSans-SemiBold.woff2" as="font" type="font/woff2" />
-          <link rel="preload" crossorigin="anonymous" href="/PublicSans-Bold.woff2" as="font" type="font/woff2" />
+          <link rel="preload" crossorigin="anonymous" href="${base}PublicSans-Light.woff2" as="font" type="font/woff2" />
+          <link rel="preload" crossorigin="anonymous" href="${base}PublicSans-Regular.woff2" as="font" type="font/woff2" />
+          <link rel="preload" crossorigin="anonymous" href="${base}PublicSans-Medium.woff2" as="font" type="font/woff2" />
+          <link rel="preload" crossorigin="anonymous" href="${base}PublicSans-SemiBold.woff2" as="font" type="font/woff2" />
+          <link rel="preload" crossorigin="anonymous" href="${base}PublicSans-Bold.woff2" as="font" type="font/woff2" />
         `);
       }
     </script>

--- a/front/vite.config.ts
+++ b/front/vite.config.ts
@@ -40,7 +40,10 @@ export default defineConfig(({ mode }) => {
 
   return {
     root: path.resolve(__dirname, 'app'), // Root directory
-    base: '/', // Base path for public assets
+    // Base path for built assets. CI sets ASSET_BASE_URL=/<git-sha>/ so every
+    // build's assets get immutable, per-build URLs (uploaded to a fresh S3
+    // prefix). Unset locally, so dev keeps serving everything from '/'.
+    base: process.env.ASSET_BASE_URL || '/',
     server: {
       port: USE_HTTPS ? 443 : Number(process.env.PORT) || 3000,
       host: '0.0.0.0',


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/CitizenLabDotCo/citizenlab/pull/14046) where I realised on deployment that the real issue was with `s3 sync` (which I was then using twice, so twice as slow!). The changes I made to Twemoji are still valid though and included again in this PR.

What changed:
  
  - Deploy each build's assets into a fresh, per-commit S3 prefix (s3://…/$CIRCLE_SHA1/) instead of dumping them all into the bucket root — and use `aws s3 cp --recursive`, not `s3 sync`.
  - Vite base now set to /<sha>/ at build time so index.html/CSS/font URLs point at that prefix; root index.html (no-cache) is flipped last as the atomic release switch.
  - Twemoji (~4k immutable SVGs) moved to a content-hashed prefix, uploaded only when missing (guarded by one aws s3 ls), and removed from build/ before the deploy.
  - Fixed removal of `.map` files so the ~2k files in `/assets` are also never uploaded
  - CDN invalidation narrowed from `/*` to `/index.html`.
  - Added infinite cache headers to the build assets (not index.html) to improve performance

Why it's faster:

 - Staging (for example) has 1.5M files in the root dir
  - s3 sync must LIST the whole destination first — that means paging through all 1.5M objects and diffing them, on every deploy. That's what is taking the time, and that number keeps growing.
  - We now user `cp --recursive` which never lists the destination — it just uploads this build's few-hundred files. So deploy time no longer scales with the 1.5M-file backlog.
  - Targeting an empty /<sha>/ prefix means there's nothing to compare against anyway — zero diff work.
  - Twemoji (the bulk of the file count) is out of the per-deploy path — synced once, then skipped with a single cheap check instead of re-diffing 4k files each time.
  - Narrowed invalidation avoids busting the entire CDN on every release.

NOTE: To derisk this, currently production is commented out so we can test on staging and leave for a few days to ensure that there are not any issue before enabling on production.

Follow-up worth doing: Remove all the old files from the S3 bucket and add an S3 lifecycle rule to expire old /<sha>/ prefixes, so the backlog stops growing.

# Changelog
## Technical
- Improved the speed of FE deployments
