### PR TITLE
[Tan-8073] Preferred username with france connect

### DIFF
--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
@@ -35,7 +35,7 @@ module CustomIdMethods::Franceconnect
       {
         first_name: auth.info['first_name'],
         email: auth.info['email'],
-        last_name: auth.info['last_name']&.titleize, # FC returns last names in ALL CAPITALS
+        last_name: auth.extra.raw_info.preferred_username.presence&.titleize || auth.info['last_name']&.titleize, # FC returns preferred usernames && last names in ALL CAPITALS
         locale: AppConfiguration.instance.closest_locale_to('fr-FR'),
         remote_avatar_url: auth.info['image']
       }.tap do |attrs|
@@ -54,7 +54,7 @@ module CustomIdMethods::Franceconnect
     def omniauth_setup(configuration, env)
       return unless Verification::VerificationService.new.active?(configuration, name)
 
-      scope = %w[openid] + (config[:scope] || %w[email given_name family_name])
+      scope = %w[openid] + (config[:scope] || %w[email given_name family_name preferred_username])
 
       if version == 'v2'
         env['omniauth.strategy'].options.merge!(

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
@@ -54,7 +54,7 @@ module CustomIdMethods::Franceconnect
     def omniauth_setup(configuration, env)
       return unless Verification::VerificationService.new.active?(configuration, name)
 
-      scope = %w[openid] + (config[:scope] || %w[email given_name family_name preferred_username])
+      scope = %w[openid] + (config[:scope] || %w[email given_name family_name])
 
       if version == 'v2'
         env['omniauth.strategy'].options.merge!(

--- a/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
@@ -58,7 +58,7 @@ context 'franceconnect verification' do
           version: 'v2',
           identifier: 'fakeid',
           secret: 'fakesecret',
-          scope: %w[given_name family_name email]
+          scope: %w[given_name family_name email preferred_username]
         }
       ]
     }

--- a/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
@@ -71,49 +71,104 @@ context 'franceconnect verification' do
     allow_any_instance_of(User).to receive(:validate_email_domain_blacklist)
   end
 
-  it 'successfully authenticates and verifies a new user' do
-    get '/auth/franceconnect?random-passthrough-param=somevalue'
-    follow_redirect!
+  context "when the user has no preferred_username" do
+    it 'successfully authenticates and verifies a new user' do
+      get '/auth/franceconnect?random-passthrough-param=somevalue'
+      follow_redirect!
 
-    expect(response).to redirect_to('/fr-FR/?random-passthrough-param=somevalue&sso_flow=signup&sso_success=true')
+      expect(response).to redirect_to('/fr-FR/?random-passthrough-param=somevalue&sso_flow=signup&sso_success=true')
 
-    user = User.find_by(email: 'wossewodda-3728@yopmail.com')
+      user = User.find_by(email: 'wossewodda-3728@yopmail.com')
 
-    expect(user).to have_attributes({
-      verified: true,
-      first_name: 'Angela Claire Louise',
-      last_name: 'Dubois'
-    })
-    expect(user.identities.first).to have_attributes({
-      provider: 'franceconnect',
-      user_id: user.id
-    })
-    expect(user.verifications.first).to have_attributes({
-      method_name: 'franceconnect',
-      user_id: user.id,
-      active: true,
-      hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
-    })
-    expect(cookies[:cl2_jwt]).to be_present
+      expect(user).to have_attributes({
+        verified: true,
+        first_name: 'Angela Claire Louise',
+        last_name: 'Dubois'
+      })
+      expect(user.identities.first).to have_attributes({
+        provider: 'franceconnect',
+        user_id: user.id
+      })
+      expect(user.verifications.first).to have_attributes({
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true,
+        hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
+      })
+      expect(cookies[:cl2_jwt]).to be_present
+    end
+
+
+    it 'successfully verifies an existing user' do
+      user = create(:user, first_name: 'Jean', last_name: 'Dupont')
+      token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
+      get "/auth/franceconnect?sso_verification=true&token=#{token}&random-passthrough-param=somevalue&verification_pathname=/yipie"
+      follow_redirect!
+
+      expect(response).to redirect_to('/en/yipie?sso_verification=true&random-passthrough-param=somevalue&verification_success=true')
+      expect(user.reload).to have_attributes({
+        verified: true,
+        first_name: 'Angela Claire Louise',
+        last_name: 'Dubois'
+      })
+      expect(user.verifications.first).to have_attributes({
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true
+      })
+    end
   end
 
-  it 'successfully verifies an existing user' do
-    user = create(:user, first_name: 'Jean', last_name: 'Dupont')
-    token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
-    get "/auth/franceconnect?sso_verification=true&token=#{token}&random-passthrough-param=somevalue&verification_pathname=/yipie"
-    follow_redirect!
+  context "when the user has a preferred_username" do
+    let(:auth_hash) do
+      super().tap { |h| h['extra']['raw_info']['preferred_username'] = 'DUPUIS' }
+    end
 
-    expect(response).to redirect_to('/en/yipie?sso_verification=true&random-passthrough-param=somevalue&verification_success=true')
-    expect(user.reload).to have_attributes({
-      verified: true,
-      first_name: 'Angela Claire Louise',
-      last_name: 'Dubois'
-    })
-    expect(user.verifications.first).to have_attributes({
-      method_name: 'franceconnect',
-      user_id: user.id,
-      active: true
-    })
+    it 'successfully authenticates and verifies a new user' do
+      get '/auth/franceconnect?random-passthrough-param=somevalue'
+      follow_redirect!
+
+      expect(response).to redirect_to('/fr-FR/?random-passthrough-param=somevalue&sso_flow=signup&sso_success=true')
+
+      user = User.find_by(email: 'wossewodda-3728@yopmail.com')
+
+      expect(user).to have_attributes({
+        verified: true,
+        first_name: 'Angela Claire Louise',
+        last_name: 'Dupuis'
+      })
+      expect(user.identities.first).to have_attributes({
+       provider: 'franceconnect',
+       user_id: user.id
+     })
+      expect(user.verifications.first).to have_attributes({
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true,
+        hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
+      })
+      expect(cookies[:cl2_jwt]).to be_present
+    end
+
+
+    it 'successfully verifies an existing user' do
+      user = create(:user, first_name: 'Jean', last_name: 'Dupont')
+      token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
+      get "/auth/franceconnect?sso_verification=true&token=#{token}&random-passthrough-param=somevalue&verification_pathname=/yipie"
+      follow_redirect!
+
+      expect(response).to redirect_to('/en/yipie?sso_verification=true&random-passthrough-param=somevalue&verification_success=true')
+      expect(user.reload).to have_attributes({
+         verified: true,
+         first_name: 'Angela Claire Louise',
+         last_name: 'Dupuis'
+       })
+      expect(user.verifications.first).to have_attributes({
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true
+      })
+    end
   end
 
   it 'successfully authenticates a user that was previously authenticated and updates the auth_hash' do
@@ -126,7 +181,7 @@ context 'franceconnect verification' do
     })
     expect(user.identities.first.auth_hash['info']['gender']).to eq 'female'
 
-    # Change the auth hash so we can check that is is updated
+    # Change the auth hash so we can check that it is updated
     auth_hash['info']['gender'] = 'male'
     OmniAuth.config.mock_auth[:franceconnect] = OmniAuth::AuthHash.new(auth_hash)
 

--- a/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
@@ -139,12 +139,12 @@ context 'franceconnect verification' do
       expect(user.identities.first).to have_attributes({
         provider: 'franceconnect',
         user_id: user.id
-     })
+      })
       expect(user.verifications.first).to have_attributes({
-         method_name: 'franceconnect',
-         user_id: user.id,
-         active: true,
-         hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true,
+        hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
       })
       expect(cookies[:cl2_jwt]).to be_present
     end
@@ -157,14 +157,14 @@ context 'franceconnect verification' do
 
       expect(response).to redirect_to('/en/yipie?sso_verification=true&random-passthrough-param=somevalue&verification_success=true')
       expect(user.reload).to have_attributes({
-         verified: true,
-         first_name: 'Angela Claire Louise',
-         last_name: 'Dupuis'
-       })
+        verified: true,
+        first_name: 'Angela Claire Louise',
+        last_name: 'Dupuis'
+      })
       expect(user.verifications.first).to have_attributes({
-         method_name: 'franceconnect',
-         user_id: user.id,
-         active: true
+        method_name: 'franceconnect',
+        user_id: user.id,
+        active: true
       })
     end
   end

--- a/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/requests/franceconnect_verification_spec.rb
@@ -71,7 +71,7 @@ context 'franceconnect verification' do
     allow_any_instance_of(User).to receive(:validate_email_domain_blacklist)
   end
 
-  context "when the user has no preferred_username" do
+  context 'when the user has no preferred_username' do
     it 'successfully authenticates and verifies a new user' do
       get '/auth/franceconnect?random-passthrough-param=somevalue'
       follow_redirect!
@@ -98,7 +98,6 @@ context 'franceconnect verification' do
       expect(cookies[:cl2_jwt]).to be_present
     end
 
-
     it 'successfully verifies an existing user' do
       user = create(:user, first_name: 'Jean', last_name: 'Dupont')
       token = AuthToken::AuthToken.new(payload: user.to_token_payload).token
@@ -119,7 +118,7 @@ context 'franceconnect verification' do
     end
   end
 
-  context "when the user has a preferred_username" do
+  context 'when the user has a preferred_username' do
     let(:auth_hash) do
       super().tap { |h| h['extra']['raw_info']['preferred_username'] = 'DUPUIS' }
     end
@@ -138,18 +137,17 @@ context 'franceconnect verification' do
         last_name: 'Dupuis'
       })
       expect(user.identities.first).to have_attributes({
-       provider: 'franceconnect',
-       user_id: user.id
+        provider: 'franceconnect',
+        user_id: user.id
      })
       expect(user.verifications.first).to have_attributes({
-        method_name: 'franceconnect',
-        user_id: user.id,
-        active: true,
-        hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
+         method_name: 'franceconnect',
+         user_id: user.id,
+         active: true,
+         hashed_uid: '84d610ebae19b5e09aa5621e006746c4cd568bec352e1d98d48643e6765a82e7'
       })
       expect(cookies[:cl2_jwt]).to be_present
     end
-
 
     it 'successfully verifies an existing user' do
       user = create(:user, first_name: 'Jean', last_name: 'Dupont')
@@ -164,9 +162,9 @@ context 'franceconnect verification' do
          last_name: 'Dupuis'
        })
       expect(user.verifications.first).to have_attributes({
-        method_name: 'franceconnect',
-        user_id: user.id,
-        active: true
+         method_name: 'franceconnect',
+         user_id: user.id,
+         active: true
       })
     end
   end


### PR DESCRIPTION
# Changelog
## Fixed
- FranceConnect takes into account the preferred_username as last_name if provided 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
