### PR TITLE
[TAN-7935] Reporting model 3/5: inputs family

### DIFF
--- a/back/db/migrate/20260707170049_create_input_reporting_views.analytics.rb
+++ b/back/db/migrate/20260707170049_create_input_reporting_views.analytics.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This migration comes from analytics (originally 20260707170000)
+# Third slice of the unified reporting model: the inputs fact and its
+# satellites (tags, statuses, votes, reactions). Grants follow in a separate
+# main-app migration.
+class CreateInputReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_inputs, version: 1
+    create_view :reporting_input_tags, version: 1
+    create_view :reporting_input_statuses, version: 1
+    create_view :reporting_input_votes, version: 1
+    create_view :reporting_input_reactions, version: 1
+  end
+end

--- a/back/db/migrate/20260707170055_grant_reporting_input_views.rb
+++ b/back/db/migrate/20260707170055_grant_reporting_input_views.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Grants analytics_reader SELECT on the reporting views introduced by
+# CreateInputReportingViews (inputs, input tags/statuses/votes/reactions), per
+# tenant schema via Apartment. Re-runs the idempotent provisioner, which grants
+# every REPORTING_TABLES entry whose relation exists at this point in the stream.
+class GrantReportingInputViews < ActiveRecord::Migration[7.2]
+  def up
+    McpServer::AnalyticsReaderProvisioner.provision!
+  end
+
+  def down
+    # No-op: the SELECT grants on the new views disappear together with the
+    # views when CreateInputReportingViews is rolled back.
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -683,6 +683,11 @@ DROP VIEW IF EXISTS public.reporting_projects;
 DROP VIEW IF EXISTS public.reporting_phases;
 DROP VIEW IF EXISTS public.reporting_participants;
 DROP VIEW IF EXISTS public.reporting_pageviews;
+DROP VIEW IF EXISTS public.reporting_inputs;
+DROP VIEW IF EXISTS public.reporting_input_votes;
+DROP VIEW IF EXISTS public.reporting_input_tags;
+DROP VIEW IF EXISTS public.reporting_input_statuses;
+DROP VIEW IF EXISTS public.reporting_input_reactions;
 DROP VIEW IF EXISTS public.reporting_contributions;
 DROP TABLE IF EXISTS public.report_builder_reports;
 DROP TABLE IF EXISTS public.report_builder_published_graph_data_units;
@@ -3858,6 +3863,115 @@ UNION ALL
     (ea.attendee_id)::text AS participant_id
    FROM (public.events_attendances ea
      LEFT JOIN public.events e ON ((e.id = ea.event_id)));
+
+
+--
+-- Name: reporting_input_reactions; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_input_reactions AS
+ SELECT id,
+    reactable_id AS input_id,
+    user_id,
+    created_at AS reacted_at,
+    mode
+   FROM public.reactions r
+  WHERE ((reactable_type)::text = 'Idea'::text);
+
+
+--
+-- Name: reporting_input_statuses; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_input_statuses AS
+ SELECT i.id AS input_id,
+    s.id AS status_id,
+    COALESCE(NULLIF((s.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(s.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS status_label,
+    s.code AS status_code
+   FROM (public.ideas i
+     JOIN public.idea_statuses s ON ((s.id = i.idea_status_id)))
+  WHERE ((i.publication_status)::text = ANY ((ARRAY['submitted'::character varying, 'published'::character varying])::text[]));
+
+
+--
+-- Name: reporting_input_tags; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_input_tags AS
+ SELECT iit.id,
+    iit.idea_id AS input_id,
+    iit.input_topic_id AS tag_id,
+    COALESCE(NULLIF((it.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(it.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS tag_label,
+    it.parent_id AS parent_tag_id
+   FROM ((public.ideas_input_topics iit
+     JOIN public.input_topics it ON ((it.id = iit.input_topic_id)))
+     JOIN public.ideas i ON ((i.id = iit.idea_id)))
+  WHERE ((i.publication_status)::text = ANY ((ARRAY['submitted'::character varying, 'published'::character varying])::text[]));
+
+
+--
+-- Name: reporting_input_votes; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_input_votes AS
+ SELECT bi.id,
+    bi.idea_id AS input_id,
+    b.user_id,
+    b.submitted_at AS voted_at,
+    bi.votes AS weight
+   FROM (public.baskets_ideas bi
+     JOIN public.baskets b ON ((b.id = bi.basket_id)))
+  WHERE (b.submitted_at IS NOT NULL);
+
+
+--
+-- Name: reporting_inputs; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_inputs AS
+ SELECT i.id,
+    COALESCE(NULLIF((i.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(i.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS title,
+    i.created_at,
+    i.submitted_at,
+    i.published_at,
+    i.author_id,
+    i.project_id,
+    i.creation_phase_id,
+    COALESCE(creation_ph.participation_method, 'ideation'::character varying) AS participation_method,
+    (EXISTS ( SELECT 1
+           FROM public.idea_imports ii
+          WHERE (ii.idea_id = i.id))) AS imported,
+    ((EXISTS ( SELECT 1
+           FROM public.official_feedbacks ofb
+          WHERE (ofb.idea_id = i.id))) OR (EXISTS ( SELECT 1
+           FROM public.activities a
+          WHERE (((a.item_type)::text = 'Idea'::text) AND ((a.action)::text = 'changed_status'::text) AND (a.item_id = i.id))))) AS received_feedback,
+    i.likes_count,
+    i.dislikes_count,
+    i.comments_count,
+    i.votes_count,
+    COALESCE(i.manual_votes_amount, 0) AS offline_votes_count
+   FROM (public.ideas i
+     LEFT JOIN public.phases creation_ph ON ((creation_ph.id = i.creation_phase_id)))
+  WHERE ((i.publication_status)::text = ANY ((ARRAY['submitted'::character varying, 'published'::character varying])::text[]));
 
 
 --
@@ -9109,6 +9223,8 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707170055'),
+('20260707170049'),
 ('20260707164520'),
 ('20260707164511'),
 ('20260707161930'),

--- a/back/db/views/reporting_input_reactions_v01.sql
+++ b/back/db/views/reporting_input_reactions_v01.sql
@@ -1,0 +1,11 @@
+-- Reporting view: one row per reaction (like/dislike) on an input. Reactions
+-- on comments are not included here; they only appear in
+-- reporting_contributions.
+SELECT
+    r.id,
+    r.reactable_id AS input_id,
+    r.user_id,
+    r.created_at AS reacted_at,
+    r.mode
+FROM reactions r
+WHERE r.reactable_type = 'Idea'

--- a/back/db/views/reporting_input_statuses_v01.sql
+++ b/back/db/views/reporting_input_statuses_v01.sql
@@ -1,0 +1,14 @@
+-- Reporting view: the current status of each input that has one. Statuses
+-- denote where an input stands in the participation process and are managed
+-- by administrators.
+SELECT
+    i.id AS input_id,
+    s.id AS status_id,
+    COALESCE(
+        NULLIF(s.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(s.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS status_label,
+    s.code AS status_code
+FROM ideas i
+INNER JOIN idea_statuses s ON s.id = i.idea_status_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/db/views/reporting_input_tags_v01.sql
+++ b/back/db/views/reporting_input_tags_v01.sql
@@ -1,0 +1,15 @@
+-- Reporting view: one row per (input, tag) association. Tags categorize the
+-- topic of publicly visible inputs.
+SELECT
+    iit.id,
+    iit.idea_id AS input_id,
+    iit.input_topic_id AS tag_id,
+    COALESCE(
+        NULLIF(it.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(it.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS tag_label,
+    it.parent_id AS parent_tag_id
+FROM ideas_input_topics iit
+INNER JOIN input_topics it ON it.id = iit.input_topic_id
+INNER JOIN ideas i ON i.id = iit.idea_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/db/views/reporting_input_votes_v01.sql
+++ b/back/db/views/reporting_input_votes_v01.sql
@@ -1,0 +1,11 @@
+-- Reporting view: one row per vote a user cast on an input in a submitted
+-- voting or participatory-budgeting basket.
+SELECT
+    bi.id,
+    bi.idea_id AS input_id,
+    b.user_id,
+    b.submitted_at AS voted_at,
+    bi.votes AS weight
+FROM baskets_ideas bi
+INNER JOIN baskets b ON b.id = bi.basket_id
+WHERE b.submitted_at IS NOT NULL

--- a/back/db/views/reporting_inputs_v01.sql
+++ b/back/db/views/reporting_inputs_v01.sql
@@ -1,0 +1,36 @@
+-- Reporting view: one row per input, the result of a participant filling out
+-- and submitting a form: ideas, proposals, common-ground statements and survey
+-- responses. Draft inputs are excluded.
+SELECT
+    i.id,
+    COALESCE(
+        NULLIF(i.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(i.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    i.created_at,
+    i.submitted_at,
+    i.published_at,
+    i.author_id,
+    i.project_id,
+    i.creation_phase_id,
+    -- inputs without a creation phase were posted through a transitive method,
+    -- which the product resolves to ideation
+    COALESCE(creation_ph.participation_method, 'ideation') AS participation_method,
+    EXISTS (
+        SELECT 1 FROM idea_imports ii WHERE ii.idea_id = i.id
+    ) AS imported,
+    (
+        EXISTS (SELECT 1 FROM official_feedbacks ofb WHERE ofb.idea_id = i.id)
+        OR EXISTS (
+            SELECT 1 FROM activities a
+            WHERE a.item_type = 'Idea' AND a.action = 'changed_status' AND a.item_id = i.id
+        )
+    ) AS received_feedback,
+    i.likes_count,
+    i.dislikes_count,
+    i.comments_count,
+    i.votes_count,
+    COALESCE(i.manual_votes_amount, 0) AS offline_votes_count
+FROM ideas i
+LEFT JOIN phases creation_ph ON creation_ph.id = i.creation_phase_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_inputs
+#
+#  id                   :uuid             primary key
+#  title                :text
+#  created_at           :datetime
+#  submitted_at         :datetime
+#  published_at         :datetime
+#  author_id            :uuid
+#  project_id           :uuid
+#  creation_phase_id    :uuid
+#  participation_method :string
+#  imported             :boolean
+#  received_feedback    :boolean
+#  likes_count          :integer
+#  dislikes_count       :integer
+#  comments_count       :integer
+#  votes_count          :integer
+#  offline_votes_count  :integer
+#
+module Analytics
+  module Reporting
+    class Input < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_inputs'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per input: the highest-level contribution, created by filling
+          out and submitting a form. Depending on the participation method an
+          input is an idea, a proposal, a common-ground statement or a survey
+          response. Drafts are excluded. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => <<~DOC.squish,
+            Input primary key. Joins to reporting_input_tags, _statuses, _votes
+            and _reactions on their input_id, and to
+            reporting_contributions.parent_id.
+          DOC
+          'title' => 'Input title, resolved to the platform primary locale. NULL for survey responses, which have no title.',
+          'created_at' => 'When the input was first created, possibly as a draft.',
+          'submitted_at' => 'When the participant submitted the input. NULL for older records.',
+          'published_at' => <<~DOC.squish,
+            When the input became publicly visible. Can be later than
+            submitted_at when administrators review inputs before publication,
+            and NULL for inputs that are submitted but not (yet) published.
+          DOC
+          'author_id' => 'The registered author, or NULL for anonymous or deleted authors. Joins to reporting_users.id.',
+          'project_id' => 'The project the input was posted in. Joins to reporting_projects.id.',
+          'creation_phase_id' => <<~DOC.squish,
+            The phase the input was created in, for phase-specific methods like
+            surveys. NULL for ideation and proposals inputs, which live across
+            phases.
+          DOC
+          'participation_method' => <<~DOC.squish,
+            The participation method the input was originally posted through
+            (see reporting_phases.participation_method for values). Filter on
+            this to separate ideas from survey responses.
+          DOC
+          'imported' => 'TRUE when the input was imported by an administrator (e.g. from paper forms) rather than posted online.',
+          'received_feedback' => <<~DOC.squish,
+            TRUE when an administrator gave official feedback on the input or
+            changed its status. Only meaningful for publicly visible methods
+            (ideation, proposals).
+          DOC
+          'likes_count' => 'Number of likes on the input.',
+          'dislikes_count' => 'Number of dislikes on the input.',
+          'comments_count' => 'Number of published comments on the input.',
+          'votes_count' => 'Total online votes the input received in voting/budgeting phases.',
+          'offline_votes_count' => 'Manually registered offline votes, entered by administrators. 0 when none.'
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input_reaction.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input_reaction.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_input_reactions
+#
+#  id         :uuid             primary key
+#  input_id   :uuid
+#  user_id    :uuid
+#  reacted_at :datetime
+#  mode       :string
+#
+module Analytics
+  module Reporting
+    class InputReaction < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_input_reactions'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per reaction (like or dislike) on an input. Authors like
+          their own input by default when posting it. Reactions on comments are
+          not included here; they only appear in reporting_contributions. All
+          timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Reaction primary key.',
+          'input_id' => 'The input reacted to. Joins to reporting_inputs.id.',
+          'user_id' => 'The reacting user, or NULL for anonymous or deleted users. Joins to reporting_users.id.',
+          'reacted_at' => 'When the reaction was placed.',
+          'mode' => "'up' for a like, 'down' for a dislike."
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input_status.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input_status.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_input_statuses
+#
+#  input_id     :uuid             primary key
+#  status_id    :uuid
+#  status_label :text
+#  status_code  :string
+#
+module Analytics
+  module Reporting
+    class InputStatus < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_input_statuses'
+      self.primary_key = :input_id
+
+      def self.table_description
+        <<~DOC.squish
+          The current status of each input. Statuses show where an input
+          stands in the participation process and are managed by
+          administrators; they are only meaningful for publicly visible
+          methods (ideation, proposals), even though survey responses carry a
+          default status too. One row per input.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'input_id' => 'The input. Joins to reporting_inputs.id.',
+          'status_id' => 'The status. Group on it to count inputs per status.',
+          'status_label' => 'Status name as configured by administrators, resolved to the platform primary locale.',
+          'status_code' => <<~DOC.squish
+            Locale-independent status category. For ideas: 'proposed', 'viewed',
+            'under_consideration', 'accepted', 'implemented', 'rejected' or
+            'custom'. For proposals also: 'threshold_reached', 'expired',
+            'answered', 'ineligible'. Prefer this over status_label for
+            filtering.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input_tag.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input_tag.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_input_tags
+#
+#  id            :uuid             primary key
+#  input_id      :uuid
+#  tag_id        :uuid
+#  tag_label     :text
+#  parent_tag_id :uuid
+#
+module Analytics
+  module Reporting
+    class InputTag < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_input_tags'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per tag on an input. Tags (also called topics) categorize
+          what an input is about and can be nested one level: when reporting
+          per tag, roll child tags up into their parent via parent_tag_id.
+          An input can carry multiple tags.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Primary key of the input-tag association.',
+          'input_id' => 'The tagged input. Joins to reporting_inputs.id.',
+          'tag_id' => 'The tag. Multiple rows share a tag_id; group on it to count per tag.',
+          'tag_label' => 'Tag name, resolved to the platform primary locale.',
+          'parent_tag_id' => 'The parent tag when this tag is a child in a two-level hierarchy, NULL for top-level tags.'
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input_vote.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input_vote.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_input_votes
+#
+#  id       :uuid             primary key
+#  input_id :uuid
+#  user_id  :uuid
+#  voted_at :datetime
+#  weight   :integer
+#
+module Analytics
+  module Reporting
+    class InputVote < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_input_votes'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per vote a user cast on an input during a voting or
+          participatory-budgeting phase, from submitted ballots only. Offline
+          votes are not included here; they only exist as a total in
+          reporting_inputs.offline_votes_count. All timestamps are in UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => 'Vote primary key.',
+          'input_id' => 'The input the vote is for. Joins to reporting_inputs.id.',
+          'user_id' => 'The voter, or NULL for deleted users. Joins to reporting_users.id.',
+          'voted_at' => 'When the voter submitted their ballot.',
+          'weight' => <<~DOC.squish
+            Magnitude of the vote: 1 for single voting, the number of votes put
+            on this input for multiple voting, and the allocated amount for
+            participatory budgeting. SUM(weight) gives an input's online vote
+            total.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/db/migrate/20260707170000_create_input_reporting_views.rb
+++ b/back/engines/commercial/analytics/db/migrate/20260707170000_create_input_reporting_views.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Third slice of the unified reporting model: the inputs fact and its
+# satellites (tags, statuses, votes, reactions). Grants follow in a separate
+# main-app migration.
+class CreateInputReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_inputs, version: 1
+    create_view :reporting_input_tags, version: 1
+    create_view :reporting_input_statuses, version: 1
+    create_view :reporting_input_votes, version: 1
+    create_view :reporting_input_reactions, version: 1
+  end
+end

--- a/back/engines/commercial/analytics/db/views/reporting_input_reactions_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_input_reactions_v01.sql
@@ -1,0 +1,11 @@
+-- Reporting view: one row per reaction (like/dislike) on an input. Reactions
+-- on comments are not included here; they only appear in
+-- reporting_contributions.
+SELECT
+    r.id,
+    r.reactable_id AS input_id,
+    r.user_id,
+    r.created_at AS reacted_at,
+    r.mode
+FROM reactions r
+WHERE r.reactable_type = 'Idea'

--- a/back/engines/commercial/analytics/db/views/reporting_input_statuses_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_input_statuses_v01.sql
@@ -1,0 +1,14 @@
+-- Reporting view: the current status of each input that has one. Statuses
+-- denote where an input stands in the participation process and are managed
+-- by administrators.
+SELECT
+    i.id AS input_id,
+    s.id AS status_id,
+    COALESCE(
+        NULLIF(s.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(s.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS status_label,
+    s.code AS status_code
+FROM ideas i
+INNER JOIN idea_statuses s ON s.id = i.idea_status_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/engines/commercial/analytics/db/views/reporting_input_tags_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_input_tags_v01.sql
@@ -1,0 +1,15 @@
+-- Reporting view: one row per (input, tag) association. Tags categorize the
+-- topic of publicly visible inputs.
+SELECT
+    iit.id,
+    iit.idea_id AS input_id,
+    iit.input_topic_id AS tag_id,
+    COALESCE(
+        NULLIF(it.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(it.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS tag_label,
+    it.parent_id AS parent_tag_id
+FROM ideas_input_topics iit
+INNER JOIN input_topics it ON it.id = iit.input_topic_id
+INNER JOIN ideas i ON i.id = iit.idea_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/engines/commercial/analytics/db/views/reporting_input_votes_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_input_votes_v01.sql
@@ -1,0 +1,11 @@
+-- Reporting view: one row per vote a user cast on an input in a submitted
+-- voting or participatory-budgeting basket.
+SELECT
+    bi.id,
+    bi.idea_id AS input_id,
+    b.user_id,
+    b.submitted_at AS voted_at,
+    bi.votes AS weight
+FROM baskets_ideas bi
+INNER JOIN baskets b ON b.id = bi.basket_id
+WHERE b.submitted_at IS NOT NULL

--- a/back/engines/commercial/analytics/db/views/reporting_inputs_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_inputs_v01.sql
@@ -1,0 +1,36 @@
+-- Reporting view: one row per input, the result of a participant filling out
+-- and submitting a form: ideas, proposals, common-ground statements and survey
+-- responses. Draft inputs are excluded.
+SELECT
+    i.id,
+    COALESCE(
+        NULLIF(i.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(i.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS title,
+    i.created_at,
+    i.submitted_at,
+    i.published_at,
+    i.author_id,
+    i.project_id,
+    i.creation_phase_id,
+    -- inputs without a creation phase were posted through a transitive method,
+    -- which the product resolves to ideation
+    COALESCE(creation_ph.participation_method, 'ideation') AS participation_method,
+    EXISTS (
+        SELECT 1 FROM idea_imports ii WHERE ii.idea_id = i.id
+    ) AS imported,
+    (
+        EXISTS (SELECT 1 FROM official_feedbacks ofb WHERE ofb.idea_id = i.id)
+        OR EXISTS (
+            SELECT 1 FROM activities a
+            WHERE a.item_type = 'Idea' AND a.action = 'changed_status' AND a.item_id = i.id
+        )
+    ) AS received_feedback,
+    i.likes_count,
+    i.dislikes_count,
+    i.comments_count,
+    i.votes_count,
+    COALESCE(i.manual_votes_amount, 0) AS offline_votes_count
+FROM ideas i
+LEFT JOIN phases creation_ph ON creation_ph.id = i.creation_phase_id
+WHERE i.publication_status IN ('submitted', 'published')

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_parity_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_parity_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The received_feedback boolean must agree with the legacy posts fact
+# (analytics_fact_posts), which derives the same signal from official
+# feedbacks and status-change activities.
+RSpec.describe 'reporting_inputs parity with Analytics::FactPost' do # rubocop:disable RSpec/DescribeClass
+  before_all do
+    Analytics::PopulateDimensionsService.populate_types
+  end
+
+  before do
+    create(:idea)
+    create(:official_feedback)
+    create(:idea_changed_status_activity, item: create(:idea))
+  end
+
+  it 'agrees with the legacy posts fact on which inputs received feedback' do
+    expect(Analytics::Reporting::Input.where(received_feedback: true).count)
+      .to eq Analytics::FactPost.where(feedback_none: 0).count
+    expect(Analytics::Reporting::Input.where(received_feedback: false).count)
+      .to eq Analytics::FactPost.where(feedback_none: 1).count
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_reaction_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_reaction_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::InputReaction do
+  it 'exposes reactions on inputs' do
+    reaction = create(:reaction, mode: 'down')
+    row = described_class.find(reaction.id)
+
+    expect(row.input_id).to eq reaction.reactable_id
+    expect(row.user_id).to eq reaction.user_id
+    expect(row.reacted_at).to eq reaction.reload.created_at
+    expect(row.mode).to eq 'down'
+  end
+
+  it 'excludes reactions on comments' do
+    create(:comment_reaction)
+
+    expect(described_class.count).to eq 0
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::Input do
+  it 'exposes a published idea with its localized title and counters' do
+    idea = create(:idea, title_multiloc: { 'en' => 'Plant more trees', 'nl-BE' => 'Plant meer bomen' })
+    row = described_class.find(idea.id)
+
+    expect(row.title).to eq 'Plant more trees'
+    expect(row.author_id).to eq idea.author_id
+    expect(row.project_id).to eq idea.project_id
+    expect(row.participation_method).to eq 'ideation'
+    expect(row.likes_count).to eq idea.likes_count
+    expect(row.comments_count).to eq idea.comments_count
+  end
+
+  it 'includes submitted (pre-screening) inputs but excludes drafts' do
+    submitted = create(:idea, publication_status: 'submitted', submitted_at: Time.zone.now)
+    create(:idea, publication_status: 'draft')
+
+    expect(described_class.ids).to eq [submitted.id]
+  end
+
+  it 'resolves the participation method of phase-specific inputs from their creation phase' do
+    create(:idea_status_proposed)
+    response = create(:native_survey_response)
+
+    expect(described_class.find(response.id).participation_method).to eq 'native_survey'
+  end
+
+  describe 'imported' do
+    it 'flags inputs that were imported by administrators' do
+      idea = create(:idea)
+      imported_idea = create(:idea)
+      create(:idea_import, idea: imported_idea)
+
+      expect(described_class.find(idea.id).imported).to be false
+      expect(described_class.find(imported_idea.id).imported).to be true
+    end
+  end
+
+  describe 'received_feedback' do
+    it 'is false without any administrator feedback' do
+      idea = create(:idea)
+
+      expect(described_class.find(idea.id).received_feedback).to be false
+    end
+
+    it 'is true after official feedback' do
+      feedback = create(:official_feedback)
+
+      expect(described_class.find(feedback.idea_id).received_feedback).to be true
+    end
+
+    it 'is true after a status change' do
+      idea = create(:idea)
+      create(:idea_changed_status_activity, item: idea)
+
+      expect(described_class.find(idea.id).received_feedback).to be true
+    end
+  end
+
+  describe 'offline_votes_count' do
+    it 'exposes manual votes and defaults to 0' do
+      idea = create(:idea)
+      offline_idea = create(:idea, manual_votes_amount: 5)
+
+      expect(described_class.find(idea.id).offline_votes_count).to eq 0
+      expect(described_class.find(offline_idea.id).offline_votes_count).to eq 5
+    end
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_status_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_status_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::InputStatus do
+  it 'exposes the current status of an input with label and code' do
+    status = create(:idea_status, code: 'accepted', title_multiloc: { 'en' => 'Approved', 'nl-BE' => 'Goedgekeurd' })
+    idea = create(:idea, idea_status: status)
+    row = described_class.find(idea.id)
+
+    expect(row.status_id).to eq status.id
+    expect(row.status_label).to eq 'Approved'
+    expect(row.status_code).to eq 'accepted'
+  end
+
+  it 'has no row for draft inputs' do
+    status = create(:idea_status)
+    create(:idea, idea_status: status, publication_status: 'draft')
+
+    expect(described_class.where(status_id: status.id)).to be_empty
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_tag_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_tag_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::InputTag do
+  it 'exposes one row per tag on an input, with its localized label' do
+    idea = create(:idea)
+    tag = create(:input_topic, project: idea.project, title_multiloc: { 'en' => 'Nature', 'nl-BE' => 'Natuur' })
+    idea.input_topics << tag
+    row = described_class.find_by!(input_id: idea.id)
+
+    expect(row.tag_id).to eq tag.id
+    expect(row.tag_label).to eq 'Nature'
+    expect(row.parent_tag_id).to be_nil
+  end
+
+  it 'exposes the parent of a nested tag for rollups' do
+    idea = create(:idea)
+    parent = create(:input_topic, project: idea.project)
+    child = create(:input_topic, project: idea.project, parent: parent)
+    idea.input_topics << child
+
+    expect(described_class.find_by!(input_id: idea.id).parent_tag_id).to eq parent.id
+  end
+
+  it 'excludes tags of draft inputs' do
+    idea = create(:idea, publication_status: 'draft')
+    idea.input_topics << create(:input_topic, project: idea.project)
+
+    expect(described_class.where(input_id: idea.id)).to be_empty
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_vote_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_vote_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::InputVote do
+  it 'exposes one row per vote in a submitted basket, with its weight' do
+    # in a budgeting basket the vote magnitude is the idea's allocated budget
+    baskets_idea = create(:baskets_idea).reload
+    row = described_class.find(baskets_idea.id)
+
+    expect(row.input_id).to eq baskets_idea.idea_id
+    expect(row.user_id).to eq baskets_idea.basket.user_id
+    expect(row.voted_at).to eq baskets_idea.basket.submitted_at
+    expect(row.weight).to eq baskets_idea.votes
+    expect(row.weight).to eq baskets_idea.idea.budget
+  end
+
+  it 'excludes votes in unsubmitted baskets' do
+    create(:baskets_idea, basket: create(:basket, submitted_at: nil))
+
+    expect(described_class.count).to eq 0
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
@@ -18,7 +18,12 @@ class McpServer::Tools::GetReportingSqlSchema < McpServer::BaseTool
     Analytics::Reporting::Session,
     Analytics::Reporting::Pageview,
     Analytics::Reporting::Contribution,
-    Analytics::Reporting::Participant
+    Analytics::Reporting::Participant,
+    Analytics::Reporting::Input,
+    Analytics::Reporting::InputTag,
+    Analytics::Reporting::InputStatus,
+    Analytics::Reporting::InputVote,
+    Analytics::Reporting::InputReaction
   ].freeze
 
   REPORTING_TABLE_NAMES = REPORTING_TABLES.map(&:table_name).freeze


### PR DESCRIPTION
# Changelog

## Added
- The AI reporting tools can now answer detailed questions about inputs (ideas, proposals, common-ground statements, survey responses): their tags (with parent-tag rollups), current status, individual votes with their magnitude (including participatory-budgeting allocations), and reactions. Input rows carry engagement counters, offline vote totals, whether they were imported from paper forms and whether they received official feedback.

## Technical
- `received_feedback` ports the legacy `analytics_build_feedbacks` derivation (official feedbacks + status-change activities) to a single boolean, guarded by a parity spec against `analytics_fact_posts`.
- `participation_method` mirrors the product's resolution: the creation phase's method, defaulting to ideation for transitive inputs.
- Vote rows come from submitted baskets only, with `weight` carrying the per-pick magnitude (votes for multiple voting, allocated budget for budgeting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkM7j4XfjYwsh3Ffh5Nvyk