### PR TITLE
[TAN-8045] Override 'Jänner' for de-AT with 'Januar'

### DIFF
--- a/back/config/initializers/de_at_date_month_names.rb
+++ b/back/config/initializers/de_at_date_month_names.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
 # Applies config/locales/overrides/de-AT.yml, which overrides the rails-i18n
-# gem's Austrian month name "Jänner" -> "Januar" (see that file for rationale).
+# gem's Austrian January month name "Jänner"/"Jän" -> "Januar"/"Jan" (see that
+# file for rationale).
 #
 # We use store_translations in a to_prepare hook rather than I18n.load_path:
 # the gem's de-AT locale is appended to the load path *after* config/initializers
 # run, so a plain load_path append loses the merge to the gem. store_translations
-# deep-merges our data on top of whatever is already loaded (replacing only the
-# month_names array, keeping abbr_month_names/formats), independent of load
-# order, and to_prepare re-applies it after code reloads in development.
+# deep-merges our data on top of whatever is already loaded (replacing the
+# month_names and abbr_month_names arrays, keeping date/time formats), independent
+# of load order, and to_prepare re-applies it after code reloads in development.
 override_path = Rails.root.join('config/locales/overrides/de-AT.yml')
 
 Rails.application.config.to_prepare do

--- a/back/config/initializers/de_at_date_month_names.rb
+++ b/back/config/initializers/de_at_date_month_names.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Applies config/locales/overrides/de-AT.yml, which overrides the rails-i18n
+# gem's Austrian month name "Jänner" -> "Januar" (see that file for rationale).
+#
+# We use store_translations in a to_prepare hook rather than I18n.load_path:
+# the gem's de-AT locale is appended to the load path *after* config/initializers
+# run, so a plain load_path append loses the merge to the gem. store_translations
+# deep-merges our data on top of whatever is already loaded (replacing only the
+# month_names array, keeping abbr_month_names/formats), independent of load
+# order, and to_prepare re-applies it after code reloads in development.
+override_path = Rails.root.join('config/locales/overrides/de-AT.yml')
+
+Rails.application.config.to_prepare do
+  translations = YAML.load_file(override_path).fetch('de-AT')
+  I18n.backend.store_translations(:'de-AT', translations)
+end

--- a/back/config/locales/overrides/de-AT.yml
+++ b/back/config/locales/overrides/de-AT.yml
@@ -1,0 +1,27 @@
+# Overrides the rails-i18n gem's Austrian (de-AT) wide month name so January
+# renders as "Januar" instead of "Jänner" (e.g. in email-campaign subjects/dates
+# via `I18n.l(..., format: :long)`). Mirrors the frontend date-fns / moment /
+# Intl overrides.
+#
+# NOT a Polyglit-managed file: it lives outside the `config/locales/{locale}.yml`
+# pattern and outside the non-recursive `config/locales/*.yml` load glob, and is
+# added to I18n.load_path explicitly by
+# config/initializers/de_at_date_month_names.rb (which also guarantees it loads
+# after the gem so this wins). Only `month_names` (the wide `%B` form) is
+# overridden; `abbr_month_names` keeps the gem's "Jän".
+de-AT:
+  date:
+    month_names:
+      -
+      - Januar
+      - Februar
+      - März
+      - April
+      - Mai
+      - Juni
+      - Juli
+      - August
+      - September
+      - Oktober
+      - November
+      - Dezember

--- a/back/config/locales/overrides/de-AT.yml
+++ b/back/config/locales/overrides/de-AT.yml
@@ -1,14 +1,13 @@
-# Overrides the rails-i18n gem's Austrian (de-AT) wide month name so January
-# renders as "Januar" instead of "Jänner" (e.g. in email-campaign subjects/dates
-# via `I18n.l(..., format: :long)`). Mirrors the frontend date-fns / moment /
+# Overrides the rails-i18n gem's Austrian (de-AT) January month name so it
+# renders as "Januar" (wide, `%B`) / "Jan" (short, `%b`) instead of the gem's
+# "Jänner" / "Jän" (e.g. in email-campaign subjects/dates via
+# `I18n.l(..., format: :long|:short)`). Mirrors the frontend date-fns / moment /
 # Intl overrides.
 #
 # NOT a Polyglit-managed file: it lives outside the `config/locales/{locale}.yml`
 # pattern and outside the non-recursive `config/locales/*.yml` load glob, and is
-# added to I18n.load_path explicitly by
-# config/initializers/de_at_date_month_names.rb (which also guarantees it loads
-# after the gem so this wins). Only `month_names` (the wide `%B` form) is
-# overridden; `abbr_month_names` keeps the gem's "Jän".
+# applied by config/initializers/de_at_date_month_names.rb. Only January is
+# changed; every other month keeps the gem's de-AT value.
 de-AT:
   date:
     month_names:
@@ -25,3 +24,17 @@ de-AT:
       - Oktober
       - November
       - Dezember
+    abbr_month_names:
+      -
+      - Jan
+      - Feb
+      - Mär
+      - Apr
+      - Mai
+      - Jun
+      - Jul
+      - Aug
+      - Sep
+      - Okt
+      - Nov
+      - Dez

--- a/back/spec/config/de_at_date_month_names_spec.rb
+++ b/back/spec/config/de_at_date_month_names_spec.rb
@@ -5,21 +5,23 @@ require 'rails_helper'
 # Guards the de-AT month-name override (config/locales/overrides/de-AT.yml +
 # config/initializers/de_at_date_month_names.rb): the rails-i18n gem renders
 # January as "Jänner" for de-AT; we render "Januar" instead.
-RSpec.describe 'de-AT date month names' do
-  it 'renders January as "Januar" (not the gem default "Jänner") for :long' do
-    result = I18n.l(Date.new(2026, 1, 15), format: :long, locale: :'de-AT')
-    expect(result).to include('Januar')
-    expect(result).not_to include('Jänner')
-  end
+RSpec.describe I18n do
+  context 'with de-AT date month names' do
+    it 'renders January as "Januar" (not the gem default "Jänner") for :long' do
+      result = I18n.l(Date.new(2026, 1, 15), format: :long, locale: :'de-AT')
+      expect(result).to include('Januar')
+      expect(result).not_to include('Jänner')
+    end
 
-  it 'overrides only January in the wide month_names list' do
-    month_names = I18n.t('date.month_names', locale: :'de-AT')
-    expect(month_names[1]).to eq('Januar')
-    expect(month_names[2]).to eq('Februar')
-    expect(month_names[12]).to eq('Dezember')
-  end
+    it 'overrides only January in the wide month_names list' do
+      month_names = I18n.t('date.month_names', locale: :'de-AT')
+      expect(month_names[1]).to eq('Januar')
+      expect(month_names[2]).to eq('Februar')
+      expect(month_names[12]).to eq('Dezember')
+    end
 
-  it 'leaves the abbreviated month name as the gem default "Jän"' do
-    expect(I18n.t('date.abbr_month_names', locale: :'de-AT')[1]).to eq('Jän')
+    it 'leaves the abbreviated month name as the gem default "Jän"' do
+      expect(I18n.t('date.abbr_month_names', locale: :'de-AT')[1]).to eq('Jän')
+    end
   end
 end

--- a/back/spec/config/de_at_date_month_names_spec.rb
+++ b/back/spec/config/de_at_date_month_names_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Guards the de-AT month-name override (config/locales/overrides/de-AT.yml +
+# config/initializers/de_at_date_month_names.rb): the rails-i18n gem renders
+# January as "Jänner" for de-AT; we render "Januar" instead.
+RSpec.describe 'de-AT date month names' do
+  it 'renders January as "Januar" (not the gem default "Jänner") for :long' do
+    result = I18n.l(Date.new(2026, 1, 15), format: :long, locale: :'de-AT')
+    expect(result).to include('Januar')
+    expect(result).not_to include('Jänner')
+  end
+
+  it 'overrides only January in the wide month_names list' do
+    month_names = I18n.t('date.month_names', locale: :'de-AT')
+    expect(month_names[1]).to eq('Januar')
+    expect(month_names[2]).to eq('Februar')
+    expect(month_names[12]).to eq('Dezember')
+  end
+
+  it 'leaves the abbreviated month name as the gem default "Jän"' do
+    expect(I18n.t('date.abbr_month_names', locale: :'de-AT')[1]).to eq('Jän')
+  end
+end

--- a/back/spec/config/de_at_date_month_names_spec.rb
+++ b/back/spec/config/de_at_date_month_names_spec.rb
@@ -4,24 +4,35 @@ require 'rails_helper'
 
 # Guards the de-AT month-name override (config/locales/overrides/de-AT.yml +
 # config/initializers/de_at_date_month_names.rb): the rails-i18n gem renders
-# January as "Jänner" for de-AT; we render "Januar" instead.
+# January as "Jänner"/"Jän" for de-AT; we render "Januar"/"Jan" instead.
 RSpec.describe I18n do
   context 'with de-AT date month names' do
     it 'renders January as "Januar" (not the gem default "Jänner") for :long' do
-      result = I18n.l(Date.new(2026, 1, 15), format: :long, locale: :'de-AT')
+      result = described_class.l(Date.new(2026, 1, 15), format: :long, locale: :'de-AT')
       expect(result).to include('Januar')
       expect(result).not_to include('Jänner')
     end
 
+    it 'renders January as "Jan" (not the gem default "Jän") for a :short time' do
+      # de-AT time.formats.short uses %b (abbreviated month); this is the path
+      # the event-registration mailer takes.
+      result = described_class.l(Time.utc(2026, 1, 15, 9, 30), format: :short, locale: :'de-AT')
+      expect(result).to include('Jan')
+      expect(result).not_to include('Jän')
+    end
+
     it 'overrides only January in the wide month_names list' do
-      month_names = I18n.t('date.month_names', locale: :'de-AT')
+      month_names = described_class.t('date.month_names', locale: :'de-AT')
       expect(month_names[1]).to eq('Januar')
       expect(month_names[2]).to eq('Februar')
       expect(month_names[12]).to eq('Dezember')
     end
 
-    it 'leaves the abbreviated month name as the gem default "Jän"' do
-      expect(I18n.t('date.abbr_month_names', locale: :'de-AT')[1]).to eq('Jän')
+    it 'overrides only January in the abbreviated abbr_month_names list' do
+      abbr = described_class.t('date.abbr_month_names', locale: :'de-AT')
+      expect(abbr[1]).to eq('Jan')
+      expect(abbr[2]).to eq('Feb')
+      expect(abbr[12]).to eq('Dez')
     end
   end
 end

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -86,9 +86,10 @@ async function importMomentLocaleFilePromise(momentLocale: string) {
   try {
     await localeGetter(momentLocale);
     if (momentLocale === 'de-at') {
-      // date-fns' and moment's de-at locales both render January as "Jänner";
-      // we display "Januar". This overrides moment's copy once its locale file
-      // is loaded (the date-fns counterpart lives in i18n/de-AT.ts).
+      // date-fns' and moment's de-at locales render January as "Jänner" (wide)
+      // and "Jän." (short); we display "Januar"/"Jan." instead. This overrides
+      // moment's copy once its locale file is loaded (the date-fns counterpart
+      // lives in i18n/de-AT.ts).
       patchMomentDeAtJanuary();
     }
     importedLocales.add(momentLocale);

--- a/front/app/containers/App/index.tsx
+++ b/front/app/containers/App/index.tsx
@@ -44,6 +44,7 @@ import Navigate from 'utils/cl-router/Navigate';
 import { removeLocale } from 'utils/cl-router/updateLocationDescriptor';
 import eventEmitter from 'utils/eventEmitter';
 import { initiativeShowPageSlug, isPage } from 'utils/helperUtils';
+import patchMomentDeAtJanuary from 'utils/patchMomentDeAtJanuary';
 import { usePermission } from 'utils/permissions';
 import { isAdmin, isModerator } from 'utils/permissions/roles';
 import { useLocation } from 'utils/router';
@@ -84,6 +85,12 @@ const importedLocales = new Set();
 async function importMomentLocaleFilePromise(momentLocale: string) {
   try {
     await localeGetter(momentLocale);
+    if (momentLocale === 'de-at') {
+      // date-fns' and moment's de-at locales both render January as "Jänner";
+      // we display "Januar". This overrides moment's copy once its locale file
+      // is loaded (the date-fns counterpart lives in i18n/de-AT.ts).
+      patchMomentDeAtJanuary();
+    }
     importedLocales.add(momentLocale);
   } catch (error) {
     console.error(`Error processing locale: ${momentLocale}`, error);

--- a/front/app/i18n/de-AT.test.ts
+++ b/front/app/i18n/de-AT.test.ts
@@ -1,0 +1,28 @@
+import { format } from 'date-fns';
+
+import { getLocale } from 'components/admin/DatePickers/_shared/locales';
+
+// Importing the module registers the (overridden) de-AT date-fns locale via addLocale.
+import 'i18n/de-AT';
+
+describe('de-AT date-fns locale', () => {
+  const deAT = getLocale('de-AT');
+  const january = new Date(2026, 0, 15);
+
+  it('renders January as "Januar" instead of date-fns\' default "Jänner"', () => {
+    // Wide month (MMMM) and standalone wide month (LLLL) both flow through
+    // localize.month and are the paths that produce the calendar month name.
+    expect(format(january, 'MMMM', { locale: deAT })).toBe('Januar');
+    expect(format(january, 'LLLL', { locale: deAT })).toBe('Januar');
+    expect(format(january, 'MMMM', { locale: deAT })).not.toBe('Jänner');
+  });
+
+  it('leaves other months and non-wide widths of January untouched', () => {
+    // Only the wide "Jänner" is overridden; everything else keeps the Austrian form.
+    expect(format(new Date(2026, 1, 1), 'MMMM', { locale: deAT })).toBe(
+      'Februar'
+    );
+    expect(format(january, 'MMM', { locale: deAT })).toBe('Jän.');
+    expect(format(january, 'MMMMM', { locale: deAT })).toBe('J');
+  });
+});

--- a/front/app/i18n/de-AT.test.ts
+++ b/front/app/i18n/de-AT.test.ts
@@ -17,12 +17,17 @@ describe('de-AT date-fns locale', () => {
     expect(format(january, 'MMMM', { locale: deAT })).not.toBe('Jänner');
   });
 
-  it('leaves other months and non-wide widths of January untouched', () => {
-    // Only the wide "Jänner" is overridden; everything else keeps the Austrian form.
+  it('renders the short January as "Jan"/"Jan." instead of "Jän"/"Jän."', () => {
+    // Formatting abbreviated (MMM) keeps the period; standalone (LLL) has none.
+    expect(format(january, 'MMM', { locale: deAT })).toBe('Jan.');
+    expect(format(january, 'LLL', { locale: deAT })).toBe('Jan');
+  });
+
+  it('leaves other months and the narrow width untouched', () => {
     expect(format(new Date(2026, 1, 1), 'MMMM', { locale: deAT })).toBe(
       'Februar'
     );
-    expect(format(january, 'MMM', { locale: deAT })).toBe('Jän.');
+    expect(format(new Date(2026, 1, 1), 'MMM', { locale: deAT })).toBe('Feb.');
     expect(format(january, 'MMMMM', { locale: deAT })).toBe('J');
   });
 });

--- a/front/app/i18n/de-AT.ts
+++ b/front/app/i18n/de-AT.ts
@@ -1,10 +1,29 @@
+import { Locale } from 'date-fns';
 import deAT from 'date-fns/locale/de-AT';
 
 import { addLocale } from 'components/admin/DatePickers/_shared/locales';
 
 import { formatTranslationMessages } from '.';
 
-addLocale('de-AT', deAT);
+// date-fns' de-AT locale renders January as "Jänner"; we display "Januar" for
+// de-AT instead. Wrapping the locale's `month` localizer overrides the value on
+// every code path date-fns uses to produce a month name (format tokens like
+// MMMM/LLLL, and react-day-picker's month dropdown).
+const { localize } = deAT;
+const deATLocale: Locale = localize
+  ? {
+      ...deAT,
+      localize: {
+        ...localize,
+        month: (...args: Parameters<typeof localize.month>) => {
+          const month = localize.month(...args);
+          return month === 'Jänner' ? 'Januar' : month;
+        },
+      },
+    }
+  : deAT;
+
+addLocale('de-AT', deATLocale);
 const deATAdminTranslationMessages = require('translations/admin/de-AT.json');
 const deATTranslationMessages = require('translations/de-AT.json');
 const translationMessages = formatTranslationMessages('de-AT', {

--- a/front/app/i18n/de-AT.ts
+++ b/front/app/i18n/de-AT.ts
@@ -5,10 +5,11 @@ import { addLocale } from 'components/admin/DatePickers/_shared/locales';
 
 import { formatTranslationMessages } from '.';
 
-// date-fns' de-AT locale renders January as "Jänner"; we display "Januar" for
-// de-AT instead. Wrapping the locale's `month` localizer overrides the value on
-// every code path date-fns uses to produce a month name (format tokens like
-// MMMM/LLLL, and react-day-picker's month dropdown).
+// date-fns' de-AT locale renders January as "Jänner" (wide) / "Jän." (short);
+// we display "Januar" / "Jan." for de-AT instead. Wrapping the locale's `month`
+// localizer overrides the value on every code path date-fns uses to produce a
+// month name (format tokens like MMMM/LLLL/MMM/LLL, and react-day-picker's month
+// dropdown).
 const { localize } = deAT;
 const deATLocale: Locale = localize
   ? {
@@ -17,7 +18,12 @@ const deATLocale: Locale = localize
         ...localize,
         month: (...args: Parameters<typeof localize.month>) => {
           const month = localize.month(...args);
-          return month === 'Jänner' ? 'Januar' : month;
+          // Wide "Jänner", plus both abbreviated variants: formatting "Jän."
+          // (MMM) and standalone "Jän" (LLL).
+          if (month === 'Jänner') return 'Januar';
+          if (month === 'Jän.') return 'Jan.';
+          if (month === 'Jän') return 'Jan';
+          return month;
         },
       },
     }

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -1,5 +1,6 @@
 // Side-effect import: must run before any date is formatted (overrides the
-// native de-AT "Jänner" month name -> "Januar"). Keep it first.
+// native de-AT January month name "Jänner"/"Jän" -> "Januar"/"Jan"). Keep it
+// first.
 import 'utils/patchIntlDeAtJanuary';
 
 import React, { StrictMode, useEffect } from 'react';

--- a/front/app/root.tsx
+++ b/front/app/root.tsx
@@ -1,3 +1,7 @@
+// Side-effect import: must run before any date is formatted (overrides the
+// native de-AT "Jänner" month name -> "Januar"). Keep it first.
+import 'utils/patchIntlDeAtJanuary';
+
 import React, { StrictMode, useEffect } from 'react';
 
 import 'assets/css/reset.min.css';

--- a/front/app/utils/patchIntlDeAtJanuary.test.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.test.ts
@@ -1,0 +1,48 @@
+// Importing the module installs the global Intl patch (side effect).
+import 'utils/patchIntlDeAtJanuary';
+
+describe('patchIntlDeAtJanuary', () => {
+  const jan = new Date(2026, 0, 15);
+  const feb = new Date(2026, 1, 1);
+
+  it('rewrites de-AT wide January to "Januar" via Intl.DateTimeFormat.format', () => {
+    const out = new Intl.DateTimeFormat('de-AT', { month: 'long' }).format(jan);
+    expect(out).toBe('Januar');
+    expect(out).not.toBe('Jänner');
+  });
+
+  it('rewrites the month part in formatToParts', () => {
+    const parts = new Intl.DateTimeFormat('de-AT', {
+      month: 'long',
+    }).formatToParts(jan);
+    expect(parts.find((p) => p.type === 'month')?.value).toBe('Januar');
+  });
+
+  it('rewrites Date#toLocaleDateString for de-AT', () => {
+    expect(jan.toLocaleDateString('de-AT', { month: 'long' })).toBe('Januar');
+  });
+
+  it('leaves abbreviated January, other months, and other locales untouched', () => {
+    // Abbreviated form is intentionally not rewritten.
+    expect(
+      new Intl.DateTimeFormat('de-AT', { month: 'short' }).format(jan)
+    ).toBe('Jän');
+    // Other months unaffected.
+    expect(
+      new Intl.DateTimeFormat('de-AT', { month: 'long' }).format(feb)
+    ).toBe('Februar');
+    // Plain German already says "Januar"; English unaffected.
+    expect(new Intl.DateTimeFormat('de', { month: 'long' }).format(jan)).toBe(
+      'Januar'
+    );
+    expect(new Intl.DateTimeFormat('en', { month: 'long' }).format(jan)).toBe(
+      'January'
+    );
+  });
+
+  it('preserves the static supportedLocalesOf', () => {
+    expect(Intl.DateTimeFormat.supportedLocalesOf(['de-AT'])).toContain(
+      'de-AT'
+    );
+  });
+});

--- a/front/app/utils/patchIntlDeAtJanuary.test.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.test.ts
@@ -1,6 +1,8 @@
 // Importing the module installs the global Intl patch (side effect).
 import 'utils/patchIntlDeAtJanuary';
 
+import { createIntl, createIntlCache } from 'react-intl';
+
 describe('patchIntlDeAtJanuary', () => {
   const jan = new Date(2026, 0, 15);
   const feb = new Date(2026, 1, 1);
@@ -54,5 +56,30 @@ describe('patchIntlDeAtJanuary', () => {
     expect(Intl.DateTimeFormat.supportedLocalesOf(['de-AT'])).toContain(
       'de-AT'
     );
+  });
+
+  // The real production path: cl-intl/react-intl's formatDate delegates to the
+  // global Intl.DateTimeFormat we patched, so a de-AT month renders "Januar"/"Jan".
+  describe('via react-intl formatDate', () => {
+    const intl = createIntl(
+      { locale: 'de-AT', messages: {} },
+      createIntlCache()
+    );
+
+    it('rewrites the wide January to "Januar"', () => {
+      const out = intl.formatDate(jan, { month: 'long' });
+      expect(out).toBe('Januar');
+      expect(out).not.toBe('Jänner');
+    });
+
+    it('rewrites the short January to "Jan"', () => {
+      const out = intl.formatDate(jan, { month: 'short' });
+      expect(out).toBe('Jan');
+      expect(out).not.toBe('Jän');
+    });
+
+    it('leaves other months untouched', () => {
+      expect(intl.formatDate(feb, { month: 'long' })).toBe('Februar');
+    });
   });
 });

--- a/front/app/utils/patchIntlDeAtJanuary.test.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.test.ts
@@ -18,19 +18,29 @@ describe('patchIntlDeAtJanuary', () => {
     expect(parts.find((p) => p.type === 'month')?.value).toBe('Januar');
   });
 
-  it('rewrites Date#toLocaleDateString for de-AT', () => {
-    expect(jan.toLocaleDateString('de-AT', { month: 'long' })).toBe('Januar');
-  });
-
-  it('leaves abbreviated January, other months, and other locales untouched', () => {
-    // Abbreviated form is intentionally not rewritten.
+  it('rewrites the short de-AT January to "Jan"', () => {
     expect(
       new Intl.DateTimeFormat('de-AT', { month: 'short' }).format(jan)
-    ).toBe('Jän');
+    ).toBe('Jan');
+  });
+
+  it('rewrites Date#toLocaleDateString for de-AT (wide and short)', () => {
+    expect(jan.toLocaleDateString('de-AT', { month: 'long' })).toBe('Januar');
+    expect(jan.toLocaleDateString('de-AT', { month: 'short' })).toBe('Jan');
+  });
+
+  it('leaves other months, the narrow width, and other locales untouched', () => {
     // Other months unaffected.
     expect(
       new Intl.DateTimeFormat('de-AT', { month: 'long' }).format(feb)
     ).toBe('Februar');
+    expect(
+      new Intl.DateTimeFormat('de-AT', { month: 'short' }).format(feb)
+    ).toBe('Feb');
+    // Narrow stays a single letter.
+    expect(
+      new Intl.DateTimeFormat('de-AT', { month: 'narrow' }).format(jan)
+    ).toBe('J');
     // Plain German already says "Januar"; English unaffected.
     expect(new Intl.DateTimeFormat('de', { month: 'long' }).format(jan)).toBe(
       'Januar'

--- a/front/app/utils/patchIntlDeAtJanuary.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.ts
@@ -1,142 +1,99 @@
 /**
  * Overrides the Austrian German (de-AT) January month name — "Jänner" (wide)
- * and "Jän" (short) — with "Januar" / "Jan" wherever it is produced by the
- * platform's native `Intl` API.
+ * and "Jän" (short) — with "Januar" / "Jan" wherever the platform's native
+ * `Intl` API produces it. Counterpart to the date-fns (`i18n/de-AT.ts`) and
+ * moment (`patchMomentDeAtJanuary.ts`) overrides.
  *
- * This is the counterpart to the date-fns (`i18n/de-AT.ts`) and moment
- * (`patchMomentDeAtJanuary.ts`) overrides. react-intl's `formatDate` /
- * `<FormattedDate>` — and any raw `new Intl.DateTimeFormat(...)` or
- * `Date#toLocale*` call — delegate to the browser's CLDR data, where de-AT
- * January is "Jänner"/"Jän". @formatjs reads the global `Intl.DateTimeFormat` at
- * format time, so wrapping the constructor here (plus the `Date#toLocale*`
- * helpers, which use the intrinsic directly) catches every native-Intl path.
- *
- * Because "Jän" is unique to de-AT January, the rewrite is a safe no-op for
- * every other locale. The narrow form ("J") is left untouched.
+ * react-intl's `formatDate` / `<FormattedDate>` and any raw `Intl` or
+ * `Date#toLocale*` call ultimately go through the native methods patched below,
+ * so we post-process their output — but only for the de-AT locale, leaving every
+ * other locale's formatting untouched.
  *
  * Imported for side effects at the very top of `root.tsx` so it runs before the
- * first date is formatted. Idempotent.
+ * first date is formatted. Idempotent per realm.
  */
 
-const JAEN = 'Jän'; // prefix shared by both "Jänner" (wide) and "Jän" (short)
-const PATCHED = '__deAtJanuarPatched';
-
-type DateArg = Date | number | undefined;
+const localeIsDeAt = (locale: string | undefined): boolean =>
+  !!locale && locale.toLowerCase().startsWith('de-at');
 
 // Rewrite the wide form first ("Jänner" -> "Januar"), then the short form
-// ("Jän" -> "Jan"). Order matters: "Jän" is a prefix of "Jänner", so the wide
-// replacement must run before the short one (after it, "Januar" has no "Jän").
+// ("Jän" -> "Jan"): "Jän" is a prefix of "Jänner", so the order matters.
 const januarize = (value: string): string =>
-  value.includes(JAEN)
-    ? value.split('Jänner').join('Januar').split('Jän').join('Jan')
-    : value;
+  value.split('Jänner').join('Januar').split('Jän').join('Jan');
 
-const januarizeParts = (
+const januarizeMonthParts = (
   parts: Intl.DateTimeFormatPart[]
 ): Intl.DateTimeFormatPart[] =>
   parts.map((part) =>
     part.type === 'month' ? { ...part, value: januarize(part.value) } : part
   );
 
-const isDeAt = (dtf: Intl.DateTimeFormat): boolean =>
-  dtf.resolvedOptions().locale.toLowerCase().startsWith('de-at');
+const dtfProto = Intl.DateTimeFormat.prototype;
 
-// Replace an instance method with `wrapped`. `format` is an inherited accessor
-// (getter, no setter), so a plain assignment throws in strict mode — define an
-// own data property instead.
-const define = (
-  target: object,
-  name: string,
-  wrapped: (...args: never[]) => unknown
-): void => {
-  Object.defineProperty(target, name, {
-    value: wrapped,
-    configurable: true,
-    writable: true,
+// `Intl.DateTimeFormat.prototype.format` is an accessor whose getter returns a
+// bound formatter. For de-AT, return a formatter that januarizes; every other
+// locale gets the original, untouched.
+const wrapFormatGetter = (): void => {
+  const descriptor = Object.getOwnPropertyDescriptor(dtfProto, 'format');
+  const originalGet = descriptor?.get;
+  if (!originalGet) return;
+  Object.defineProperty(dtfProto, 'format', {
+    ...descriptor,
+    get(this: Intl.DateTimeFormat) {
+      const format = originalGet.call(this) as Intl.DateTimeFormat['format'];
+      if (!localeIsDeAt(this.resolvedOptions().locale)) return format;
+      return (date?: Date | number) => januarize(format(date));
+    },
   });
 };
 
-const wrapInstance = (dtf: Intl.DateTimeFormat): void => {
-  const originalFormat = dtf.format.bind(dtf);
-  define(dtf, 'format', (date: DateArg) => januarize(originalFormat(date)));
-
-  const originalFormatToParts = dtf.formatToParts.bind(dtf);
-  define(dtf, 'formatToParts', (date: DateArg) =>
-    januarizeParts(originalFormatToParts(date))
-  );
-
-  // formatRange / formatRangeToParts exist in modern engines only.
-  const ranged = dtf as Intl.DateTimeFormat & {
-    formatRange?: (start: Date | number, end: Date | number) => string;
-    formatRangeToParts?: (
-      start: Date | number,
-      end: Date | number
-    ) => Intl.DateTimeFormatPart[];
+// formatToParts is a plain method; januarize its month part for de-AT instances.
+const wrapFormatToParts = (): void => {
+  const original = dtfProto.formatToParts;
+  dtfProto.formatToParts = function (
+    this: Intl.DateTimeFormat,
+    date?: Date | number
+  ) {
+    const parts = original.call(this, date);
+    return localeIsDeAt(this.resolvedOptions().locale)
+      ? januarizeMonthParts(parts)
+      : parts;
   };
-  if (typeof ranged.formatRange === 'function') {
-    const original = ranged.formatRange.bind(dtf);
-    define(dtf, 'formatRange', (start: Date | number, end: Date | number) =>
-      januarize(original(start, end))
-    );
-  }
-  if (typeof ranged.formatRangeToParts === 'function') {
-    const original = ranged.formatRangeToParts.bind(dtf);
-    define(
-      dtf,
-      'formatRangeToParts',
-      (start: Date | number, end: Date | number) =>
-        januarizeParts(original(start, end))
-    );
-  }
-};
-
-const patchDateTimeFormatConstructor = (): void => {
-  const Original = Intl.DateTimeFormat;
-  if ((Original as unknown as Record<string, unknown>)[PATCHED]) return;
-
-  // Kept as a plain function while we set up prototype/statics (the constructor
-  // type's `prototype` is read-only); cast to the constructor type at the end.
-  // Called only via `new` (incl. `new (Intl.DateTimeFormat).bind.apply(...)` as
-  // @formatjs does); returning an object makes `new` yield it.
-  const Patched = function (
-    locales?: string | string[],
-    options?: Intl.DateTimeFormatOptions
-  ): Intl.DateTimeFormat {
-    const dtf = new Original(locales, options);
-    if (isDeAt(dtf)) wrapInstance(dtf);
-    return dtf;
-  };
-
-  Patched.prototype = Original.prototype;
-  const patched = Patched as unknown as typeof Intl.DateTimeFormat &
-    Record<string, unknown>;
-  patched.supportedLocalesOf = Original.supportedLocalesOf.bind(Original);
-  patched[PATCHED] = true;
-
-  Intl.DateTimeFormat = patched;
 };
 
 // Date#toLocaleDateString / #toLocaleString use the %DateTimeFormat% intrinsic
-// directly, not the global we patched above, so wrap them too. januarize is
-// applied unconditionally — safe because "Jän" (the prefix it keys on) only
-// occurs for de-AT January.
-const patchDatePrototype = (): void => {
-  const proto = Date.prototype;
-  (['toLocaleDateString', 'toLocaleString'] as const).forEach((name) => {
-    const original = proto[name];
-    if ((original as unknown as Record<string, unknown>)[PATCHED]) return;
+// directly (not the prototype above), so wrap them too. There's no formatter
+// instance, so gate on the requested `locales` argument.
+type ToLocaleFn = (
+  locales?: string | string[],
+  options?: Intl.DateTimeFormatOptions
+) => string;
 
-    const wrapped = function (
-      this: Date,
-      locales?: string | string[],
-      options?: Intl.DateTimeFormatOptions
-    ): string {
-      return januarize(original.call(this, locales, options));
-    };
-    (wrapped as unknown as Record<string, unknown>)[PATCHED] = true;
-    proto[name] = wrapped;
-  });
+const wrapDateMethod = (
+  name: 'toLocaleDateString' | 'toLocaleString'
+): void => {
+  const holder = Date.prototype as unknown as Record<string, ToLocaleFn>;
+  const original = holder[name];
+  holder[name] = function (this: Date, locales, options) {
+    const result = original.call(this, locales, options);
+    const requested = Array.isArray(locales)
+      ? locales
+      : locales
+      ? [locales]
+      : [];
+    return requested.some(localeIsDeAt) ? januarize(result) : result;
+  };
 };
 
-patchDateTimeFormatConstructor();
-patchDatePrototype();
+const MARKER = '__deAtJanuarPatched';
+
+// Guard so re-importing within the same realm (e.g. Jest test files sharing the
+// global Intl) doesn't wrap twice.
+if (!Object.prototype.hasOwnProperty.call(dtfProto, MARKER)) {
+  Object.defineProperty(dtfProto, MARKER, { value: true });
+
+  wrapFormatGetter();
+  wrapFormatToParts();
+  wrapDateMethod('toLocaleDateString');
+  wrapDateMethod('toLocaleString');
+}

--- a/front/app/utils/patchIntlDeAtJanuary.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.ts
@@ -118,7 +118,8 @@ const patchDateTimeFormatConstructor = (): void => {
 
 // Date#toLocaleDateString / #toLocaleString use the %DateTimeFormat% intrinsic
 // directly, not the global we patched above, so wrap them too. januarize is
-// applied unconditionally — safe because "Jänner" only occurs for de-AT.
+// applied unconditionally — safe because "Jän" (the prefix it keys on) only
+// occurs for de-AT January.
 const patchDatePrototype = (): void => {
   const proto = Date.prototype;
   (['toLocaleDateString', 'toLocaleString'] as const).forEach((name) => {

--- a/front/app/utils/patchIntlDeAtJanuary.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.ts
@@ -1,0 +1,135 @@
+/**
+ * Overrides the Austrian German (de-AT) wide month name "Jänner" with "Januar"
+ * wherever it is produced by the platform's native `Intl` API.
+ *
+ * This is the counterpart to the date-fns (`i18n/de-AT.ts`) and moment
+ * (`patchMomentDeAtJanuary.ts`) overrides. react-intl's `formatDate` /
+ * `<FormattedDate>` — and any raw `new Intl.DateTimeFormat(...)` or
+ * `Date#toLocale*` call — delegate to the browser's CLDR data, where de-AT
+ * January is "Jänner". @formatjs reads the global `Intl.DateTimeFormat` at
+ * format time, so wrapping the constructor here (plus the `Date#toLocale*`
+ * helpers, which use the intrinsic directly) catches every native-Intl path.
+ *
+ * Only the exact wide form "Jänner" is rewritten (abbreviated "Jän" is left as
+ * is, matching the date-fns/moment overrides). Because "Jänner" is unique to
+ * de-AT January, the rewrite is a safe no-op for every other locale.
+ *
+ * Imported for side effects at the very top of `root.tsx` so it runs before the
+ * first date is formatted. Idempotent.
+ */
+
+const JAENNER = 'Jänner';
+const JANUAR = 'Januar';
+const PATCHED = '__deAtJanuarPatched';
+
+type DateArg = Date | number | undefined;
+
+const januarize = (value: string): string =>
+  value.includes(JAENNER) ? value.split(JAENNER).join(JANUAR) : value;
+
+const januarizeParts = (
+  parts: Intl.DateTimeFormatPart[]
+): Intl.DateTimeFormatPart[] =>
+  parts.map((part) =>
+    part.type === 'month' ? { ...part, value: januarize(part.value) } : part
+  );
+
+const isDeAt = (dtf: Intl.DateTimeFormat): boolean =>
+  dtf.resolvedOptions().locale.toLowerCase().startsWith('de-at');
+
+// Replace an instance method with `wrapped`. `format` is an inherited accessor
+// (getter, no setter), so a plain assignment throws in strict mode — define an
+// own data property instead.
+const define = (
+  target: object,
+  name: string,
+  wrapped: (...args: never[]) => unknown
+): void => {
+  Object.defineProperty(target, name, {
+    value: wrapped,
+    configurable: true,
+    writable: true,
+  });
+};
+
+const wrapInstance = (dtf: Intl.DateTimeFormat): void => {
+  const originalFormat = dtf.format.bind(dtf);
+  define(dtf, 'format', (date: DateArg) => januarize(originalFormat(date)));
+
+  const originalFormatToParts = dtf.formatToParts.bind(dtf);
+  define(dtf, 'formatToParts', (date: DateArg) =>
+    januarizeParts(originalFormatToParts(date))
+  );
+
+  // formatRange / formatRangeToParts exist in modern engines only.
+  const ranged = dtf as Intl.DateTimeFormat & {
+    formatRange?: (start: Date | number, end: Date | number) => string;
+    formatRangeToParts?: (
+      start: Date | number,
+      end: Date | number
+    ) => Intl.DateTimeFormatPart[];
+  };
+  if (typeof ranged.formatRange === 'function') {
+    const original = ranged.formatRange.bind(dtf);
+    define(dtf, 'formatRange', (start: Date | number, end: Date | number) =>
+      januarize(original(start, end))
+    );
+  }
+  if (typeof ranged.formatRangeToParts === 'function') {
+    const original = ranged.formatRangeToParts.bind(dtf);
+    define(
+      dtf,
+      'formatRangeToParts',
+      (start: Date | number, end: Date | number) =>
+        januarizeParts(original(start, end))
+    );
+  }
+};
+
+const patchDateTimeFormatConstructor = (): void => {
+  const Original = Intl.DateTimeFormat;
+  if ((Original as unknown as Record<string, unknown>)[PATCHED]) return;
+
+  const Patched = function (
+    locales?: string | string[],
+    options?: Intl.DateTimeFormatOptions
+  ): Intl.DateTimeFormat {
+    const dtf = new Original(locales, options);
+    if (isDeAt(dtf)) wrapInstance(dtf);
+    return dtf;
+    // Called only via `new` (incl. `new (Intl.DateTimeFormat).bind.apply(...)`
+    // as @formatjs does); returning an object makes `new` yield it.
+    // The signature intentionally differs from the constructor type, hence the
+    // cast at the assignment below.
+  } as unknown as typeof Intl.DateTimeFormat;
+
+  Patched.prototype = Original.prototype;
+  Patched.supportedLocalesOf = Original.supportedLocalesOf.bind(Original);
+  (Patched as unknown as Record<string, unknown>)[PATCHED] = true;
+
+  Intl.DateTimeFormat = Patched;
+};
+
+// Date#toLocaleDateString / #toLocaleString use the %DateTimeFormat% intrinsic
+// directly, not the global we patched above, so wrap them too. januarize is
+// applied unconditionally — safe because "Jänner" only occurs for de-AT.
+const patchDatePrototype = (): void => {
+  const proto = Date.prototype;
+  (['toLocaleDateString', 'toLocaleString'] as const).forEach((name) => {
+    const original = proto[name];
+    if ((original as unknown as Record<string, unknown>)[PATCHED]) return;
+
+    const wrapped = function (
+      this: Date,
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions
+    ): string {
+      return januarize(original.call(this, locales, options));
+    };
+    (wrapped as unknown as Record<string, unknown>)[PATCHED] = true;
+    proto[name] = wrapped;
+  });
+};
+
+patchDateTimeFormatConstructor();
+patchDatePrototype();

--- a/front/app/utils/patchIntlDeAtJanuary.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.ts
@@ -1,31 +1,35 @@
 /**
- * Overrides the Austrian German (de-AT) wide month name "Jänner" with "Januar"
- * wherever it is produced by the platform's native `Intl` API.
+ * Overrides the Austrian German (de-AT) January month name — "Jänner" (wide)
+ * and "Jän" (short) — with "Januar" / "Jan" wherever it is produced by the
+ * platform's native `Intl` API.
  *
  * This is the counterpart to the date-fns (`i18n/de-AT.ts`) and moment
  * (`patchMomentDeAtJanuary.ts`) overrides. react-intl's `formatDate` /
  * `<FormattedDate>` — and any raw `new Intl.DateTimeFormat(...)` or
  * `Date#toLocale*` call — delegate to the browser's CLDR data, where de-AT
- * January is "Jänner". @formatjs reads the global `Intl.DateTimeFormat` at
+ * January is "Jänner"/"Jän". @formatjs reads the global `Intl.DateTimeFormat` at
  * format time, so wrapping the constructor here (plus the `Date#toLocale*`
  * helpers, which use the intrinsic directly) catches every native-Intl path.
  *
- * Only the exact wide form "Jänner" is rewritten (abbreviated "Jän" is left as
- * is, matching the date-fns/moment overrides). Because "Jänner" is unique to
- * de-AT January, the rewrite is a safe no-op for every other locale.
+ * Because "Jän" is unique to de-AT January, the rewrite is a safe no-op for
+ * every other locale. The narrow form ("J") is left untouched.
  *
  * Imported for side effects at the very top of `root.tsx` so it runs before the
  * first date is formatted. Idempotent.
  */
 
-const JAENNER = 'Jänner';
-const JANUAR = 'Januar';
+const JAEN = 'Jän'; // prefix shared by both "Jänner" (wide) and "Jän" (short)
 const PATCHED = '__deAtJanuarPatched';
 
 type DateArg = Date | number | undefined;
 
+// Rewrite the wide form first ("Jänner" -> "Januar"), then the short form
+// ("Jän" -> "Jan"). Order matters: "Jän" is a prefix of "Jänner", so the wide
+// replacement must run before the short one (after it, "Januar" has no "Jän").
 const januarize = (value: string): string =>
-  value.includes(JAENNER) ? value.split(JAENNER).join(JANUAR) : value;
+  value.includes(JAEN)
+    ? value.split('Jänner').join('Januar').split('Jän').join('Jan')
+    : value;
 
 const januarizeParts = (
   parts: Intl.DateTimeFormatPart[]

--- a/front/app/utils/patchIntlDeAtJanuary.ts
+++ b/front/app/utils/patchIntlDeAtJanuary.ts
@@ -90,6 +90,10 @@ const patchDateTimeFormatConstructor = (): void => {
   const Original = Intl.DateTimeFormat;
   if ((Original as unknown as Record<string, unknown>)[PATCHED]) return;
 
+  // Kept as a plain function while we set up prototype/statics (the constructor
+  // type's `prototype` is read-only); cast to the constructor type at the end.
+  // Called only via `new` (incl. `new (Intl.DateTimeFormat).bind.apply(...)` as
+  // @formatjs does); returning an object makes `new` yield it.
   const Patched = function (
     locales?: string | string[],
     options?: Intl.DateTimeFormatOptions
@@ -97,17 +101,15 @@ const patchDateTimeFormatConstructor = (): void => {
     const dtf = new Original(locales, options);
     if (isDeAt(dtf)) wrapInstance(dtf);
     return dtf;
-    // Called only via `new` (incl. `new (Intl.DateTimeFormat).bind.apply(...)`
-    // as @formatjs does); returning an object makes `new` yield it.
-    // The signature intentionally differs from the constructor type, hence the
-    // cast at the assignment below.
-  } as unknown as typeof Intl.DateTimeFormat;
+  };
 
   Patched.prototype = Original.prototype;
-  Patched.supportedLocalesOf = Original.supportedLocalesOf.bind(Original);
-  (Patched as unknown as Record<string, unknown>)[PATCHED] = true;
+  const patched = Patched as unknown as typeof Intl.DateTimeFormat &
+    Record<string, unknown>;
+  patched.supportedLocalesOf = Original.supportedLocalesOf.bind(Original);
+  patched[PATCHED] = true;
 
-  Intl.DateTimeFormat = Patched;
+  Intl.DateTimeFormat = patched;
 };
 
 // Date#toLocaleDateString / #toLocaleString use the %DateTimeFormat% intrinsic

--- a/front/app/utils/patchMomentDeAtJanuary.test.ts
+++ b/front/app/utils/patchMomentDeAtJanuary.test.ts
@@ -1,0 +1,32 @@
+import moment from 'moment-timezone';
+
+import patchMomentDeAtJanuary from './patchMomentDeAtJanuary';
+
+describe('patchMomentDeAtJanuary', () => {
+  beforeAll(() => {
+    // Load moment's built-in de-at locale (normally loaded lazily in App).
+    require('moment/locale/de-at');
+    patchMomentDeAtJanuary();
+  });
+
+  const january = () => moment(new Date(2026, 0, 5, 14, 30)).locale('de-at');
+
+  it('renders January as "Januar" instead of moment\'s default "Jänner"', () => {
+    expect(january().format('MMMM')).toBe('Januar');
+    expect(january().format('LLL')).toBe('5. Januar 2026 14:30');
+    expect(january().format('MMMM')).not.toBe('Jänner');
+  });
+
+  it('leaves other months and the abbreviated January untouched', () => {
+    expect(moment(new Date(2026, 1, 1)).locale('de-at').format('MMMM')).toBe(
+      'Februar'
+    );
+    expect(january().format('MMM')).toBe('Jän.');
+  });
+
+  it('does not leave the global locale changed as a side effect', () => {
+    moment.locale('en');
+    patchMomentDeAtJanuary();
+    expect(moment.locale()).toBe('en');
+  });
+});

--- a/front/app/utils/patchMomentDeAtJanuary.test.ts
+++ b/front/app/utils/patchMomentDeAtJanuary.test.ts
@@ -17,11 +17,17 @@ describe('patchMomentDeAtJanuary', () => {
     expect(january().format('MMMM')).not.toBe('Jänner');
   });
 
-  it('leaves other months and the abbreviated January untouched', () => {
+  it('renders the abbreviated January as "Jan." instead of "Jän."', () => {
+    expect(january().format('MMM')).toBe('Jan.');
+  });
+
+  it('leaves other months untouched', () => {
     expect(moment(new Date(2026, 1, 1)).locale('de-at').format('MMMM')).toBe(
       'Februar'
     );
-    expect(january().format('MMM')).toBe('Jän.');
+    expect(moment(new Date(2026, 1, 1)).locale('de-at').format('MMM')).toBe(
+      'Feb.'
+    );
   });
 
   it('does not leave the global locale changed as a side effect', () => {

--- a/front/app/utils/patchMomentDeAtJanuary.ts
+++ b/front/app/utils/patchMomentDeAtJanuary.ts
@@ -1,22 +1,26 @@
 import moment from 'moment-timezone';
 
 /**
- * moment's built-in `de-at` locale renders January as "Jänner"; we display
- * "Januar" for de-AT instead. This mirrors the date-fns override in
- * `i18n/de-AT.ts` so both date libraries agree on the month name.
+ * moment's built-in `de-at` locale renders January as "Jänner" (wide) / "Jän."
+ * (short); we display "Januar" / "Jan." for de-AT instead. This mirrors the
+ * date-fns override in `i18n/de-AT.ts` so both date libraries agree on the month
+ * name.
  *
  * Must be called *after* moment's `de-at` locale file has been loaded (its
  * definition is what we merge the override onto). It is idempotent and a no-op
  * if the locale isn't loaded or has already been patched.
  */
 export default function patchMomentDeAtJanuary(): void {
-  const months = [...moment.localeData('de-at').months()];
-  if (months[0] !== 'Jänner') return;
+  const data = moment.localeData('de-at');
+  const months = [...data.months()];
+  const monthsShort = [...data.monthsShort()];
+  if (months[0] !== 'Jänner' && monthsShort[0] !== 'Jän.') return;
 
   months[0] = 'Januar';
+  monthsShort[0] = 'Jan.';
   // `updateLocale` switches moment's global locale to 'de-at' as a side effect,
   // so capture the current one and restore it afterwards.
   const currentLocale = moment.locale();
-  moment.updateLocale('de-at', { months });
+  moment.updateLocale('de-at', { months, monthsShort });
   moment.locale(currentLocale);
 }

--- a/front/app/utils/patchMomentDeAtJanuary.ts
+++ b/front/app/utils/patchMomentDeAtJanuary.ts
@@ -1,0 +1,22 @@
+import moment from 'moment-timezone';
+
+/**
+ * moment's built-in `de-at` locale renders January as "Jänner"; we display
+ * "Januar" for de-AT instead. This mirrors the date-fns override in
+ * `i18n/de-AT.ts` so both date libraries agree on the month name.
+ *
+ * Must be called *after* moment's `de-at` locale file has been loaded (its
+ * definition is what we merge the override onto). It is idempotent and a no-op
+ * if the locale isn't loaded or has already been patched.
+ */
+export default function patchMomentDeAtJanuary(): void {
+  const months = [...moment.localeData('de-at').months()];
+  if (months[0] !== 'Jänner') return;
+
+  months[0] = 'Januar';
+  // `updateLocale` switches moment's global locale to 'de-at' as a side effect,
+  // so capture the current one and restore it afterwards.
+  const currentLocale = moment.locale();
+  moment.updateLocale('de-at', { months });
+  moment.locale(currentLocale);
+}


### PR DESCRIPTION
Overrides the short and long forms of the month "Jänner/Jän" in de-AT, provided via 4 libraries, to be "Januar/Jan".

Sometimes the short form override is "Jan." and sometimes it is "Jan", in line with the format(s) used by each library for short de-AT months.

The 4 libraries we are overriding are:
1. date-fns
2. moment
3. react-intl/formatjs
4. rails-i18n

We use the long form from all 4 libraries at some place(s) in our app, The short form is only currently used from `moment` and `rails-i18n`, but it seemed wise to also defensively override this in the values from the other 2 libraries.

Includes unit tests (mainly to catch regression). I considered adding e2e test(s), but this seemed a heavy-handed approach for such an issue (enabling de-AT tenant-wide just to assert these overrides seems disproportionate).

Screenshots:
Date-picker in de-AT (uses `date-fns`):
<img width="730" height="645" alt="Screenshot 2026-07-01 at 09 36 54" src="https://github.com/user-attachments/assets/813139d1-008c-4b19-a548-f2e582c8282b" />

Event in de-AT, short and long month forms (uses `moment`):
<img width="437" height="459" alt="Screenshot 2026-07-01 at 11 50 54" src="https://github.com/user-attachments/assets/e8f7ccf8-fd22-4644-a8fc-d914b5e8e234" />

Phase dates in FO in de-AT (uses `moment`):
<img width="1325" height="728" alt="Screenshot 2026-07-01 at 10 23 39" src="https://github.com/user-attachments/assets/50f8511a-ec1a-4d6d-be91-a40d644124ca" />

Idea `published_at`, in BO idea show in de-AT (uses `react-intl/formatjs`):
<img width="1023" height="358" alt="Screenshot 2026-07-01 at 11 08 02" src="https://github.com/user-attachments/assets/28489de9-025f-4708-b344-587e1e96118d" />

Email subject line (long form of month) in mail preview in de-AT (uses `rails-i18n`):
<img width="648" height="193" alt="Screenshot 2026-07-01 at 11 17 22" src="https://github.com/user-attachments/assets/0bde8ed3-2cb4-485c-ab1e-0c72ab25218c" />

Email body of event registration mail preview (short form of month) in de-AT (uses `rails-i18n`):
<img width="662" height="251" alt="Screenshot 2026-07-01 at 12 14 30" src="https://github.com/user-attachments/assets/8db2c8ea-b309-4916-92b4-de6201f3a35b" />



# Changelog
## Added
- [TAN-8045] Override 'Jänner/Jän' for de-AT with 'Januar/Jan'
