### PR TITLE
[TAN-8089] Improve audit of 'lost' admin_publications

### DIFF
--- a/back/app/jobs/report_orphaned_admin_publications_job.rb
+++ b/back/app/jobs/report_orphaned_admin_publications_job.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Forwards rows captured by the admin_publication deletion-audit trigger
+# (see migration 20260703120000_create_admin_publication_deletion_audit) to
+# Sentry, so a capture becomes an alert instead of sitting unnoticed in a
+# per-tenant table.
+#
+# Idempotent: only unreported rows are pushed, and each is stamped with
+# `reported_at` once forwarded, so re-runs never double-report. A missed run is
+# simply picked up by the next one. Meant to be invoked periodically (e.g. the
+# `admin_publications:report_orphans` rake task, from the infra scheduler).
+class ReportOrphanedAdminPublicationsJob < ApplicationJob
+  self.priority = 70 # low priority: diagnostics, never user-facing
+
+  def perform
+    Tenant.safe_switch_each do |tenant|
+      report_tenant(tenant)
+    end
+  end
+
+  private
+
+  def report_tenant(tenant)
+    # The table exists in every schema after the migration; guard anyway so a
+    # single odd schema can't abort the whole sweep.
+    return unless AdminPublicationDeletionAudit.table_exists?
+
+    AdminPublicationDeletionAudit.unreported.find_each do |audit|
+      ErrorReporter.report_msg(
+        "Orphaned admin_publication captured on #{tenant.host}: " \
+        "#{audit.publication_type} #{audit.publication_id} lost its admin_publication",
+        extra: audit_context(tenant, audit)
+      )
+      audit.update_column(:reported_at, Time.current)
+    end
+  rescue StandardError => e
+    # One bad tenant must not stop the sweep across the others.
+    ErrorReporter.report(e)
+  end
+
+  def audit_context(tenant, audit)
+    {
+      tenant_host: tenant.host,
+      tenant_schema: audit.tenant_schema,
+      audit_id: audit.id,
+      admin_publication_id: audit.admin_publication_id,
+      publication_id: audit.publication_id,
+      publication_type: audit.publication_type,
+      parent_id: audit.parent_id,
+      was_in_folder: !audit.parent_id.nil?,
+      lft: audit.lft,
+      rgt: audit.rgt,
+      publication_status: audit.publication_status,
+      deleted_at: audit.deleted_at,
+      db_user: audit.db_user,
+      application_name: audit.application_name,
+      client_addr: audit.client_addr,
+      backend_pid: audit.backend_pid,
+      transaction_id: audit.transaction_id
+    }
+  end
+end

--- a/back/app/models/admin_publication_deletion_audit.rb
+++ b/back/app/models/admin_publication_deletion_audit.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: admin_publication_deletion_audits
+#
+#  id                   :uuid             not null, primary key
+#  tenant_schema        :string
+#  tenant_host          :string
+#  admin_publication_id :uuid             not null
+#  publication_id       :uuid
+#  publication_type     :string
+#  parent_id            :uuid
+#  lft                  :integer
+#  rgt                  :integer
+#  ordering             :integer
+#  publication_status   :string
+#  deleted_at           :datetime
+#  db_user              :string
+#  application_name     :string
+#  client_addr          :inet
+#  backend_pid          :integer
+#  transaction_id       :bigint
+#  query                :text
+#  reported_at          :datetime
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#
+class AdminPublicationDeletionAudit < ApplicationRecord
+  scope :recent, -> { order(deleted_at: :desc) }
+  scope :unreported, -> { where(reported_at: nil) }
+end

--- a/back/db/migrate/20260703120000_create_admin_publication_deletion_audit.rb
+++ b/back/db/migrate/20260703120000_create_admin_publication_deletion_audit.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+# Diagnostic instrumentation for orphaned admin_publications.
+#
+# We keep finding Project rows whose admin_publication row has been deleted
+# (Project.where.missing(:admin_publication)), with no code path in the repo
+# that produces it and nothing in the activity log. This captures the NEXT
+# occurrence at the database layer, so it catches deletions from ANY source,
+# including raw SQL / console / rake that bypasses ActiveRecord callbacks.
+#
+# The trigger is a DEFERRABLE constraint trigger: it runs at COMMIT, after the
+# whole transaction has settled, and only records a row when the deleted
+# admin_publication's publication (Project or Folder) STILL EXISTS. That
+# cleanly excludes legitimate cascades (Project#destroy / Folder#destroy, where
+# the publication is deleted in the same transaction) and records only true
+# orphaning.
+#
+# Audit-only: it never raises, so it cannot break any operation.
+class CreateAdminPublicationDeletionAudit < ActiveRecord::Migration[7.2]
+  def up
+    safety_assured do
+      create_table :admin_publication_deletion_audits, id: :uuid do |t|
+        t.string  :tenant_schema
+        t.string  :tenant_host
+        t.uuid    :admin_publication_id, null: false
+        t.uuid    :publication_id
+        t.string  :publication_type
+        t.uuid    :parent_id
+        t.integer :lft
+        t.integer :rgt
+        t.integer :ordering
+        t.string  :publication_status
+        t.datetime :deleted_at
+        t.string  :db_user
+        t.string  :application_name
+        t.column  :client_addr, :inet
+        t.integer :backend_pid
+        t.bigint  :transaction_id
+        t.text    :query
+        t.datetime :reported_at # set by the forwarder once pushed to Sentry
+        t.timestamps
+      end
+
+      execute <<~SQL
+        CREATE OR REPLACE FUNCTION log_orphaned_admin_publication() RETURNS trigger
+        LANGUAGE plpgsql AS $function$
+        DECLARE
+          publication_exists boolean := false;
+          pub_table text;
+        BEGIN
+          IF OLD.publication_type = 'Project' THEN
+            pub_table := 'projects';
+          ELSIF OLD.publication_type = 'ProjectFolders::Folder' THEN
+            pub_table := 'project_folders_folders';
+          ELSE
+            RETURN NULL;
+          END IF;
+
+          -- Resolve tables in the trigger's OWN schema, so the check is correct
+          -- regardless of the deleting session's search_path (raw SQL included).
+          EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I.%I WHERE id = $1)', TG_TABLE_SCHEMA, pub_table)
+            INTO publication_exists
+            USING OLD.publication_id;
+
+          -- Publication gone too => legitimate cascade. Only log real orphans.
+          IF NOT publication_exists THEN
+            RETURN NULL;
+          END IF;
+
+          EXECUTE format(
+            'INSERT INTO %I.admin_publication_deletion_audits
+               (id, tenant_schema, tenant_host, admin_publication_id, publication_id,
+                publication_type, parent_id, lft, rgt, ordering, publication_status,
+                deleted_at, db_user, application_name, client_addr, backend_pid,
+                transaction_id, query, created_at, updated_at)
+             VALUES (gen_random_uuid(), $9, $10, $1, $2, $3, $4, $5, $6, $7, $8,
+                     clock_timestamp(), current_user,
+                     current_setting(''application_name'', true), inet_client_addr(),
+                     pg_backend_pid(), txid_current(), current_query(),
+                     clock_timestamp(), clock_timestamp())',
+            TG_TABLE_SCHEMA)
+            USING OLD.id, OLD.publication_id, OLD.publication_type, OLD.parent_id,
+                  OLD.lft, OLD.rgt, OLD.ordering, OLD.publication_status,
+                  TG_TABLE_SCHEMA, replace(TG_TABLE_SCHEMA, '_', '.');
+
+          RETURN NULL;
+        EXCEPTION
+          WHEN OTHERS THEN
+            -- Auditing must never break a legitimate deletion. If anything in
+            -- this trigger fails (missing table in a schema, unexpected mismatch,
+            -- etc.), silently drop the audit and allow the delete to proceed.
+            RETURN NULL;
+        END;
+        $function$;
+      SQL
+
+      execute <<~SQL
+        CREATE CONSTRAINT TRIGGER audit_orphaned_admin_publication
+        AFTER DELETE ON admin_publications
+        DEFERRABLE INITIALLY DEFERRED
+        FOR EACH ROW
+        EXECUTE FUNCTION log_orphaned_admin_publication();
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute 'DROP TRIGGER IF EXISTS audit_orphaned_admin_publication ON admin_publications;'
+      execute 'DROP FUNCTION IF EXISTS log_orphaned_admin_publication();'
+      drop_table :admin_publication_deletion_audits
+    end
+  end
+end

--- a/back/db/migrate/20260703120000_create_admin_publication_deletion_audit.rb
+++ b/back/db/migrate/20260703120000_create_admin_publication_deletion_audit.rb
@@ -94,7 +94,7 @@ class CreateAdminPublicationDeletionAudit < ActiveRecord::Migration[7.2]
         $function$;
       SQL
 
-      execute <<~SQL
+      execute <<~SQL.squish
         CREATE CONSTRAINT TRIGGER audit_orphaned_admin_publication
         AFTER DELETE ON admin_publications
         DEFERRABLE INITIALLY DEFERRED

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -175,6 +175,7 @@ ALTER TABLE IF EXISTS ONLY public.claim_tokens DROP CONSTRAINT IF EXISTS fk_rail
 ALTER TABLE IF EXISTS ONLY public.analytics_dimension_locales_fact_visits DROP CONSTRAINT IF EXISTS fk_rails_00698f2e02;
 DROP TRIGGER IF EXISTS que_state_notify ON public.que_jobs;
 DROP TRIGGER IF EXISTS que_job_notify ON public.que_jobs;
+DROP TRIGGER IF EXISTS audit_orphaned_admin_publication ON public.admin_publications;
 DROP INDEX IF EXISTS public.users_unique_lower_email_idx;
 DROP INDEX IF EXISTS public.spam_reportable_index;
 DROP INDEX IF EXISTS public.report_builder_published_data_units_report_id_idx;
@@ -661,6 +662,7 @@ ALTER TABLE IF EXISTS ONLY public.analysis_background_tasks DROP CONSTRAINT IF E
 ALTER TABLE IF EXISTS ONLY public.analysis_analyses DROP CONSTRAINT IF EXISTS analysis_analyses_pkey;
 ALTER TABLE IF EXISTS ONLY public.analysis_additional_custom_fields DROP CONSTRAINT IF EXISTS analysis_analyses_custom_fields_pkey;
 ALTER TABLE IF EXISTS ONLY public.admin_publications DROP CONSTRAINT IF EXISTS admin_publications_pkey;
+ALTER TABLE IF EXISTS ONLY public.admin_publication_deletion_audits DROP CONSTRAINT IF EXISTS admin_publication_deletion_audits_pkey;
 ALTER TABLE IF EXISTS ONLY public.activities DROP CONSTRAINT IF EXISTS activities_pkey;
 ALTER TABLE IF EXISTS public.que_jobs ALTER COLUMN id DROP DEFAULT;
 DROP TABLE IF EXISTS public.wise_voice_flags;
@@ -816,10 +818,12 @@ DROP TABLE IF EXISTS public.analysis_background_tasks;
 DROP TABLE IF EXISTS public.analysis_analyses;
 DROP TABLE IF EXISTS public.analysis_additional_custom_fields;
 DROP TABLE IF EXISTS public.admin_publications;
+DROP TABLE IF EXISTS public.admin_publication_deletion_audits;
 DROP TABLE IF EXISTS public.activities;
 DROP FUNCTION IF EXISTS public.que_state_notify();
 DROP FUNCTION IF EXISTS public.que_job_notify();
 DROP FUNCTION IF EXISTS public.que_determine_job_state(job public.que_jobs);
+DROP FUNCTION IF EXISTS public.log_orphaned_admin_publication();
 DROP TABLE IF EXISTS public.que_jobs;
 DROP FUNCTION IF EXISTS public.que_validate_tags(tags_array jsonb);
 DROP EXTENSION IF EXISTS vector;
@@ -977,6 +981,63 @@ WITH (fillfactor='90');
 --
 
 COMMENT ON TABLE public.que_jobs IS '6';
+
+
+--
+-- Name: log_orphaned_admin_publication(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.log_orphaned_admin_publication() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $_$
+DECLARE
+  publication_exists boolean := false;
+  pub_table text;
+BEGIN
+  IF OLD.publication_type = 'Project' THEN
+    pub_table := 'projects';
+  ELSIF OLD.publication_type = 'ProjectFolders::Folder' THEN
+    pub_table := 'project_folders_folders';
+  ELSE
+    RETURN NULL;
+  END IF;
+
+  -- Resolve tables in the trigger's OWN schema, so the check is correct
+  -- regardless of the deleting session's search_path (raw SQL included).
+  EXECUTE format('SELECT EXISTS (SELECT 1 FROM %I.%I WHERE id = $1)', TG_TABLE_SCHEMA, pub_table)
+    INTO publication_exists
+    USING OLD.publication_id;
+
+  -- Publication gone too => legitimate cascade. Only log real orphans.
+  IF NOT publication_exists THEN
+    RETURN NULL;
+  END IF;
+
+  EXECUTE format(
+    'INSERT INTO %I.admin_publication_deletion_audits
+       (id, tenant_schema, tenant_host, admin_publication_id, publication_id,
+        publication_type, parent_id, lft, rgt, ordering, publication_status,
+        deleted_at, db_user, application_name, client_addr, backend_pid,
+        transaction_id, query, created_at, updated_at)
+     VALUES (gen_random_uuid(), $9, $10, $1, $2, $3, $4, $5, $6, $7, $8,
+             clock_timestamp(), current_user,
+             current_setting(''application_name'', true), inet_client_addr(),
+             pg_backend_pid(), txid_current(), current_query(),
+             clock_timestamp(), clock_timestamp())',
+    TG_TABLE_SCHEMA)
+    USING OLD.id, OLD.publication_id, OLD.publication_type, OLD.parent_id,
+          OLD.lft, OLD.rgt, OLD.ordering, OLD.publication_status,
+          TG_TABLE_SCHEMA, replace(TG_TABLE_SCHEMA, '_', '.');
+
+  RETURN NULL;
+EXCEPTION
+  WHEN OTHERS THEN
+    -- Auditing must never break a legitimate deletion. If anything in
+    -- this trigger fails (missing table in a schema, unexpected mismatch,
+    -- etc.), silently drop the audit and allow the delete to proceed.
+    RETURN NULL;
+END;
+$_$;
 
 
 --
@@ -1145,6 +1206,35 @@ CREATE TABLE public.activities (
     acted_at timestamp without time zone NOT NULL,
     created_at timestamp without time zone NOT NULL,
     project_id uuid
+);
+
+
+--
+-- Name: admin_publication_deletion_audits; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.admin_publication_deletion_audits (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    tenant_schema character varying,
+    tenant_host character varying,
+    admin_publication_id uuid NOT NULL,
+    publication_id uuid,
+    publication_type character varying,
+    parent_id uuid,
+    lft integer,
+    rgt integer,
+    ordering integer,
+    publication_status character varying,
+    deleted_at timestamp(6) without time zone,
+    db_user character varying,
+    application_name character varying,
+    client_addr inet,
+    backend_pid integer,
+    transaction_id bigint,
+    query text,
+    reported_at timestamp(6) without time zone,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL
 );
 
 
@@ -3961,6 +4051,14 @@ ALTER TABLE ONLY public.que_jobs ALTER COLUMN id SET DEFAULT nextval('public.que
 
 ALTER TABLE ONLY public.activities
     ADD CONSTRAINT activities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: admin_publication_deletion_audits admin_publication_deletion_audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.admin_publication_deletion_audits
+    ADD CONSTRAINT admin_publication_deletion_audits_pkey PRIMARY KEY (id);
 
 
 --
@@ -7509,6 +7607,13 @@ CREATE UNIQUE INDEX users_unique_lower_email_idx ON public.users USING btree (lo
 
 
 --
+-- Name: admin_publications audit_orphaned_admin_publication; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE CONSTRAINT TRIGGER audit_orphaned_admin_publication AFTER DELETE ON public.admin_publications DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION public.log_orphaned_admin_publication();
+
+
+--
 -- Name: que_jobs que_job_notify; Type: TRIGGER; Schema: public; Owner: -
 --
 
@@ -8841,6 +8946,7 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260703120000'),
 ('20260701113056'),
 ('20260617120000'),
 ('20260617090200'),

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/invalid_data_checker.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/invalid_data_checker.rake
@@ -13,6 +13,11 @@ namespace :checks do
       summary = checker.check_tenant tenant: tenant, summary: summary
     end
 
+    # Forward any admin_publication orphaning events captured by the DB trigger
+    # (see AdminPublicationDeletionAudit) to Sentry. Reuses this weekly, per-region
+    # schedule rather than a dedicated one; idempotent via `reported_at`.
+    ReportOrphanedAdminPublicationsJob.perform_now
+
     if summary[:issues].present?
       puts JSON.pretty_generate summary
       raise 'Some data is invalid.'

--- a/back/spec/factories/admin_publication_deletion_audits.rb
+++ b/back/spec/factories/admin_publication_deletion_audits.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Rows are normally written by the `audit_orphaned_admin_publication` DB trigger,
+# never by the app. This factory only exists to fabricate rows for testing the
+# model scopes and the forwarder job.
+FactoryBot.define do
+  factory :admin_publication_deletion_audit do
+    admin_publication_id { SecureRandom.uuid }
+    publication_id { SecureRandom.uuid }
+    publication_type { 'Project' }
+    tenant_schema { 'example_org' }
+    tenant_host { 'example.org' }
+    publication_status { 'published' }
+    deleted_at { Time.zone.now }
+    application_name { 'bin/rails' }
+    reported_at { nil }
+  end
+end

--- a/back/spec/jobs/report_orphaned_admin_publications_job_spec.rb
+++ b/back/spec/jobs/report_orphaned_admin_publications_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReportOrphanedAdminPublicationsJob do
+  subject(:job) { described_class.new }
+
+  let(:tenant) { Tenant.current }
+
+  # Yield the current tenant without an actual schema switch: the spec already
+  # runs inside that tenant's schema, where the audit rows are created.
+  before { allow(Tenant).to receive(:safe_switch_each).and_yield(tenant) }
+
+  it 'reports each unreported audit row to Sentry and stamps reported_at' do
+    audit = create(:admin_publication_deletion_audit, reported_at: nil)
+
+    expect(ErrorReporter).to receive(:report_msg).once.with(
+      a_string_including('Orphaned admin_publication captured'),
+      extra: hash_including(
+        audit_id: audit.id,
+        publication_id: audit.publication_id,
+        publication_type: audit.publication_type,
+        tenant_host: tenant.host
+      )
+    )
+
+    expect { job.perform }.to change { audit.reload.reported_at }.from(nil).to(be_present)
+  end
+
+  it 'is idempotent: already-reported rows are not reported again' do
+    create(:admin_publication_deletion_audit, reported_at: Time.zone.now)
+
+    expect(ErrorReporter).not_to receive(:report_msg)
+
+    job.perform
+  end
+
+  it 'reports nothing when there are no captured rows' do
+    expect(ErrorReporter).not_to receive(:report_msg)
+
+    expect { job.perform }.not_to raise_error
+  end
+end

--- a/back/spec/models/admin_publication_deletion_audit_spec.rb
+++ b/back/spec/models/admin_publication_deletion_audit_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe AdminPublicationDeletionAudit do
+  describe 'scopes' do
+    describe '.unreported' do
+      it 'returns only rows that have not been reported yet' do
+        unreported = create(:admin_publication_deletion_audit, reported_at: nil)
+        create(:admin_publication_deletion_audit, reported_at: Time.zone.now)
+
+        expect(described_class.unreported).to contain_exactly(unreported)
+      end
+    end
+
+    describe '.recent' do
+      it 'orders by deleted_at descending' do
+        older = create(:admin_publication_deletion_audit, deleted_at: 2.days.ago)
+        newer = create(:admin_publication_deletion_audit, deleted_at: 1.hour.ago)
+
+        expect(described_class.recent.to_a).to eq([newer, older])
+      end
+    end
+  end
+
+  # The trigger is DEFERRABLE INITIALLY DEFERRED, so within a transactional test
+  # it would only fire at COMMIT (which never happens). Forcing constraints to
+  # IMMEDIATE runs the pending deferred trigger inside the current transaction so
+  # we can observe its effect.
+  describe 'the audit_orphaned_admin_publication trigger', :aggregate_failures do
+    def flush_deferred_triggers!
+      ActiveRecord::Base.connection.execute('SET CONSTRAINTS ALL IMMEDIATE')
+    end
+
+    # Deletes only the admin_publication row (bypassing ActiveRecord callbacks,
+    # exactly like the out-of-band deletions we are hunting), leaving the
+    # publication behind.
+    def orphan!(admin_publication)
+      AdminPublication.where(id: admin_publication.id).delete_all
+      flush_deferred_triggers!
+    end
+
+    it 'records a row when a project is orphaned, and the project survives' do
+      project = create(:project)
+      admin_publication = project.admin_publication
+
+      expect { orphan!(admin_publication) }.to change(described_class, :count).by(1)
+
+      audit = described_class.last
+      expect(audit).to have_attributes(
+        admin_publication_id: admin_publication.id,
+        publication_id: project.id,
+        publication_type: 'Project'
+      )
+      expect(Project.find_by(id: project.id)).to be_present
+    end
+
+    it 'records a row when a folder is orphaned' do
+      folder = create(:project_folder)
+
+      expect { orphan!(folder.admin_publication) }.to change(described_class, :count).by(1)
+      expect(described_class.last).to have_attributes(
+        publication_id: folder.id,
+        publication_type: 'ProjectFolders::Folder'
+      )
+    end
+
+    it 'does NOT record a row for a legitimate project destroy (cascade)' do
+      project = create(:project)
+
+      expect do
+        project.destroy!
+        flush_deferred_triggers!
+      end.not_to change(described_class, :count)
+    end
+
+    it 'does NOT record a row for a legitimate folder destroy (cascade)' do
+      folder = create(:project_folder)
+
+      expect do
+        folder.destroy!
+        flush_deferred_triggers!
+      end.not_to change(described_class, :count)
+    end
+
+    it 'captures the tenant and the deleted row state' do
+      project = create(:project)
+      admin_publication = AdminPublication.find(project.admin_publication.id)
+
+      orphan!(admin_publication)
+
+      audit = described_class.last
+      expect(audit.tenant_schema).to eq(Apartment::Tenant.current)
+      expect(audit.tenant_host).to eq(Apartment::Tenant.current.tr('_', '.'))
+      expect(audit.parent_id).to eq(admin_publication.parent_id)
+      expect(audit.lft).to eq(admin_publication.lft)
+      expect(audit.deleted_at).to be_present
+    end
+  end
+end


### PR DESCRIPTION
## Rationale

We periodically find orphaned projects in production — a `project` whose `admin_publication` has been deleted while the project survives, leaving it un-loadable (500s) and un-manageable. (e.g. recent [TAN-8074](https://app.notion.com/p/govocal/SLS-Restore-accidentally-deleted-project-Geef-jouw-mening-over-de-nieuwe-speeltuin-Gemeente-Alke-3899663b7b2681659124d9006ba3fa2f?source=copy_link)) No app code path produces this, it leaves nothing in the activity log, and the event has aged out of Sentry by the time we notice — so we've never found the cause. This adds DB-level instrumentation to catch the next occurrence with enough context to (hopefully) identify the source.

## Adds

- **A DB `AFTER DELETE` trigger on `admin_publications`** logging orphaning deletions to a per-tenant `admin_publication_deletion_audits` table. Done at the DB level on purpose: it catches deletions from *any* source — raw SQL, console, rake, migration — that  bypass `ActiveRecord` callbacks and would be invisible to a model hook.
- It's a **deferrable constraint trigger** that only logs when the publication still exists at COMMIT, so legitimate destroy cascades are excluded and only real orphaning is recorded. **Fail-safe** — it can never abort a deletion.
- Captures the culprit fingerprint: tenant, `application_name`, `client_addr`, `db_user`, `backend_pid`, `transaction_id`, `deleted_at`, and the deleted row's tree position.
- **`ReportOrphanedAdminPublicationsJob`** forwards captures to Sentry (idempotent via `reported_at`), wired into the existing weekly per-region `checks:invalid_data` task — no new schedule or infra.
- Model + specs (scopes, trigger behaviour, forwarder). Verified propagation to newly-provisioned tenants.

## Not done (AWS/server-side, possible follow-ups)

- **RDS `log_connections`** is off, so a captured `backend_pid` can't yet be traced to a session (user/host/app_name). Enabling it (dynamic, no reboot) would make the fingerprint fully followable — could be done later per parameter group.
- **`log_statement=mod` / pgaudit** off, so the literal `DELETE` isn't logged. Could enable later for the exact statement.
- Distinct per-process `application_name` not set — defaults already distinguish `puma` / `que` / `bin/rails`, which is enough.

# Changelog
## Technical
- [TAN-8089] Improve audit trail of 'lost' admin_publications
