### PR TITLE
[TAN-7935] Reporting model 1/5: thin reporting views

### DIFF
--- a/back/db/migrate/20260707161925_create_thin_reporting_views.analytics.rb
+++ b/back/db/migrate/20260707161925_create_thin_reporting_views.analytics.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from analytics (originally 20260707120000)
+# First slice of the unified reporting model exposed through the MCP reporting
+# tools: the thin, near-passthrough views. The read grants for analytics_reader
+# are added in a separate main-app migration that runs after this one.
+class CreateThinReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_projects, version: 1
+    create_view :reporting_phases, version: 1
+    create_view :reporting_sessions, version: 1
+    create_view :reporting_pageviews, version: 1
+  end
+end

--- a/back/db/migrate/20260707161930_grant_reporting_thin_views.rb
+++ b/back/db/migrate/20260707161930_grant_reporting_thin_views.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Grants analytics_reader SELECT on the reporting_* views introduced by
+# CreateThinReportingViews (projects, phases, sessions, pageviews), per tenant
+# schema via Apartment. Re-runs the idempotent provisioner, which grants every
+# REPORTING_TABLES entry whose relation exists at this point in the stream.
+class GrantReportingThinViews < ActiveRecord::Migration[7.2]
+  def up
+    McpServer::AnalyticsReaderProvisioner.provision!
+  end
+
+  def down
+    # No-op: the SELECT grants on the new views disappear together with the
+    # views when CreateThinReportingViews is rolled back.
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -228,7 +228,6 @@ DROP INDEX IF EXISTS public.index_report_builder_reports_on_name;
 DROP INDEX IF EXISTS public.index_reactions_on_user_id;
 DROP INDEX IF EXISTS public.index_reactions_on_reactable_type_and_reactable_id_and_user_id;
 DROP INDEX IF EXISTS public.index_reactions_on_reactable_type_and_reactable_id;
-DROP INDEX IF EXISTS public.index_public_api_api_clients_on_name;
 DROP INDEX IF EXISTS public.index_projects_on_space_id;
 DROP INDEX IF EXISTS public.index_projects_on_slug;
 DROP INDEX IF EXISTS public.index_projects_global_topics_on_project_id;
@@ -679,6 +678,10 @@ DROP TABLE IF EXISTS public.static_page_files;
 DROP TABLE IF EXISTS public.spam_reports;
 DROP TABLE IF EXISTS public.spaces;
 DROP TABLE IF EXISTS public.schema_migrations;
+DROP VIEW IF EXISTS public.reporting_sessions;
+DROP VIEW IF EXISTS public.reporting_projects;
+DROP VIEW IF EXISTS public.reporting_phases;
+DROP VIEW IF EXISTS public.reporting_pageviews;
 DROP TABLE IF EXISTS public.report_builder_reports;
 DROP TABLE IF EXISTS public.report_builder_published_graph_data_units;
 DROP TABLE IF EXISTS public.que_values;
@@ -3690,6 +3693,92 @@ CREATE TABLE public.report_builder_reports (
     quarter integer,
     community_monitor boolean DEFAULT false NOT NULL
 );
+
+
+--
+-- Name: reporting_pageviews; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_pageviews AS
+ SELECT id,
+    session_id,
+    created_at AS viewed_at,
+    path,
+    project_id,
+        CASE
+            WHEN (split_part((path)::text, '/'::text, 2) IN ( SELECT jsonb_array_elements_text(((ac.settings -> 'core'::text) -> 'locales'::text)) AS jsonb_array_elements_text
+               FROM public.app_configurations ac)) THEN split_part((path)::text, '/'::text, 2)
+            ELSE NULL::text
+        END AS locale
+   FROM public.impact_tracking_pageviews pv;
+
+
+--
+-- Name: reporting_phases; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_phases AS
+ SELECT id,
+    project_id,
+    COALESCE(NULLIF((title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(ph.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS title,
+    start_at,
+    end_at,
+    participation_method
+   FROM public.phases ph;
+
+
+--
+-- Name: reporting_projects; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_projects AS
+ SELECT p.id,
+    COALESCE(NULLIF((p.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(p.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS title,
+    ap.publication_status,
+    phase_bounds.start_at,
+    phase_bounds.end_at,
+    folder_ap.publication_id AS folder_id,
+    p.hidden,
+    p.listed
+   FROM (((public.projects p
+     LEFT JOIN public.admin_publications ap ON (((ap.publication_id = p.id) AND ((ap.publication_type)::text = 'Project'::text))))
+     LEFT JOIN public.admin_publications folder_ap ON ((folder_ap.id = ap.parent_id)))
+     LEFT JOIN ( SELECT ph.project_id,
+            min(ph.start_at) AS start_at,
+                CASE
+                    WHEN bool_or((ph.end_at IS NULL)) THEN NULL::timestamp without time zone
+                    ELSE max(ph.end_at)
+                END AS end_at
+           FROM public.phases ph
+          GROUP BY ph.project_id) phase_bounds ON ((phase_bounds.project_id = p.id)));
+
+
+--
+-- Name: reporting_sessions; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_sessions AS
+ SELECT id,
+    created_at AS started_at,
+    user_id,
+    monthly_user_hash AS anonymous_id,
+    COALESCE((user_id)::text, (monthly_user_hash)::text) AS visitor_id,
+    highest_role,
+    device_type AS device,
+    referrer
+   FROM public.impact_tracking_sessions s;
 
 
 --
@@ -7139,13 +7228,6 @@ CREATE INDEX index_projects_on_space_id ON public.projects USING btree (space_id
 
 
 --
--- Name: index_public_api_api_clients_on_name; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE UNIQUE INDEX index_public_api_api_clients_on_name ON public.public_api_api_clients USING btree (name) WHERE (name IS NOT NULL);
-
-
---
 -- Name: index_reactions_on_reactable_type_and_reactable_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -8849,6 +8931,8 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707161930'),
+('20260707161925'),
 ('20260701113056'),
 ('20260617120000'),
 ('20260617090200'),
@@ -8868,7 +8952,6 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20260429101252'),
 ('20260421105121'),
 ('20260420120659'),
-('20260414120848'),
 ('20260408161034'),
 ('20260408131955'),
 ('20260323120000'),

--- a/back/db/views/analytics_fact_project_statuses_v05.sql
+++ b/back/db/views/analytics_fact_project_statuses_v05.sql
@@ -6,6 +6,8 @@
 -- projects that are finished.
 
 WITH finished_statuses_for_timeline_projects AS
+         -- With exclusive end boundaries, end_at already points to the moment the phase
+         -- ends, so no +1 adjustment is needed.
          (SELECT phases.project_id, MAX(phases.end_at) as timestamp
           FROM phases
           GROUP BY phases.project_id

--- a/back/db/views/reporting_pageviews_v01.sql
+++ b/back/db/views/reporting_pageviews_v01.sql
@@ -1,0 +1,17 @@
+-- Reporting view: one row per pageview (a single page displayed to a visitor).
+SELECT
+    pv.id,
+    pv.session_id,
+    pv.created_at AS viewed_at,
+    pv.path,
+    pv.project_id,
+    -- second path segment, but only when it is one of the tenant's configured
+    -- locales (pageviews for since-removed locales resolve to NULL)
+    CASE
+        WHEN split_part(pv.path, '/', 2) IN (
+            SELECT jsonb_array_elements_text(ac.settings -> 'core' -> 'locales')
+            FROM app_configurations ac
+        )
+        THEN split_part(pv.path, '/', 2)
+    END AS locale
+FROM impact_tracking_pageviews pv

--- a/back/db/views/reporting_phases_v01.sql
+++ b/back/db/views/reporting_phases_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per phase (a participation step within a project).
+SELECT
+    ph.id,
+    ph.project_id,
+    COALESCE(
+        NULLIF(ph.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(ph.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    ph.start_at,
+    ph.end_at,
+    ph.participation_method
+FROM phases ph

--- a/back/db/views/reporting_projects_v01.sql
+++ b/back/db/views/reporting_projects_v01.sql
@@ -1,0 +1,32 @@
+-- Reporting view: one row per project (participation container).
+--
+-- Localised text columns resolve a multiloc to the tenant's primary locale
+-- (the first entry of core.locales in app_configurations), falling back to
+-- the alphabetically-first non-empty translation. Keep this expression
+-- identical across all reporting_* views.
+SELECT
+    p.id,
+    COALESCE(
+        NULLIF(p.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(p.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    ap.publication_status,
+    phase_bounds.start_at,
+    phase_bounds.end_at,
+    folder_ap.publication_id AS folder_id,
+    p.hidden,
+    p.listed
+FROM projects p
+LEFT JOIN admin_publications ap
+    ON ap.publication_id = p.id AND ap.publication_type = 'Project'
+LEFT JOIN admin_publications folder_ap
+    ON folder_ap.id = ap.parent_id
+LEFT JOIN (
+    SELECT
+        ph.project_id,
+        MIN(ph.start_at) AS start_at,
+        -- an open-ended phase (NULL end_at) makes the whole project open-ended
+        CASE WHEN bool_or(ph.end_at IS NULL) THEN NULL ELSE MAX(ph.end_at) END AS end_at
+    FROM phases ph
+    GROUP BY ph.project_id
+) phase_bounds ON phase_bounds.project_id = p.id

--- a/back/db/views/reporting_sessions_v01.sql
+++ b/back/db/views/reporting_sessions_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per browser session (bot traffic is filtered out at
+-- ingestion time, before a session row is created).
+SELECT
+    s.id,
+    s.created_at AS started_at,
+    s.user_id,
+    s.monthly_user_hash AS anonymous_id,
+    COALESCE(s.user_id::text, s.monthly_user_hash) AS visitor_id,
+    s.highest_role,
+    s.device_type AS device,
+    s.referrer
+FROM impact_tracking_sessions s

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/pageview.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/pageview.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_pageviews
+#
+#  id         :uuid             primary key
+#  session_id :uuid
+#  viewed_at  :datetime
+#  path       :string
+#  project_id :uuid
+#  locale     :text
+#
+module Analytics
+  module Reporting
+    class Pageview < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_pageviews'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per pageview: a single page displayed to a visitor. Join to
+          reporting_sessions via session_id for visitor identity, device and
+          referrer. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Pageview primary key.',
+          'session_id' => 'The browser session this pageview belongs to. Joins to reporting_sessions.id.',
+          'viewed_at' => 'When the page was displayed.',
+          'path' => "URL path of the page, starting with the locale segment, for example '/en/projects/my-project'.",
+          'project_id' => <<~DOC.squish,
+            The project the page belongs to, or NULL for pages outside any
+            project (such as the home page). Use this to count visitors or
+            pageviews per project.
+          DOC
+          'locale' => <<~DOC.squish
+            Interface language of the pageview, parsed from the path (for
+            example 'en' or 'nl-BE'). NULL when the path carries no currently
+            configured locale.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/phase.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/phase.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_phases
+#
+#  id                   :uuid             primary key
+#  project_id           :uuid
+#  title                :text
+#  start_at             :datetime
+#  end_at               :datetime
+#  participation_method :string
+#
+module Analytics
+  module Reporting
+    class Phase < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_phases'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per phase. A phase is a consecutive step in a project's
+          timeline with exactly one participation method. All timestamps are in
+          UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Phase primary key.',
+          'project_id' => 'The project this phase belongs to. Joins to reporting_projects.id.',
+          'title' => 'Phase title, resolved to the platform primary locale.',
+          'start_at' => 'When the phase starts.',
+          'end_at' => 'When the phase ends. NULL means the phase is open-ended.',
+          'participation_method' => <<~DOC.squish
+            How residents participate in this phase. One of: 'ideation' (posting
+            and discussing ideas), 'proposals' (resident-initiated proposals),
+            'voting' (voting or participatory budgeting over ideas),
+            'native_survey' (survey built on the platform),
+            'community_monitor_survey' (recurring sentiment survey), 'survey'
+            (embedded third-party survey), 'poll' (quick multiple-choice poll),
+            'volunteering' (signing up for causes), 'common_ground' (reacting to
+            statements), 'document_annotation' (annotating a document), or
+            'information' (no participation, informational content only).
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/project.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/project.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_projects
+#
+#  id                 :uuid             primary key
+#  title              :text
+#  publication_status :string
+#  start_at           :datetime
+#  end_at             :datetime
+#  folder_id          :uuid
+#  hidden             :boolean
+#  listed             :boolean
+#
+module Analytics
+  module Reporting
+    class Project < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_projects'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per project, the container in which all participation happens.
+          A project consists of one or more phases (see reporting_phases). All
+          timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Project primary key. Joins to reporting_phases.project_id and reporting_pageviews.project_id.',
+          'title' => 'Project title, resolved to the platform primary locale.',
+          'publication_status' => <<~DOC.squish,
+            Lifecycle state: 'draft' (not yet visible to residents), 'published'
+            (live), or 'archived' (visible but closed). Count only 'published'
+            and 'archived' projects unless explicitly asked about drafts.
+          DOC
+          'start_at' => 'Start of the earliest phase. NULL when the project has no phases yet.',
+          'end_at' => <<~DOC.squish,
+            End of the latest phase. NULL when the project has no phases yet or
+            when any phase is open-ended, meaning the project has no planned end.
+            A project is finished when end_at is in the past.
+          DOC
+          'folder_id' => 'The folder this project is grouped under, or NULL when not in a folder.',
+          'hidden' => <<~DOC.squish,
+            TRUE for internal system projects that residents never see as projects
+            (for example the hidden project that holds the community monitor
+            survey). Exclude hidden projects when counting projects, but their
+            participation data is still meaningful.
+          DOC
+          'listed' => 'FALSE when the project is unlisted: live and reachable via direct link, but not shown in public project listings.'
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/session.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/session.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_sessions
+#
+#  id           :uuid             primary key
+#  started_at   :datetime
+#  user_id      :uuid
+#  anonymous_id :string
+#  visitor_id   :text
+#  highest_role :string
+#  device       :string
+#  referrer     :string
+#
+module Analytics
+  module Reporting
+    class Session < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_sessions'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per browser session on the platform. Bot traffic is filtered
+          out before sessions are recorded, and sessions are recorded regardless
+          of cookie consent. Count visitors as COUNT(DISTINCT visitor_id): this
+          slightly overcounts unique people because anonymous_id changes at
+          calendar-month boundaries. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Session primary key. Joins to reporting_pageviews.session_id.',
+          'started_at' => 'When the session started.',
+          'user_id' => 'The signed-in user, or NULL for signed-out visitors.',
+          'anonymous_id' => <<~DOC.squish,
+            Privacy-preserving fingerprint of the visitor. Stable only within a
+            calendar month, so distinct counts across month boundaries overcount
+            unique people.
+          DOC
+          'visitor_id' => <<~DOC.squish,
+            The canonical visitor identity: user_id when signed in, otherwise
+            anonymous_id. Use COUNT(DISTINCT visitor_id) for visitor counts, and
+            for visitor counts per project join reporting_pageviews on its
+            project_id.
+          DOC
+          'highest_role' => <<~DOC.squish,
+            Highest platform role of the signed-in user at session start: one of
+            'super_admin', 'admin', 'space_moderator', 'project_folder_moderator',
+            'project_moderator', 'user', or NULL for signed-out visitors. Filter
+            to 'user' (or NULL) to measure resident traffic without platform staff.
+          DOC
+          'device' => "Device class: 'mobile', 'tablet', or 'desktop_or_other'. NULL when unknown.",
+          'referrer' => 'Full URL the visitor came from, or NULL for direct visits.'
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/db/migrate/20260707120000_create_thin_reporting_views.rb
+++ b/back/engines/commercial/analytics/db/migrate/20260707120000_create_thin_reporting_views.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# First slice of the unified reporting model exposed through the MCP reporting
+# tools: the thin, near-passthrough views. The read grants for analytics_reader
+# are added in a separate main-app migration that runs after this one.
+class CreateThinReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_projects, version: 1
+    create_view :reporting_phases, version: 1
+    create_view :reporting_sessions, version: 1
+    create_view :reporting_pageviews, version: 1
+  end
+end

--- a/back/engines/commercial/analytics/db/views/reporting_pageviews_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_pageviews_v01.sql
@@ -1,0 +1,17 @@
+-- Reporting view: one row per pageview (a single page displayed to a visitor).
+SELECT
+    pv.id,
+    pv.session_id,
+    pv.created_at AS viewed_at,
+    pv.path,
+    pv.project_id,
+    -- second path segment, but only when it is one of the tenant's configured
+    -- locales (pageviews for since-removed locales resolve to NULL)
+    CASE
+        WHEN split_part(pv.path, '/', 2) IN (
+            SELECT jsonb_array_elements_text(ac.settings -> 'core' -> 'locales')
+            FROM app_configurations ac
+        )
+        THEN split_part(pv.path, '/', 2)
+    END AS locale
+FROM impact_tracking_pageviews pv

--- a/back/engines/commercial/analytics/db/views/reporting_phases_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_phases_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per phase (a participation step within a project).
+SELECT
+    ph.id,
+    ph.project_id,
+    COALESCE(
+        NULLIF(ph.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(ph.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    ph.start_at,
+    ph.end_at,
+    ph.participation_method
+FROM phases ph

--- a/back/engines/commercial/analytics/db/views/reporting_projects_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_projects_v01.sql
@@ -1,0 +1,32 @@
+-- Reporting view: one row per project (participation container).
+--
+-- Localised text columns resolve a multiloc to the tenant's primary locale
+-- (the first entry of core.locales in app_configurations), falling back to
+-- the alphabetically-first non-empty translation. Keep this expression
+-- identical across all reporting_* views.
+SELECT
+    p.id,
+    COALESCE(
+        NULLIF(p.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(p.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    ap.publication_status,
+    phase_bounds.start_at,
+    phase_bounds.end_at,
+    folder_ap.publication_id AS folder_id,
+    p.hidden,
+    p.listed
+FROM projects p
+LEFT JOIN admin_publications ap
+    ON ap.publication_id = p.id AND ap.publication_type = 'Project'
+LEFT JOIN admin_publications folder_ap
+    ON folder_ap.id = ap.parent_id
+LEFT JOIN (
+    SELECT
+        ph.project_id,
+        MIN(ph.start_at) AS start_at,
+        -- an open-ended phase (NULL end_at) makes the whole project open-ended
+        CASE WHEN bool_or(ph.end_at IS NULL) THEN NULL ELSE MAX(ph.end_at) END AS end_at
+    FROM phases ph
+    GROUP BY ph.project_id
+) phase_bounds ON phase_bounds.project_id = p.id

--- a/back/engines/commercial/analytics/db/views/reporting_sessions_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_sessions_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per browser session (bot traffic is filtered out at
+-- ingestion time, before a session row is created).
+SELECT
+    s.id,
+    s.created_at AS started_at,
+    s.user_id,
+    s.monthly_user_hash AS anonymous_id,
+    COALESCE(s.user_id::text, s.monthly_user_hash) AS visitor_id,
+    s.highest_role,
+    s.device_type AS device,
+    s.referrer
+FROM impact_tracking_sessions s

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/pageview_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/pageview_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Pageview do
+  it 'exposes one row per pageview with its session and project' do
+    project = create(:project)
+    pageview = create(:pageview, path: '/en/projects/park-renewal', project_id: project.id)
+    row = described_class.find(pageview.id)
+
+    expect(row.session_id).to eq pageview.session_id
+    expect(row.viewed_at).to eq pageview.created_at
+    expect(row.path).to eq '/en/projects/park-renewal'
+    expect(row.project_id).to eq project.id
+  end
+
+  describe 'locale' do
+    it 'parses a configured locale from the path' do
+      expect(described_class.find(create(:pageview, path: '/fr-FR/ideas').id).locale).to eq 'fr-FR'
+    end
+
+    it 'is NULL when the path segment is not a configured locale' do
+      expect(described_class.find(create(:pageview, path: '/xx/ideas').id).locale).to be_nil
+      expect(described_class.find(create(:pageview, path: '/').id).locale).to be_nil
+    end
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/phase_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/phase_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Phase do
+  subject(:row) { described_class.find(phase.id) }
+
+  let!(:phase) do
+    create(
+      :phase,
+      title_multiloc: { 'en' => 'Gather ideas', 'nl-BE' => 'Ideeën verzamelen' },
+      start_at: '2026-01-01',
+      end_at: '2026-01-31'
+    )
+  end
+
+  it 'exposes one row per phase with its project and method' do
+    expect(row.project_id).to eq phase.project_id
+    expect(row.participation_method).to eq 'ideation'
+    expect(row.start_at).to eq phase.start_at
+    expect(row.end_at).to eq phase.end_at
+  end
+
+  describe 'title' do
+    it 'resolves to the tenant primary locale' do
+      expect(row.title).to eq 'Gather ideas'
+    end
+
+    it 'falls back to another locale when the primary locale is missing' do
+      phase.update_column(:title_multiloc, { 'nl-BE' => 'Ideeën verzamelen' })
+
+      expect(row.title).to eq 'Ideeën verzamelen'
+    end
+  end
+
+  it 'keeps end_at NULL for an open-ended phase' do
+    phase.update!(end_at: nil)
+
+    expect(row.end_at).to be_nil
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/project_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/project_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Project do
+  subject(:row) { described_class.find(project.id) }
+
+  let!(:project) { create(:project, title_multiloc: { 'en' => 'Park renewal', 'nl-BE' => 'Parkvernieuwing' }) }
+
+  describe 'title' do
+    it 'resolves to the tenant primary locale' do
+      expect(row.title).to eq 'Park renewal'
+    end
+
+    it 'falls back to another locale when the primary locale is missing' do
+      project.update!(title_multiloc: { 'nl-BE' => 'Parkvernieuwing' })
+
+      expect(row.title).to eq 'Parkvernieuwing'
+    end
+  end
+
+  describe 'publication_status' do
+    it 'exposes the admin publication status' do
+      draft = create(:project, :draft)
+
+      expect(row.publication_status).to eq 'published'
+      expect(described_class.find(draft.id).publication_status).to eq 'draft'
+    end
+  end
+
+  describe 'start_at / end_at' do
+    it 'is NULL for a project without phases' do
+      expect(row.start_at).to be_nil
+      expect(row.end_at).to be_nil
+    end
+
+    it 'spans from the earliest phase start to the latest phase end' do
+      create(:phase, project: project, start_at: '2026-01-01', end_at: '2026-01-31')
+      create(:phase, project: project, start_at: '2026-02-01', end_at: '2026-03-31')
+
+      expect(row.start_at).to eq project.phases.minimum(:start_at)
+      expect(row.end_at).to eq project.phases.maximum(:end_at)
+    end
+
+    it 'has a NULL end when any phase is open-ended' do
+      create(:phase, project: project, start_at: '2026-01-01', end_at: '2026-01-31')
+      create(:phase, project: project, start_at: '2026-02-01', end_at: nil)
+
+      expect(row.start_at).to eq project.phases.minimum(:start_at)
+      expect(row.end_at).to be_nil
+    end
+  end
+
+  describe 'folder_id' do
+    it 'is NULL for a project outside any folder' do
+      expect(row.folder_id).to be_nil
+    end
+
+    it 'is the folder id for a project in a folder' do
+      folder = create(:project_folder, projects: [project])
+
+      expect(row.folder_id).to eq folder.id
+    end
+  end
+
+  it 'exposes the visibility flags' do
+    expect(row.hidden).to be false
+    expect(row.listed).to be true
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/session_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/session_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Session do
+  it 'uses the user id as visitor identity for signed-in sessions' do
+    user = create(:user)
+    session = create(:session, user_id: user.id, highest_role: 'user')
+    row = described_class.find(session.id)
+
+    expect(row.user_id).to eq user.id
+    expect(row.visitor_id).to eq user.id
+    expect(row.highest_role).to eq 'user'
+  end
+
+  it 'falls back to the anonymous hash for signed-out sessions' do
+    session = create(:session)
+    row = described_class.find(session.id)
+
+    expect(row.user_id).to be_nil
+    expect(row.anonymous_id).to eq session.monthly_user_hash
+    expect(row.visitor_id).to eq session.monthly_user_hash
+    expect(row.highest_role).to be_nil
+  end
+
+  it 'exposes session start, device and referrer' do
+    session = create(:session, device_type: 'mobile', referrer: 'https://www.google.com/')
+    row = described_class.find(session.id)
+
+    expect(row.started_at).to eq session.created_at
+    expect(row.device).to eq 'mobile'
+    expect(row.referrer).to eq 'https://www.google.com/'
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
@@ -12,7 +12,11 @@ class McpServer::Tools::GetReportingSqlSchema < McpServer::BaseTool
     Analytics::DimensionDate,
     Analytics::DimensionProject,
     Analytics::DimensionType,
-    Analytics::DimensionUser
+    Analytics::DimensionUser,
+    Analytics::Reporting::Project,
+    Analytics::Reporting::Phase,
+    Analytics::Reporting::Session,
+    Analytics::Reporting::Pageview
   ].freeze
 
   REPORTING_TABLE_NAMES = REPORTING_TABLES.map(&:table_name).freeze

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/analytics_reader_provisioner.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/analytics_reader_provisioner.rb
@@ -53,9 +53,17 @@ module McpServer
         execute("GRANT #{quoted_role} TO CURRENT_USER")
       end
 
+      # Relations missing from the schema are skipped rather than raised on:
+      # REPORTING_TABLE_NAMES reflects the newest code, but during a fresh
+      # `db:migrate` an older provisioning migration runs before the migrations
+      # that create the newer reporting views. Every view-adding change ships
+      # its own provision! migration, so skipped grants are always picked up by
+      # a later step in the same stream.
       def grant!(schema = Apartment::Tenant.current)
         execute("GRANT USAGE ON SCHEMA #{quote_ident(schema)} TO #{quoted_role}")
         reporting_tables.each do |table|
+          next unless relation_exists?(schema, table)
+
           execute("GRANT SELECT ON #{quote_rel(schema, table)} TO #{quoted_role}")
         end
       end
@@ -78,6 +86,14 @@ module McpServer
 
       def reporting_tables
         McpServer::Tools::GetReportingSqlSchema::REPORTING_TABLE_NAMES
+      end
+
+      def relation_exists?(schema, table)
+        connection.select_value(<<~SQL.squish).present?
+          SELECT 1 FROM pg_catalog.pg_class c
+          JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+          WHERE n.nspname = #{connection.quote(schema)} AND c.relname = #{connection.quote(table)}
+        SQL
       end
 
       def quoted_role = quote_ident(ROLE)

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/run_reporting_sql_query_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/run_reporting_sql_query_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe McpServer::Tools::RunReportingSqlQuery do
     end
   end
 
+  # A table in REPORTING_TABLES is only usable when its view exists AND carries
+  # the analytics_reader grant; a missing grant only surfaces at execution time.
+  # This guards the whole whitelist end-to-end, including future additions.
+  describe 'every whitelisted table' do
+    McpServer::Tools::GetReportingSqlSchema::REPORTING_TABLE_NAMES.each do |table|
+      it "can be selected from (#{table})" do
+        response = run("SELECT * FROM #{table} LIMIT 1")
+
+        expect(response.error?).to be false
+      end
+    end
+  end
+
   describe 'layer 1 (sandbox) rejections' do
     it 'rejects a blank query before touching the database' do
       response = run('   ')


### PR DESCRIPTION
# Changelog

## Added
- The AI reporting tools (MCP) can now query four new reporting tables: projects (with status, timeline and folder), phases (with participation method), visitor sessions (with device, referrer and staff role) and pageviews (with project and language). This is the first slice of the unified reporting data model that will replace the legacy analytics views for AI querying.

## Technical
- New `reporting_*` scenic views live in the analytics engine, with documented `Analytics::Reporting::*` models serving the schema tool. Localized text columns resolve multilocs to the tenant's primary locale in SQL, with a fallback to the first non-empty translation.
- `AnalyticsReaderProvisioner#grant!` now skips relations that don't exist yet in the schema, keeping older provisioning migrations valid on fresh databases as the reporting whitelist grows; each view-adding change ships its own re-provision migration.
- The `run_reporting_sql_query` spec now asserts every whitelisted table is queryable end-to-end, so a missing grant fails CI instead of surfacing at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkM7j4XfjYwsh3Ffh5Nvyk