### PR TITLE
Temporarily enable idea published email for demo platform

### DIFF
--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -42,7 +42,7 @@ module EmailCampaigns
     include ContentConfigurable
     include ContextConfigurable
     include LifecycleStageRestrictable
-    allow_lifecycle_stages only: %w[trial active]
+    allow_lifecycle_stages only: %w[trial active demo] # demo is temp for gouda demo 7/7/26
 
     recipient_filter :filter_recipient
 


### PR DESCRIPTION
# Changelog
## Changed
- Temporarily enable idea published email on demo platforms
