### PR TITLE
[TAN-7935] Reporting model 2/5: unified contributions fact

### DIFF
--- a/back/db/migrate/20260707164511_create_contribution_reporting_views.analytics.rb
+++ b/back/db/migrate/20260707164511_create_contribution_reporting_views.analytics.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# This migration comes from analytics (originally 20260707150000)
+# Second slice of the unified reporting model: the contributions fact (one row
+# per participatory action, all methods) and the participants view derived from
+# it. reporting_participants selects from reporting_contributions, so creation
+# order matters. Grants follow in a separate main-app migration.
+class CreateContributionReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_contributions, version: 1
+    create_view :reporting_participants, version: 1
+  end
+end

--- a/back/db/migrate/20260707164520_grant_reporting_contribution_views.rb
+++ b/back/db/migrate/20260707164520_grant_reporting_contribution_views.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Grants analytics_reader SELECT on the reporting views introduced by
+# CreateContributionReportingViews (contributions, participants), per tenant
+# schema via Apartment. Re-runs the idempotent provisioner, which grants every
+# REPORTING_TABLES entry whose relation exists at this point in the stream.
+class GrantReportingContributionViews < ActiveRecord::Migration[7.2]
+  def up
+    McpServer::AnalyticsReaderProvisioner.provision!
+  end
+
+  def down
+    # No-op: the SELECT grants on the new views disappear together with the
+    # views when CreateContributionReportingViews is rolled back.
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -681,7 +681,9 @@ DROP TABLE IF EXISTS public.schema_migrations;
 DROP VIEW IF EXISTS public.reporting_sessions;
 DROP VIEW IF EXISTS public.reporting_projects;
 DROP VIEW IF EXISTS public.reporting_phases;
+DROP VIEW IF EXISTS public.reporting_participants;
 DROP VIEW IF EXISTS public.reporting_pageviews;
+DROP VIEW IF EXISTS public.reporting_contributions;
 DROP TABLE IF EXISTS public.report_builder_reports;
 DROP TABLE IF EXISTS public.report_builder_published_graph_data_units;
 DROP TABLE IF EXISTS public.que_values;
@@ -3696,6 +3698,169 @@ CREATE TABLE public.report_builder_reports (
 
 
 --
+-- Name: reporting_contributions; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_contributions AS
+ SELECT i.id,
+    'input'::text AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    i.contributed_at,
+    i.created_at,
+    COALESCE(creation_ph.participation_method, inferred_ph.participation_method) AS participation_method,
+    i.project_id,
+    COALESCE(i.creation_phase_id, inferred_ph.id) AS phase_id,
+    i.author_id AS user_id,
+    COALESCE((i.author_id)::text, (i.author_hash)::text, (i.id)::text) AS participant_id
+   FROM ((( SELECT ideas.id,
+            ideas.title_multiloc,
+            ideas.body_multiloc,
+            ideas.publication_status,
+            ideas.published_at,
+            ideas.project_id,
+            ideas.author_id,
+            ideas.created_at,
+            ideas.updated_at,
+            ideas.likes_count,
+            ideas.dislikes_count,
+            ideas.location_point,
+            ideas.location_description,
+            ideas.comments_count,
+            ideas.idea_status_id,
+            ideas.slug,
+            ideas.budget,
+            ideas.baskets_count,
+            ideas.official_feedbacks_count,
+            ideas.assignee_id,
+            ideas.assigned_at,
+            ideas.proposed_budget,
+            ideas.custom_field_values,
+            ideas.creation_phase_id,
+            ideas.author_hash,
+            ideas.anonymous,
+            ideas.internal_comments_count,
+            ideas.votes_count,
+            ideas.followers_count,
+            ideas.submitted_at,
+            ideas.manual_votes_amount,
+            ideas.manual_votes_last_updated_by_id,
+            ideas.manual_votes_last_updated_at,
+            ideas.neutral_reactions_count,
+            ideas.weglot_data,
+            COALESCE(ideas.submitted_at, ideas.published_at, ideas.created_at) AS contributed_at
+           FROM public.ideas
+          WHERE ((ideas.publication_status)::text = 'published'::text)) i
+     LEFT JOIN public.phases creation_ph ON ((creation_ph.id = i.creation_phase_id)))
+     LEFT JOIN public.phases inferred_ph ON (((i.creation_phase_id IS NULL) AND (inferred_ph.project_id = i.project_id) AND (i.contributed_at >= inferred_ph.start_at) AND ((inferred_ph.end_at IS NULL) OR (i.contributed_at < inferred_ph.end_at)))))
+UNION ALL
+ SELECT c.id,
+    'comment'::text AS type,
+    'input'::text AS parent_type,
+    c.idea_id AS parent_id,
+    c.created_at AS contributed_at,
+    c.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    i.project_id,
+    inferred_ph.id AS phase_id,
+    c.author_id AS user_id,
+    COALESCE((c.author_id)::text, (c.author_hash)::text, (c.id)::text) AS participant_id
+   FROM (((public.comments c
+     LEFT JOIN public.ideas i ON ((i.id = c.idea_id)))
+     LEFT JOIN public.phases input_creation_ph ON ((input_creation_ph.id = i.creation_phase_id)))
+     LEFT JOIN public.phases inferred_ph ON (((inferred_ph.project_id = i.project_id) AND (c.created_at >= inferred_ph.start_at) AND ((inferred_ph.end_at IS NULL) OR (c.created_at < inferred_ph.end_at)))))
+  WHERE ((c.publication_status)::text = 'published'::text)
+UNION ALL
+ SELECT r.id,
+    'reaction'::text AS type,
+    r.parent_type,
+    r.parent_id,
+    r.created_at AS contributed_at,
+    r.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    r.project_id,
+    inferred_ph.id AS phase_id,
+    r.user_id,
+    COALESCE((r.user_id)::text, (r.id)::text) AS participant_id
+   FROM ((( SELECT reactions.id,
+            reactions.user_id,
+            reactions.created_at,
+                CASE
+                    WHEN ((reactions.reactable_type)::text = 'Idea'::text) THEN 'input'::text
+                    ELSE 'comment'::text
+                END AS parent_type,
+            reactions.reactable_id AS parent_id,
+            COALESCE(ri.project_id, rci.project_id) AS project_id,
+            COALESCE(ri.creation_phase_id, rci.creation_phase_id) AS input_creation_phase_id
+           FROM (((public.reactions
+             LEFT JOIN public.ideas ri ON ((((reactions.reactable_type)::text = 'Idea'::text) AND (ri.id = reactions.reactable_id))))
+             LEFT JOIN public.comments rc ON ((((reactions.reactable_type)::text = 'Comment'::text) AND (rc.id = reactions.reactable_id))))
+             LEFT JOIN public.ideas rci ON ((rci.id = rc.idea_id)))
+          WHERE ((reactions.reactable_type)::text = ANY ((ARRAY['Idea'::character varying, 'Comment'::character varying])::text[]))) r
+     LEFT JOIN public.phases input_creation_ph ON ((input_creation_ph.id = r.input_creation_phase_id)))
+     LEFT JOIN public.phases inferred_ph ON (((inferred_ph.project_id = r.project_id) AND (r.created_at >= inferred_ph.start_at) AND ((inferred_ph.end_at IS NULL) OR (r.created_at < inferred_ph.end_at)))))
+UNION ALL
+ SELECT bi.id,
+    'vote'::text AS type,
+    'input'::text AS parent_type,
+    bi.idea_id AS parent_id,
+    b.submitted_at AS contributed_at,
+    bi.created_at,
+    ph.participation_method,
+    ph.project_id,
+    b.phase_id,
+    b.user_id,
+    COALESCE((b.user_id)::text, (b.id)::text) AS participant_id
+   FROM ((public.baskets_ideas bi
+     JOIN public.baskets b ON ((b.id = bi.basket_id)))
+     LEFT JOIN public.phases ph ON ((ph.id = b.phase_id)))
+  WHERE (b.submitted_at IS NOT NULL)
+UNION ALL
+ SELECT vv.id,
+    'volunteering'::text AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    vv.created_at AS contributed_at,
+    vv.created_at,
+    ph.participation_method,
+    ph.project_id,
+    vc.phase_id,
+    vv.user_id,
+    COALESCE((vv.user_id)::text, (vv.id)::text) AS participant_id
+   FROM ((public.volunteering_volunteers vv
+     JOIN public.volunteering_causes vc ON ((vc.id = vv.cause_id)))
+     LEFT JOIN public.phases ph ON ((ph.id = vc.phase_id)))
+UNION ALL
+ SELECT pr.id,
+    'poll_response'::text AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    pr.created_at AS contributed_at,
+    pr.created_at,
+    ph.participation_method,
+    ph.project_id,
+    pr.phase_id,
+    pr.user_id,
+    COALESCE((pr.user_id)::text, (pr.id)::text) AS participant_id
+   FROM (public.polls_responses pr
+     LEFT JOIN public.phases ph ON ((ph.id = pr.phase_id)))
+UNION ALL
+ SELECT ea.id,
+    'attendance'::text AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    ea.created_at AS contributed_at,
+    ea.created_at,
+    NULL::character varying AS participation_method,
+    e.project_id,
+    NULL::uuid AS phase_id,
+    ea.attendee_id AS user_id,
+    (ea.attendee_id)::text AS participant_id
+   FROM (public.events_attendances ea
+     LEFT JOIN public.events e ON ((e.id = ea.event_id)));
+
+
+--
 -- Name: reporting_pageviews; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -3711,6 +3876,19 @@ CREATE VIEW public.reporting_pageviews AS
             ELSE NULL::text
         END AS locale
    FROM public.impact_tracking_pageviews pv;
+
+
+--
+-- Name: reporting_participants; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_participants AS
+ SELECT participant_id AS id,
+    (max((user_id)::text))::uuid AS user_id,
+    min(contributed_at) AS created_at,
+    bool_and((user_id IS NULL)) AS anonymous
+   FROM public.reporting_contributions c
+  GROUP BY participant_id;
 
 
 --
@@ -8931,6 +9109,8 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707164520'),
+('20260707164511'),
 ('20260707161930'),
 ('20260707161925'),
 ('20260701113056'),

--- a/back/db/views/reporting_contributions_v01.sql
+++ b/back/db/views/reporting_contributions_v01.sql
@@ -1,0 +1,175 @@
+-- Reporting view: the unified participation fact. One row per participatory
+-- action a resident took, across all participation methods.
+--
+-- Shared derivation rules:
+-- * participant_id identifies the author across contributions:
+--   user id when known, the stable per-user-per-project author_hash for
+--   anonymous ideas/comments, and the row id as a last resort (each such row
+--   counts as its own participant).
+-- * phase_id is structural where the source table links to a phase; for ideas
+--   without a creation phase, and for comments and reactions, it is inferred
+--   as the project phase whose [start_at, end_at) window contains
+--   contributed_at (phases of a project never overlap).
+-- * participation_method comes from the resolved phase; comments and
+--   reactions fall back to the creation phase method of their input.
+
+-- Inputs: ideas, proposals, common-ground statements and survey responses
+SELECT
+    i.id,
+    'input' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    i.contributed_at,
+    i.created_at,
+    COALESCE(creation_ph.participation_method, inferred_ph.participation_method) AS participation_method,
+    i.project_id,
+    COALESCE(i.creation_phase_id, inferred_ph.id) AS phase_id,
+    i.author_id AS user_id,
+    COALESCE(i.author_id::text, i.author_hash, i.id::text) AS participant_id
+FROM (
+    SELECT ideas.*, COALESCE(ideas.submitted_at, ideas.published_at, ideas.created_at) AS contributed_at
+    FROM ideas
+    WHERE ideas.publication_status = 'published'
+) i
+LEFT JOIN phases creation_ph ON creation_ph.id = i.creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON i.creation_phase_id IS NULL
+    AND inferred_ph.project_id = i.project_id
+    AND i.contributed_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR i.contributed_at < inferred_ph.end_at)
+
+UNION ALL
+
+-- Comments on inputs
+SELECT
+    c.id,
+    'comment' AS type,
+    'input' AS parent_type,
+    c.idea_id AS parent_id,
+    c.created_at AS contributed_at,
+    c.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    i.project_id,
+    inferred_ph.id AS phase_id,
+    c.author_id AS user_id,
+    COALESCE(c.author_id::text, c.author_hash, c.id::text) AS participant_id
+FROM comments c
+LEFT JOIN ideas i ON i.id = c.idea_id
+LEFT JOIN phases input_creation_ph ON input_creation_ph.id = i.creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON inferred_ph.project_id = i.project_id
+    AND c.created_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR c.created_at < inferred_ph.end_at)
+WHERE c.publication_status = 'published'
+
+UNION ALL
+
+-- Reactions (likes/dislikes) on inputs and on comments
+SELECT
+    r.id,
+    'reaction' AS type,
+    r.parent_type,
+    r.parent_id,
+    r.created_at AS contributed_at,
+    r.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    r.project_id,
+    inferred_ph.id AS phase_id,
+    r.user_id,
+    COALESCE(r.user_id::text, r.id::text) AS participant_id
+FROM (
+    SELECT
+        reactions.id,
+        reactions.user_id,
+        reactions.created_at,
+        CASE WHEN reactions.reactable_type = 'Idea' THEN 'input' ELSE 'comment' END AS parent_type,
+        reactions.reactable_id AS parent_id,
+        COALESCE(ri.project_id, rci.project_id) AS project_id,
+        COALESCE(ri.creation_phase_id, rci.creation_phase_id) AS input_creation_phase_id
+    FROM reactions
+    LEFT JOIN ideas ri ON reactions.reactable_type = 'Idea' AND ri.id = reactions.reactable_id
+    LEFT JOIN comments rc ON reactions.reactable_type = 'Comment' AND rc.id = reactions.reactable_id
+    LEFT JOIN ideas rci ON rci.id = rc.idea_id
+    WHERE reactions.reactable_type IN ('Idea', 'Comment')
+) r
+LEFT JOIN phases input_creation_ph ON input_creation_ph.id = r.input_creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON inferred_ph.project_id = r.project_id
+    AND r.created_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR r.created_at < inferred_ph.end_at)
+
+UNION ALL
+
+-- Votes: each picked input in a submitted basket (voting & participatory budgeting)
+SELECT
+    bi.id,
+    'vote' AS type,
+    'input' AS parent_type,
+    bi.idea_id AS parent_id,
+    b.submitted_at AS contributed_at,
+    bi.created_at,
+    ph.participation_method,
+    ph.project_id,
+    b.phase_id,
+    b.user_id,
+    -- basket id (not row id) as fallback: a basket is one person's submission
+    COALESCE(b.user_id::text, b.id::text) AS participant_id
+FROM baskets_ideas bi
+INNER JOIN baskets b ON b.id = bi.basket_id
+LEFT JOIN phases ph ON ph.id = b.phase_id
+WHERE b.submitted_at IS NOT NULL
+
+UNION ALL
+
+-- Volunteerings: signing up for a cause
+SELECT
+    vv.id,
+    'volunteering' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    vv.created_at AS contributed_at,
+    vv.created_at,
+    ph.participation_method,
+    ph.project_id,
+    vc.phase_id,
+    vv.user_id,
+    COALESCE(vv.user_id::text, vv.id::text) AS participant_id
+FROM volunteering_volunteers vv
+INNER JOIN volunteering_causes vc ON vc.id = vv.cause_id
+LEFT JOIN phases ph ON ph.id = vc.phase_id
+
+UNION ALL
+
+-- Poll responses
+SELECT
+    pr.id,
+    'poll_response' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    pr.created_at AS contributed_at,
+    pr.created_at,
+    ph.participation_method,
+    ph.project_id,
+    pr.phase_id,
+    pr.user_id,
+    COALESCE(pr.user_id::text, pr.id::text) AS participant_id
+FROM polls_responses pr
+LEFT JOIN phases ph ON ph.id = pr.phase_id
+
+UNION ALL
+
+-- Event attendances: registering for an event
+SELECT
+    ea.id,
+    'attendance' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    ea.created_at AS contributed_at,
+    ea.created_at,
+    NULL::character varying AS participation_method,
+    e.project_id,
+    NULL::uuid AS phase_id,
+    ea.attendee_id AS user_id,
+    ea.attendee_id::text AS participant_id
+FROM events_attendances ea
+LEFT JOIN events e ON e.id = ea.event_id

--- a/back/db/views/reporting_participants_v01.sql
+++ b/back/db/views/reporting_participants_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per participant, aggregated from
+-- reporting_contributions. A participant is the (best-effort) human being
+-- behind one or more contributions; anonymous contributions without a stable
+-- author hash each count as their own participant.
+SELECT
+    c.participant_id AS id,
+    -- constant per participant_id: the user id itself, or NULL when anonymous
+    MAX(c.user_id::text)::uuid AS user_id,
+    MIN(c.contributed_at) AS created_at,
+    BOOL_AND(c.user_id IS NULL) AS anonymous
+FROM reporting_contributions c
+GROUP BY c.participant_id

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/contribution.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/contribution.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_contributions
+#
+#  id                   :uuid             primary key
+#  type                 :text
+#  parent_type          :text
+#  parent_id            :uuid
+#  contributed_at       :datetime
+#  created_at           :datetime
+#  participation_method :string
+#  project_id           :uuid
+#  phase_id             :uuid
+#  user_id              :uuid
+#  participant_id       :text
+#
+module Analytics
+  module Reporting
+    class Contribution < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_contributions'
+      self.primary_key = :id
+      # The `type` column is the contribution kind, not Rails STI.
+      self.inheritance_column = nil
+
+      def self.table_description
+        <<~DOC.squish
+          The unified participation fact: one row per action a resident took,
+          across all participation methods. Count participants as
+          COUNT(DISTINCT participant_id), optionally filtered by type, project,
+          phase or date. Not covered: participation in embedded third-party
+          surveys and document annotation. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Id of the underlying record (idea, comment, reaction, vote, ...). Unique within the view.',
+          'type' => <<~DOC.squish,
+            The kind of action: 'input' (posting an idea, proposal, common-ground
+            statement or survey response), 'comment', 'reaction' (like/dislike),
+            'vote' (one picked input in a submitted voting/budgeting basket),
+            'volunteering' (signing up for a cause), 'poll_response', or
+            'attendance' (registering for an event).
+          DOC
+          'parent_type' => <<~DOC.squish,
+            What the action targets: 'input' for comments, votes and reactions
+            on inputs; 'comment' for reactions on comments; NULL for standalone
+            actions (inputs, volunteering, poll responses, attendances).
+          DOC
+          'parent_id' => 'Id of the parent input or comment. Join to reporting_contributions.id of the parent row.',
+          'contributed_at' => 'When the resident performed the action (for inputs: submission, falling back to publication).',
+          'created_at' => 'When the underlying record was first created; can predate contributed_at for drafts.',
+          'participation_method' => <<~DOC.squish,
+            Participation method of the phase this action belongs to (see
+            reporting_phases.participation_method for values). Best-effort for
+            comments and reactions; NULL when no phase could be resolved.
+          DOC
+          'project_id' => 'The project the action happened in. Joins to reporting_projects.id. NULL only for platform-wide edge cases.',
+          'phase_id' => <<~DOC.squish,
+            The phase the action belongs to. Structural where the source links
+            to a phase; inferred from the action date for ideas without a
+            creation phase, comments and reactions. NULL for event attendances
+            and when no phase matches the date.
+          DOC
+          'user_id' => 'The registered author, or NULL for anonymous or deleted authors. Joins to reporting_users.id.',
+          'participant_id' => <<~DOC.squish
+            Stable identity of the author across contributions, to the best of
+            our ability: the user id, or a stable per-user-per-project hash for
+            anonymous ideas and comments, or the row id as last resort (such
+            rows each count as one participant, which can overcount people).
+            Use COUNT(DISTINCT participant_id) to count participants.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/participant.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/participant.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_participants
+#
+#  id         :text             primary key
+#  user_id    :uuid
+#  created_at :datetime
+#  anonymous  :boolean
+#
+module Analytics
+  module Reporting
+    class Participant < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_participants'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per participant: the (best-effort) human being behind one or
+          more rows in reporting_contributions. Anonymous contributions without
+          a stable author hash each count as their own participant, which can
+          overcount people. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Participant identity. Equals reporting_contributions.participant_id.',
+          'user_id' => 'The registered user behind this participant, or NULL when anonymous. Joins to reporting_users.id.',
+          'created_at' => 'When this participant first participated (earliest contributed_at).',
+          'anonymous' => 'TRUE when the participant cannot be tied to a registered user account.'
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/db/migrate/20260707150000_create_contribution_reporting_views.rb
+++ b/back/engines/commercial/analytics/db/migrate/20260707150000_create_contribution_reporting_views.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Second slice of the unified reporting model: the contributions fact (one row
+# per participatory action, all methods) and the participants view derived from
+# it. reporting_participants selects from reporting_contributions, so creation
+# order matters. Grants follow in a separate main-app migration.
+class CreateContributionReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_contributions, version: 1
+    create_view :reporting_participants, version: 1
+  end
+end

--- a/back/engines/commercial/analytics/db/views/reporting_contributions_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_contributions_v01.sql
@@ -1,0 +1,175 @@
+-- Reporting view: the unified participation fact. One row per participatory
+-- action a resident took, across all participation methods.
+--
+-- Shared derivation rules:
+-- * participant_id identifies the author across contributions:
+--   user id when known, the stable per-user-per-project author_hash for
+--   anonymous ideas/comments, and the row id as a last resort (each such row
+--   counts as its own participant).
+-- * phase_id is structural where the source table links to a phase; for ideas
+--   without a creation phase, and for comments and reactions, it is inferred
+--   as the project phase whose [start_at, end_at) window contains
+--   contributed_at (phases of a project never overlap).
+-- * participation_method comes from the resolved phase; comments and
+--   reactions fall back to the creation phase method of their input.
+
+-- Inputs: ideas, proposals, common-ground statements and survey responses
+SELECT
+    i.id,
+    'input' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    i.contributed_at,
+    i.created_at,
+    COALESCE(creation_ph.participation_method, inferred_ph.participation_method) AS participation_method,
+    i.project_id,
+    COALESCE(i.creation_phase_id, inferred_ph.id) AS phase_id,
+    i.author_id AS user_id,
+    COALESCE(i.author_id::text, i.author_hash, i.id::text) AS participant_id
+FROM (
+    SELECT ideas.*, COALESCE(ideas.submitted_at, ideas.published_at, ideas.created_at) AS contributed_at
+    FROM ideas
+    WHERE ideas.publication_status = 'published'
+) i
+LEFT JOIN phases creation_ph ON creation_ph.id = i.creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON i.creation_phase_id IS NULL
+    AND inferred_ph.project_id = i.project_id
+    AND i.contributed_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR i.contributed_at < inferred_ph.end_at)
+
+UNION ALL
+
+-- Comments on inputs
+SELECT
+    c.id,
+    'comment' AS type,
+    'input' AS parent_type,
+    c.idea_id AS parent_id,
+    c.created_at AS contributed_at,
+    c.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    i.project_id,
+    inferred_ph.id AS phase_id,
+    c.author_id AS user_id,
+    COALESCE(c.author_id::text, c.author_hash, c.id::text) AS participant_id
+FROM comments c
+LEFT JOIN ideas i ON i.id = c.idea_id
+LEFT JOIN phases input_creation_ph ON input_creation_ph.id = i.creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON inferred_ph.project_id = i.project_id
+    AND c.created_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR c.created_at < inferred_ph.end_at)
+WHERE c.publication_status = 'published'
+
+UNION ALL
+
+-- Reactions (likes/dislikes) on inputs and on comments
+SELECT
+    r.id,
+    'reaction' AS type,
+    r.parent_type,
+    r.parent_id,
+    r.created_at AS contributed_at,
+    r.created_at,
+    COALESCE(inferred_ph.participation_method, input_creation_ph.participation_method) AS participation_method,
+    r.project_id,
+    inferred_ph.id AS phase_id,
+    r.user_id,
+    COALESCE(r.user_id::text, r.id::text) AS participant_id
+FROM (
+    SELECT
+        reactions.id,
+        reactions.user_id,
+        reactions.created_at,
+        CASE WHEN reactions.reactable_type = 'Idea' THEN 'input' ELSE 'comment' END AS parent_type,
+        reactions.reactable_id AS parent_id,
+        COALESCE(ri.project_id, rci.project_id) AS project_id,
+        COALESCE(ri.creation_phase_id, rci.creation_phase_id) AS input_creation_phase_id
+    FROM reactions
+    LEFT JOIN ideas ri ON reactions.reactable_type = 'Idea' AND ri.id = reactions.reactable_id
+    LEFT JOIN comments rc ON reactions.reactable_type = 'Comment' AND rc.id = reactions.reactable_id
+    LEFT JOIN ideas rci ON rci.id = rc.idea_id
+    WHERE reactions.reactable_type IN ('Idea', 'Comment')
+) r
+LEFT JOIN phases input_creation_ph ON input_creation_ph.id = r.input_creation_phase_id
+LEFT JOIN phases inferred_ph
+    ON inferred_ph.project_id = r.project_id
+    AND r.created_at >= inferred_ph.start_at
+    AND (inferred_ph.end_at IS NULL OR r.created_at < inferred_ph.end_at)
+
+UNION ALL
+
+-- Votes: each picked input in a submitted basket (voting & participatory budgeting)
+SELECT
+    bi.id,
+    'vote' AS type,
+    'input' AS parent_type,
+    bi.idea_id AS parent_id,
+    b.submitted_at AS contributed_at,
+    bi.created_at,
+    ph.participation_method,
+    ph.project_id,
+    b.phase_id,
+    b.user_id,
+    -- basket id (not row id) as fallback: a basket is one person's submission
+    COALESCE(b.user_id::text, b.id::text) AS participant_id
+FROM baskets_ideas bi
+INNER JOIN baskets b ON b.id = bi.basket_id
+LEFT JOIN phases ph ON ph.id = b.phase_id
+WHERE b.submitted_at IS NOT NULL
+
+UNION ALL
+
+-- Volunteerings: signing up for a cause
+SELECT
+    vv.id,
+    'volunteering' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    vv.created_at AS contributed_at,
+    vv.created_at,
+    ph.participation_method,
+    ph.project_id,
+    vc.phase_id,
+    vv.user_id,
+    COALESCE(vv.user_id::text, vv.id::text) AS participant_id
+FROM volunteering_volunteers vv
+INNER JOIN volunteering_causes vc ON vc.id = vv.cause_id
+LEFT JOIN phases ph ON ph.id = vc.phase_id
+
+UNION ALL
+
+-- Poll responses
+SELECT
+    pr.id,
+    'poll_response' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    pr.created_at AS contributed_at,
+    pr.created_at,
+    ph.participation_method,
+    ph.project_id,
+    pr.phase_id,
+    pr.user_id,
+    COALESCE(pr.user_id::text, pr.id::text) AS participant_id
+FROM polls_responses pr
+LEFT JOIN phases ph ON ph.id = pr.phase_id
+
+UNION ALL
+
+-- Event attendances: registering for an event
+SELECT
+    ea.id,
+    'attendance' AS type,
+    NULL::text AS parent_type,
+    NULL::uuid AS parent_id,
+    ea.created_at AS contributed_at,
+    ea.created_at,
+    NULL::character varying AS participation_method,
+    e.project_id,
+    NULL::uuid AS phase_id,
+    ea.attendee_id AS user_id,
+    ea.attendee_id::text AS participant_id
+FROM events_attendances ea
+LEFT JOIN events e ON e.id = ea.event_id

--- a/back/engines/commercial/analytics/db/views/reporting_participants_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_participants_v01.sql
@@ -1,0 +1,12 @@
+-- Reporting view: one row per participant, aggregated from
+-- reporting_contributions. A participant is the (best-effort) human being
+-- behind one or more contributions; anonymous contributions without a stable
+-- author hash each count as their own participant.
+SELECT
+    c.participant_id AS id,
+    -- constant per participant_id: the user id itself, or NULL when anonymous
+    MAX(c.user_id::text)::uuid AS user_id,
+    MIN(c.contributed_at) AS created_at,
+    BOOL_AND(c.user_id IS NULL) AS anonymous
+FROM reporting_contributions c
+GROUP BY c.participant_id

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/contribution_parity_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/contribution_parity_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Guards the "consistent statistics" goal: the numbers the new contributions
+# fact produces must match the legacy participation fact wherever the two
+# models make the same modelling choice, and every deliberate divergence is
+# pinned down explicitly so it can never drift in unnoticed.
+RSpec.describe 'reporting_contributions parity with Analytics::FactParticipation' do # rubocop:disable RSpec/DescribeClass
+  before_all do
+    Analytics::PopulateDimensionsService.populate_types
+  end
+
+  def contributions = Analytics::Reporting::Contribution
+  def legacy = Analytics::FactParticipation
+
+  def legacy_count(*type_names)
+    legacy.joins(:dimension_type).where(analytics_dimension_types: { name: type_names }).count
+  end
+
+  context 'with one contribution of every kind' do
+    before do
+      create(:idea_status_proposed)
+      create(:idea, submitted_at: Time.zone.now)
+      create(:native_survey_response)
+      create(:idea, anonymous: true, submitted_at: Time.zone.now)
+      create(:comment)
+      create(:reaction)
+      create(:comment_reaction)
+      create(:baskets_idea, basket: create(:basket))
+      create(:volunteer)
+      create(:poll_response)
+      create(:event_attendance)
+    end
+
+    it 'counts the same distinct participants' do
+      expect(contributions.distinct.count(:participant_id))
+        .to eq legacy.distinct.count(:participant_id)
+    end
+
+    it 'counts the same rows for the types whose grain is unchanged' do
+      expect(contributions.where(type: 'input').count).to eq legacy_count('idea', 'survey')
+      expect(contributions.where(type: 'comment').count).to eq legacy_count('comment')
+      expect(contributions.where(type: 'reaction').count).to eq legacy_count('reaction')
+      expect(contributions.where(type: 'volunteering').count).to eq legacy_count('volunteer')
+      expect(contributions.where(type: 'poll_response').count).to eq legacy_count('poll')
+      expect(contributions.where(type: 'attendance').count).to eq legacy_count('event_attendance')
+    end
+  end
+
+  describe 'deliberate divergences from the legacy fact' do
+    it 'excludes votes in unsubmitted baskets, which the legacy fact counts' do
+      create(:baskets_idea, basket: create(:basket, submitted_at: nil))
+
+      expect(legacy_count('basket')).to eq 1
+      expect(contributions.where(type: 'vote')).to be_empty
+    end
+
+    it 'counts votes per picked input, where the legacy fact counts one row per basket' do
+      create_list(:baskets_idea, 2, basket: create(:basket))
+
+      expect(legacy_count('basket')).to eq 1
+      expect(contributions.where(type: 'vote').count).to eq 2
+      expect(contributions.distinct.count(:participant_id))
+        .to eq legacy.distinct.count(:participant_id)
+    end
+
+    it 'excludes deleted comments, which the legacy fact counts' do
+      create(:comment).update_column(:publication_status, 'deleted')
+
+      expect(legacy_count('comment')).to eq 1
+      expect(contributions.where(type: 'comment')).to be_empty
+    end
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/contribution_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/contribution_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Contribution do
+  describe 'inputs' do
+    it 'exposes a published idea with its phase inferred from the contribution date' do
+      idea = create(:idea, submitted_at: Time.zone.now)
+      row = described_class.find(idea.id)
+
+      expect(row.type).to eq 'input'
+      expect(row.parent_type).to be_nil
+      expect(row.project_id).to eq idea.project_id
+      expect(row.phase_id).to eq idea.project.phases.first.id
+      expect(row.participation_method).to eq 'ideation'
+      expect(row.user_id).to eq idea.author_id
+      expect(row.participant_id).to eq idea.author_id
+    end
+
+    it 'uses the creation phase for phase-specific inputs like survey responses' do
+      create(:idea_status_proposed)
+      response = create(:native_survey_response, submitted_at: 2.days.ago)
+      row = described_class.find(response.id)
+
+      expect(row.type).to eq 'input'
+      expect(row.phase_id).to eq response.creation_phase_id
+      expect(row.participation_method).to eq 'native_survey'
+      expect(row.contributed_at).to eq response.submitted_at
+    end
+
+    it 'excludes unpublished inputs' do
+      create(:idea, publication_status: 'draft')
+
+      expect(described_class.where(type: 'input')).to be_empty
+    end
+
+    it 'identifies anonymous authors by their stable author hash' do
+      idea = create(:idea, anonymous: true, submitted_at: Time.zone.now)
+      row = described_class.find(idea.id)
+
+      expect(row.user_id).to be_nil
+      expect(row.participant_id).to eq idea.reload.author_hash
+    end
+  end
+
+  describe 'comments' do
+    it 'exposes a comment as a child of its input' do
+      comment = create(:comment)
+      row = described_class.find(comment.id)
+
+      expect(row.type).to eq 'comment'
+      expect(row.parent_type).to eq 'input'
+      expect(row.parent_id).to eq comment.idea_id
+      expect(row.project_id).to eq comment.idea.project_id
+      expect(row.user_id).to eq comment.author_id
+    end
+
+    it 'excludes deleted comments' do
+      comment = create(:comment)
+      comment.update_column(:publication_status, 'deleted')
+
+      expect(described_class.where(type: 'comment')).to be_empty
+    end
+
+    it 'infers the phase active at commenting time' do
+      project = create(:project)
+      ideation = create(:phase, project: project, participation_method: 'ideation',
+        start_at: '2026-01-01', end_at: '2026-02-01')
+      voting = create(:phase, project: project, participation_method: 'voting',
+        voting_method: 'single_voting', start_at: '2026-02-01', end_at: nil)
+      idea = create(:idea, project: project, phases: [ideation],
+        created_at: '2026-01-10', submitted_at: '2026-01-10', published_at: '2026-01-10')
+      comment = create(:comment, idea: idea, created_at: '2026-02-10')
+
+      expect(described_class.find(idea.id).phase_id).to eq ideation.id
+      expect(described_class.find(comment.id).phase_id).to eq voting.id
+    end
+  end
+
+  describe 'reactions' do
+    it 'exposes a reaction on an input' do
+      reaction = create(:reaction)
+      row = described_class.find(reaction.id)
+
+      expect(row.type).to eq 'reaction'
+      expect(row.parent_type).to eq 'input'
+      expect(row.parent_id).to eq reaction.reactable_id
+      expect(row.project_id).to eq reaction.reactable.project_id
+    end
+
+    it 'resolves the project of a reaction on a comment through its input' do
+      comment = create(:comment)
+      reaction = create(:comment_reaction, reactable: comment)
+      row = described_class.find(reaction.id)
+
+      expect(row.parent_type).to eq 'comment'
+      expect(row.parent_id).to eq comment.id
+      expect(row.project_id).to eq comment.idea.project_id
+    end
+  end
+
+  describe 'votes' do
+    it 'exposes one vote per picked input in a submitted basket' do
+      basket = create(:basket)
+      baskets_ideas = create_list(:baskets_idea, 2, basket: basket)
+      rows = described_class.where(type: 'vote')
+
+      expect(rows.map(&:id)).to match_array baskets_ideas.map(&:id)
+      rows.each do |row|
+        expect(row.parent_type).to eq 'input'
+        expect(row.contributed_at).to eq basket.submitted_at
+        expect(row.phase_id).to eq basket.phase_id
+        expect(row.project_id).to eq basket.phase.project_id
+        expect(row.participation_method).to eq 'voting'
+        expect(row.participant_id).to eq basket.user_id
+      end
+    end
+
+    it 'excludes votes in unsubmitted baskets' do
+      basket = create(:basket, submitted_at: nil)
+      create(:baskets_idea, basket: basket)
+
+      expect(described_class.where(type: 'vote')).to be_empty
+    end
+  end
+
+  describe 'other participation types' do
+    it 'exposes volunteering with its cause phase and project' do
+      volunteer = create(:volunteer)
+      row = described_class.find(volunteer.id)
+
+      expect(row.type).to eq 'volunteering'
+      expect(row.phase_id).to eq volunteer.cause.phase_id
+      expect(row.project_id).to eq volunteer.cause.phase.project_id
+      expect(row.user_id).to eq volunteer.user_id
+    end
+
+    it 'exposes poll responses with their phase and project' do
+      response = create(:poll_response)
+      row = described_class.find(response.id)
+
+      expect(row.type).to eq 'poll_response'
+      expect(row.phase_id).to eq response.phase_id
+      expect(row.project_id).to eq response.phase.project_id
+    end
+
+    it 'exposes event attendances with their project but no phase' do
+      attendance = create(:event_attendance)
+      row = described_class.find(attendance.id)
+
+      expect(row.type).to eq 'attendance'
+      expect(row.phase_id).to be_nil
+      expect(row.project_id).to eq attendance.event.project_id
+      expect(row.participant_id).to eq attendance.attendee_id
+    end
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/participant_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/participant_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Participant do
+  it 'aggregates all contributions of a user into one participant' do
+    user = create(:user)
+    create(:idea, author: user, submitted_at: Time.zone.now)
+    create(:comment, author: user)
+    row = described_class.find(user.id)
+
+    expect(row.user_id).to eq user.id
+    expect(row.anonymous).to be false
+    expect(row.created_at)
+      .to eq Analytics::Reporting::Contribution.where(user_id: user.id).minimum(:contributed_at)
+  end
+
+  it 'exposes an anonymous participant per stable author hash' do
+    idea = create(:idea, anonymous: true, submitted_at: Time.zone.now)
+    row = described_class.find(idea.reload.author_hash)
+
+    expect(row.user_id).to be_nil
+    expect(row.anonymous).to be true
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
@@ -16,7 +16,9 @@ class McpServer::Tools::GetReportingSqlSchema < McpServer::BaseTool
     Analytics::Reporting::Project,
     Analytics::Reporting::Phase,
     Analytics::Reporting::Session,
-    Analytics::Reporting::Pageview
+    Analytics::Reporting::Pageview,
+    Analytics::Reporting::Contribution,
+    Analytics::Reporting::Participant
   ].freeze
 
   REPORTING_TABLE_NAMES = REPORTING_TABLES.map(&:table_name).freeze


### PR DESCRIPTION
# Changelog

## Added
- The AI reporting tools can now answer participation questions across every participation method: a unified contributions table records each action a resident took (posting inputs, commenting, reacting, voting, volunteering, answering polls, registering for events), and a participants table aggregates the people behind those actions, including anonymous participation.

## Technical
- Participant identity reuses the proven rule from the legacy participation fact: user id, falling back to the stable per-user-per-project author hash for anonymous ideas/comments, falling back to the row id.
- `phase_id` is structural where the source table links a phase, and inferred from the contribution date against the project's phase windows for ideas without a creation phase, comments and reactions (project phases never overlap, so the match is unambiguous).
- Deliberate divergences from the legacy participation fact are pinned in a parity spec so they can't drift unnoticed: votes count per picked input instead of per basket, unsubmitted baskets are excluded, deleted comments are excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkM7j4XfjYwsh3Ffh5Nvyk