### PR TITLE
Migrate native survey phases submission disabled -> enabled

### DIFF
--- a/back/db/migrate/20260701113056_enable_submission_for_native_survey_phases.rb
+++ b/back/db/migrate/20260701113056_enable_submission_for_native_survey_phases.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# The UI toggle to disable submissions on native survey phases was removed, so
+# existing phases that were left disabled can no longer be re-enabled. Native
+# surveys must always accept submissions, so backfill any that are still off.
+# (Community monitor surveys intentionally keep submission_enabled = false and
+# use a different participation method, so they are not affected.)
+class EnableSubmissionForNativeSurveyPhases < ActiveRecord::Migration[7.2]
+  def up
+    # Strong Migrations can't inspect raw SQL; this is a plain conditional data
+    # backfill on one column, so it is safe.
+    safety_assured do
+      execute <<~SQL.squish
+        UPDATE phases
+        SET submission_enabled = true
+        WHERE participation_method = 'native_survey'
+          AND submission_enabled IS NOT TRUE
+      SQL
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -8841,6 +8841,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260701113056'),
 ('20260617120000'),
 ('20260617090200'),
 ('20260617090100'),


### PR DESCRIPTION
Migration for native survey phases after "accepting submissions" toggle removed, to make sure native survey phases have submission enabled (not disabled).