### PR TITLE
[TAN-7935] Reporting model 4/5: users and question answers

### DIFF
--- a/back/db/migrate/20260707171133_create_user_and_answer_reporting_views.analytics.rb
+++ b/back/db/migrate/20260707171133_create_user_and_answer_reporting_views.analytics.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This migration comes from analytics (originally 20260707180000)
+# Fourth slice of the unified reporting model: active users (without PII) and
+# the exploded question answers for users (demographics) and inputs (survey
+# and idea-form answers). reporting_user_question_answers selects from
+# reporting_users, so creation order matters. Grants follow in a separate
+# main-app migration.
+class CreateUserAndAnswerReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_users, version: 1
+    create_view :reporting_user_question_answers, version: 1
+    create_view :reporting_input_question_answers, version: 1
+  end
+end

--- a/back/db/migrate/20260707171140_grant_reporting_user_and_answer_views.rb
+++ b/back/db/migrate/20260707171140_grant_reporting_user_and_answer_views.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Grants analytics_reader SELECT on the reporting views introduced by
+# CreateUserAndAnswerReportingViews (users, user/input question answers), per
+# tenant schema via Apartment. Re-runs the idempotent provisioner, which grants
+# every REPORTING_TABLES entry whose relation exists at this point in the stream.
+class GrantReportingUserAndAnswerViews < ActiveRecord::Migration[7.2]
+  def up
+    McpServer::AnalyticsReaderProvisioner.provision!
+  end
+
+  def down
+    # No-op: the SELECT grants on the new views disappear together with the
+    # views when CreateUserAndAnswerReportingViews is rolled back.
+  end
+end

--- a/back/db/structure.sql
+++ b/back/db/structure.sql
@@ -678,6 +678,8 @@ DROP TABLE IF EXISTS public.static_page_files;
 DROP TABLE IF EXISTS public.spam_reports;
 DROP TABLE IF EXISTS public.spaces;
 DROP TABLE IF EXISTS public.schema_migrations;
+DROP VIEW IF EXISTS public.reporting_user_question_answers;
+DROP VIEW IF EXISTS public.reporting_users;
 DROP VIEW IF EXISTS public.reporting_sessions;
 DROP VIEW IF EXISTS public.reporting_projects;
 DROP VIEW IF EXISTS public.reporting_phases;
@@ -688,6 +690,7 @@ DROP VIEW IF EXISTS public.reporting_input_votes;
 DROP VIEW IF EXISTS public.reporting_input_tags;
 DROP VIEW IF EXISTS public.reporting_input_statuses;
 DROP VIEW IF EXISTS public.reporting_input_reactions;
+DROP VIEW IF EXISTS public.reporting_input_question_answers;
 DROP VIEW IF EXISTS public.reporting_contributions;
 DROP TABLE IF EXISTS public.report_builder_reports;
 DROP TABLE IF EXISTS public.report_builder_published_graph_data_units;
@@ -3866,6 +3869,62 @@ UNION ALL
 
 
 --
+-- Name: reporting_input_question_answers; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_input_question_answers AS
+ WITH form_inputs AS (
+         SELECT i.id,
+            i.custom_field_values,
+            COALESCE(phase_form.id, project_form.id) AS form_id
+           FROM ((public.ideas i
+             LEFT JOIN public.custom_forms phase_form ON ((((phase_form.participation_context_type)::text = 'Phase'::text) AND (phase_form.participation_context_id = i.creation_phase_id))))
+             LEFT JOIN public.custom_forms project_form ON ((((project_form.participation_context_type)::text = 'Project'::text) AND (project_form.participation_context_id = i.project_id))))
+          WHERE ((i.publication_status)::text = ANY ((ARRAY['submitted'::character varying, 'published'::character varying])::text[]))
+        )
+ SELECT i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(NULLIF((q.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(q.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS question_label,
+        CASE
+            WHEN ((q.input_type)::text = ANY ((ARRAY['number'::character varying, 'linear_scale'::character varying, 'rating'::character varying, 'sentiment_linear_scale'::character varying])::text[])) THEN NULL::text
+            ELSE (i.custom_field_values ->> (q.key)::text)
+        END AS value_text,
+        CASE
+            WHEN (((q.input_type)::text = ANY ((ARRAY['number'::character varying, 'linear_scale'::character varying, 'rating'::character varying, 'sentiment_linear_scale'::character varying])::text[])) AND (jsonb_typeof((i.custom_field_values -> (q.key)::text)) = 'number'::text)) THEN ((i.custom_field_values ->> (q.key)::text))::numeric
+            ELSE NULL::numeric
+        END AS value_numeric
+   FROM (form_inputs i
+     JOIN public.custom_fields q ON ((((q.resource_type)::text = 'CustomForm'::text) AND (q.resource_id = i.form_id) AND ((q.input_type)::text = ANY ((ARRAY['text'::character varying, 'multiline_text'::character varying, 'select'::character varying, 'select_image'::character varying, 'checkbox'::character varying, 'date'::character varying, 'number'::character varying, 'linear_scale'::character varying, 'rating'::character varying, 'sentiment_linear_scale'::character varying])::text[])))))
+  WHERE jsonb_exists(i.custom_field_values, (q.key)::text)
+UNION ALL
+ SELECT i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(NULLIF((q.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(q.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS question_label,
+    selected.value AS value_text,
+    NULL::numeric AS value_numeric
+   FROM ((form_inputs i
+     JOIN public.custom_fields q ON ((((q.resource_type)::text = 'CustomForm'::text) AND (q.resource_id = i.form_id) AND ((q.input_type)::text = ANY ((ARRAY['multiselect'::character varying, 'multiselect_image'::character varying])::text[])))))
+     CROSS JOIN LATERAL jsonb_array_elements_text((i.custom_field_values -> (q.key)::text)) selected(value))
+  WHERE (jsonb_typeof((i.custom_field_values -> (q.key)::text)) = 'array'::text);
+
+
+--
 -- Name: reporting_input_reactions; Type: VIEW; Schema: public; Owner: -
 --
 
@@ -4071,6 +4130,66 @@ CREATE VIEW public.reporting_sessions AS
     device_type AS device,
     referrer
    FROM public.impact_tracking_sessions s;
+
+
+--
+-- Name: reporting_users; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_users AS
+ SELECT id,
+    registration_completed_at AS registered_at,
+    created_at,
+        CASE
+            WHEN (roles @> '[{"type": "admin"}]'::jsonb) THEN 'admin'::text
+            WHEN (roles @> '[{"type": "space_moderator"}]'::jsonb) THEN 'space_moderator'::text
+            WHEN (roles @> '[{"type": "project_folder_moderator"}]'::jsonb) THEN 'project_folder_moderator'::text
+            WHEN (roles @> '[{"type": "project_moderator"}]'::jsonb) THEN 'project_moderator'::text
+            ELSE 'user'::text
+        END AS highest_role
+   FROM public.users u
+  WHERE ((registration_completed_at IS NOT NULL) AND ((invite_status IS NULL) OR ((invite_status)::text <> 'pending'::text)) AND ((block_end_at IS NULL) OR (block_end_at < now())));
+
+
+--
+-- Name: reporting_user_question_answers; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW public.reporting_user_question_answers AS
+ SELECT u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(NULLIF((q.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(q.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS question_label,
+    (u.custom_field_values ->> (q.key)::text) AS answer_value
+   FROM ((public.reporting_users ru
+     JOIN public.users u ON ((u.id = ru.id)))
+     JOIN public.custom_fields q ON ((((q.resource_type)::text = 'User'::text) AND q.enabled)))
+  WHERE (((q.input_type)::text <> 'multiselect'::text) AND jsonb_exists(u.custom_field_values, (q.key)::text))
+UNION ALL
+ SELECT u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(NULLIF((q.title_multiloc ->> ( SELECT (((ac.settings -> 'core'::text) -> 'locales'::text) ->> 0)
+           FROM public.app_configurations ac
+         LIMIT 1)), ''::text), ( SELECT t.value
+           FROM jsonb_each_text(q.title_multiloc) t(key, value)
+          WHERE (t.value <> ''::text)
+          ORDER BY t.key
+         LIMIT 1)) AS question_label,
+    selected.value AS answer_value
+   FROM (((public.reporting_users ru
+     JOIN public.users u ON ((u.id = ru.id)))
+     JOIN public.custom_fields q ON ((((q.resource_type)::text = 'User'::text) AND q.enabled AND ((q.input_type)::text = 'multiselect'::text))))
+     CROSS JOIN LATERAL jsonb_array_elements_text((u.custom_field_values -> (q.key)::text)) selected(value))
+  WHERE (jsonb_typeof((u.custom_field_values -> (q.key)::text)) = 'array'::text);
 
 
 --
@@ -9223,6 +9342,8 @@ ALTER TABLE ONLY public.project_reviews
 SET search_path TO public,shared_extensions;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260707171140'),
+('20260707171133'),
 ('20260707170055'),
 ('20260707170049'),
 ('20260707164520'),

--- a/back/db/views/reporting_input_question_answers_v01.sql
+++ b/back/db/views/reporting_input_question_answers_v01.sql
@@ -1,0 +1,72 @@
+-- Reporting view: one row per answer to a form question of an input (survey
+-- questions and extra idea-form fields). The form is resolved from the
+-- input's creation phase, falling back to the project form. Multi-select
+-- questions produce one row per selected option. Structurally complex
+-- question types (ranking, matrix, mapping, file upload, pages) are not
+-- included.
+
+WITH form_inputs AS (
+    SELECT
+        i.id,
+        i.custom_field_values,
+        COALESCE(phase_form.id, project_form.id) AS form_id
+    FROM ideas i
+    LEFT JOIN custom_forms phase_form
+        ON phase_form.participation_context_type = 'Phase'
+        AND phase_form.participation_context_id = i.creation_phase_id
+    LEFT JOIN custom_forms project_form
+        ON project_form.participation_context_type = 'Project'
+        AND project_form.participation_context_id = i.project_id
+    WHERE i.publication_status IN ('submitted', 'published')
+)
+
+-- single-valued questions
+SELECT
+    i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    CASE
+        WHEN q.input_type IN ('number', 'linear_scale', 'rating', 'sentiment_linear_scale') THEN NULL
+        ELSE i.custom_field_values ->> q.key
+    END AS value_text,
+    CASE
+        WHEN q.input_type IN ('number', 'linear_scale', 'rating', 'sentiment_linear_scale')
+            AND jsonb_typeof(i.custom_field_values -> q.key) = 'number'
+        THEN (i.custom_field_values ->> q.key)::numeric
+    END AS value_numeric
+FROM form_inputs i
+INNER JOIN custom_fields q
+    ON q.resource_type = 'CustomForm'
+    AND q.resource_id = i.form_id
+    AND q.input_type IN (
+        'text', 'multiline_text', 'select', 'select_image', 'checkbox', 'date',
+        'number', 'linear_scale', 'rating', 'sentiment_linear_scale'
+    )
+WHERE jsonb_exists(i.custom_field_values, q.key)
+
+UNION ALL
+
+-- multi-select questions: one row per selected option
+SELECT
+    i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    selected.value AS value_text,
+    NULL::numeric AS value_numeric
+FROM form_inputs i
+INNER JOIN custom_fields q
+    ON q.resource_type = 'CustomForm'
+    AND q.resource_id = i.form_id
+    AND q.input_type IN ('multiselect', 'multiselect_image')
+CROSS JOIN LATERAL jsonb_array_elements_text(i.custom_field_values -> q.key) AS selected(value)
+WHERE jsonb_typeof(i.custom_field_values -> q.key) = 'array'

--- a/back/db/views/reporting_user_question_answers_v01.sql
+++ b/back/db/views/reporting_user_question_answers_v01.sql
@@ -1,0 +1,39 @@
+-- Reporting view: one row per answer an active user gave to an enabled
+-- registration question (demographics). Multi-select questions produce one
+-- row per selected option.
+
+-- single-valued questions
+SELECT
+    u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    u.custom_field_values ->> q.key AS answer_value
+FROM reporting_users ru
+INNER JOIN users u ON u.id = ru.id
+INNER JOIN custom_fields q ON q.resource_type = 'User' AND q.enabled
+WHERE q.input_type <> 'multiselect'
+    AND jsonb_exists(u.custom_field_values, q.key)
+
+UNION ALL
+
+-- multi-select questions: one row per selected option
+SELECT
+    u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    selected.value AS answer_value
+FROM reporting_users ru
+INNER JOIN users u ON u.id = ru.id
+INNER JOIN custom_fields q ON q.resource_type = 'User' AND q.enabled AND q.input_type = 'multiselect'
+CROSS JOIN LATERAL jsonb_array_elements_text(u.custom_field_values -> q.key) AS selected(value)
+WHERE jsonb_typeof(u.custom_field_values -> q.key) = 'array'

--- a/back/db/views/reporting_users_v01.sql
+++ b/back/db/views/reporting_users_v01.sql
@@ -1,0 +1,19 @@
+-- Reporting view: one row per active registered user. Users who are not (yet)
+-- active are excluded: pending invitations, incomplete registrations and
+-- currently blocked accounts. Deliberately carries no personally identifiable
+-- information.
+SELECT
+    u.id,
+    u.registration_completed_at AS registered_at,
+    u.created_at,
+    CASE
+        WHEN u.roles @> '[{"type":"admin"}]' THEN 'admin'
+        WHEN u.roles @> '[{"type":"space_moderator"}]' THEN 'space_moderator'
+        WHEN u.roles @> '[{"type":"project_folder_moderator"}]' THEN 'project_folder_moderator'
+        WHEN u.roles @> '[{"type":"project_moderator"}]' THEN 'project_moderator'
+        ELSE 'user'
+    END AS highest_role
+FROM users u
+WHERE u.registration_completed_at IS NOT NULL
+    AND (u.invite_status IS NULL OR u.invite_status <> 'pending')
+    AND (u.block_end_at IS NULL OR u.block_end_at < now())

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/input_question_answer.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/input_question_answer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_input_question_answers
+#
+#  input_id       :uuid
+#  question_id    :uuid
+#  question_key   :string
+#  question_type  :string
+#  question_label :text
+#  value_text     :text
+#  value_numeric  :decimal(, )
+#
+module Analytics
+  module Reporting
+    class InputQuestionAnswer < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_input_question_answers'
+      self.primary_key = nil
+
+      def self.table_description
+        <<~DOC.squish
+          One row per answer to a form question of an input: survey answers and
+          extra idea-form fields. Multi-select questions produce one row per
+          selected option. Structurally complex question types (ranking,
+          matrix, mapping, file upload) are not included. Inputs that skipped a
+          question have no row for it.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'input_id' => 'The input the answer belongs to. Joins to reporting_inputs.id.',
+          'question_id' => 'Id of the form question (custom field). Group on it to aggregate per question.',
+          'question_key' => 'Stable machine key of the question within its form.',
+          'question_type' => <<~DOC.squish,
+            Answer format: 'select', 'select_image', 'multiselect',
+            'multiselect_image', 'checkbox', 'text', 'multiline_text', 'date',
+            'number', 'linear_scale', 'rating' or 'sentiment_linear_scale'.
+          DOC
+          'question_label' => 'Question text, resolved to the platform primary locale.',
+          'value_text' => <<~DOC.squish,
+            Textual answer: the option key for (multi)select questions, free
+            text for text questions, 'true'/'false' for checkboxes. NULL for
+            numeric question types.
+          DOC
+          'value_numeric' => <<~DOC.squish
+            Numeric answer for 'number', 'linear_scale', 'rating' and
+            'sentiment_linear_scale' questions (scales run from 1 upwards).
+            Aggregate with AVG for scores. NULL for textual question types.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/user.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/user.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_users
+#
+#  id            :uuid             primary key
+#  registered_at :datetime
+#  created_at    :datetime
+#  highest_role  :text
+#
+module Analytics
+  module Reporting
+    class User < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_users'
+      self.primary_key = :id
+
+      def self.table_description
+        <<~DOC.squish
+          One row per active registered user. Pending invitations, incomplete
+          registrations and currently blocked accounts are excluded. The view
+          carries no names or email addresses by design; demographics live in
+          reporting_user_question_answers. Note that a user is not necessarily
+          a participant (see reporting_participants). All timestamps are in
+          UTC.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'id' => <<~DOC.squish,
+            User primary key. Joins to reporting_user_question_answers.user_id,
+            reporting_contributions.user_id, reporting_participants.user_id and
+            reporting_sessions.user_id.
+          DOC
+          'registered_at' => 'When the user completed registration. Count registrations by this date.',
+          'created_at' => 'When the account was first created, possibly before completing registration.',
+          'highest_role' => <<~DOC.squish
+            Highest platform role: 'admin', 'space_moderator',
+            'project_folder_moderator', 'project_moderator' or 'user'
+            (a regular resident). Filter to 'user' to exclude platform staff
+            from counts.
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/app/models/analytics/reporting/user_question_answer.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/reporting/user_question_answer.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: reporting_user_question_answers
+#
+#  user_id        :uuid
+#  question_id    :uuid
+#  question_key   :string
+#  question_type  :string
+#  question_label :text
+#  answer_value   :text
+#
+module Analytics
+  module Reporting
+    class UserQuestionAnswer < Analytics::ApplicationRecordView
+      self.table_name = 'reporting_user_question_answers'
+      self.primary_key = nil
+
+      def self.table_description
+        <<~DOC.squish
+          One row per answer an active user gave to an enabled registration
+          question. This is where demographics live (age, gender, place of
+          residence, ...). Multi-select questions produce one row per selected
+          option. Users who did not answer a question have no row for it:
+          compute unknown counts against reporting_users.
+        DOC
+      end
+
+      def self.field_descriptions
+        {
+          'user_id' => 'The user who answered. Joins to reporting_users.id.',
+          'question_id' => 'Id of the registration question (custom field).',
+          'question_key' => "Stable machine key of the question, for example 'gender', 'birthyear' or 'domicile'.",
+          'question_type' => "Answer format: 'select', 'multiselect', 'checkbox' or 'number'.",
+          'question_label' => 'Question text, resolved to the platform primary locale.',
+          'answer_value' => <<~DOC.squish
+            The answer as raw text: the option key for (multi)select questions
+            (for 'domicile' this is a geographic area id), a year for
+            'birthyear', 'true'/'false' for checkboxes, a number as text for
+            number questions (cast with ::numeric to aggregate).
+          DOC
+        }
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analytics/db/migrate/20260707180000_create_user_and_answer_reporting_views.rb
+++ b/back/engines/commercial/analytics/db/migrate/20260707180000_create_user_and_answer_reporting_views.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# Fourth slice of the unified reporting model: active users (without PII) and
+# the exploded question answers for users (demographics) and inputs (survey
+# and idea-form answers). reporting_user_question_answers selects from
+# reporting_users, so creation order matters. Grants follow in a separate
+# main-app migration.
+class CreateUserAndAnswerReportingViews < ActiveRecord::Migration[7.2]
+  def change
+    create_view :reporting_users, version: 1
+    create_view :reporting_user_question_answers, version: 1
+    create_view :reporting_input_question_answers, version: 1
+  end
+end

--- a/back/engines/commercial/analytics/db/views/reporting_input_question_answers_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_input_question_answers_v01.sql
@@ -1,0 +1,72 @@
+-- Reporting view: one row per answer to a form question of an input (survey
+-- questions and extra idea-form fields). The form is resolved from the
+-- input's creation phase, falling back to the project form. Multi-select
+-- questions produce one row per selected option. Structurally complex
+-- question types (ranking, matrix, mapping, file upload, pages) are not
+-- included.
+
+WITH form_inputs AS (
+    SELECT
+        i.id,
+        i.custom_field_values,
+        COALESCE(phase_form.id, project_form.id) AS form_id
+    FROM ideas i
+    LEFT JOIN custom_forms phase_form
+        ON phase_form.participation_context_type = 'Phase'
+        AND phase_form.participation_context_id = i.creation_phase_id
+    LEFT JOIN custom_forms project_form
+        ON project_form.participation_context_type = 'Project'
+        AND project_form.participation_context_id = i.project_id
+    WHERE i.publication_status IN ('submitted', 'published')
+)
+
+-- single-valued questions
+SELECT
+    i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    CASE
+        WHEN q.input_type IN ('number', 'linear_scale', 'rating', 'sentiment_linear_scale') THEN NULL
+        ELSE i.custom_field_values ->> q.key
+    END AS value_text,
+    CASE
+        WHEN q.input_type IN ('number', 'linear_scale', 'rating', 'sentiment_linear_scale')
+            AND jsonb_typeof(i.custom_field_values -> q.key) = 'number'
+        THEN (i.custom_field_values ->> q.key)::numeric
+    END AS value_numeric
+FROM form_inputs i
+INNER JOIN custom_fields q
+    ON q.resource_type = 'CustomForm'
+    AND q.resource_id = i.form_id
+    AND q.input_type IN (
+        'text', 'multiline_text', 'select', 'select_image', 'checkbox', 'date',
+        'number', 'linear_scale', 'rating', 'sentiment_linear_scale'
+    )
+WHERE jsonb_exists(i.custom_field_values, q.key)
+
+UNION ALL
+
+-- multi-select questions: one row per selected option
+SELECT
+    i.id AS input_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    selected.value AS value_text,
+    NULL::numeric AS value_numeric
+FROM form_inputs i
+INNER JOIN custom_fields q
+    ON q.resource_type = 'CustomForm'
+    AND q.resource_id = i.form_id
+    AND q.input_type IN ('multiselect', 'multiselect_image')
+CROSS JOIN LATERAL jsonb_array_elements_text(i.custom_field_values -> q.key) AS selected(value)
+WHERE jsonb_typeof(i.custom_field_values -> q.key) = 'array'

--- a/back/engines/commercial/analytics/db/views/reporting_user_question_answers_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_user_question_answers_v01.sql
@@ -1,0 +1,39 @@
+-- Reporting view: one row per answer an active user gave to an enabled
+-- registration question (demographics). Multi-select questions produce one
+-- row per selected option.
+
+-- single-valued questions
+SELECT
+    u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    u.custom_field_values ->> q.key AS answer_value
+FROM reporting_users ru
+INNER JOIN users u ON u.id = ru.id
+INNER JOIN custom_fields q ON q.resource_type = 'User' AND q.enabled
+WHERE q.input_type <> 'multiselect'
+    AND jsonb_exists(u.custom_field_values, q.key)
+
+UNION ALL
+
+-- multi-select questions: one row per selected option
+SELECT
+    u.id AS user_id,
+    q.id AS question_id,
+    q.key AS question_key,
+    q.input_type AS question_type,
+    COALESCE(
+        NULLIF(q.title_multiloc ->> (SELECT ac.settings -> 'core' -> 'locales' ->> 0 FROM app_configurations ac LIMIT 1), ''),
+        (SELECT t.value FROM jsonb_each_text(q.title_multiloc) t WHERE t.value <> '' ORDER BY t.key LIMIT 1)
+    ) AS question_label,
+    selected.value AS answer_value
+FROM reporting_users ru
+INNER JOIN users u ON u.id = ru.id
+INNER JOIN custom_fields q ON q.resource_type = 'User' AND q.enabled AND q.input_type = 'multiselect'
+CROSS JOIN LATERAL jsonb_array_elements_text(u.custom_field_values -> q.key) AS selected(value)
+WHERE jsonb_typeof(u.custom_field_values -> q.key) = 'array'

--- a/back/engines/commercial/analytics/db/views/reporting_users_v01.sql
+++ b/back/engines/commercial/analytics/db/views/reporting_users_v01.sql
@@ -1,0 +1,19 @@
+-- Reporting view: one row per active registered user. Users who are not (yet)
+-- active are excluded: pending invitations, incomplete registrations and
+-- currently blocked accounts. Deliberately carries no personally identifiable
+-- information.
+SELECT
+    u.id,
+    u.registration_completed_at AS registered_at,
+    u.created_at,
+    CASE
+        WHEN u.roles @> '[{"type":"admin"}]' THEN 'admin'
+        WHEN u.roles @> '[{"type":"space_moderator"}]' THEN 'space_moderator'
+        WHEN u.roles @> '[{"type":"project_folder_moderator"}]' THEN 'project_folder_moderator'
+        WHEN u.roles @> '[{"type":"project_moderator"}]' THEN 'project_moderator'
+        ELSE 'user'
+    END AS highest_role
+FROM users u
+WHERE u.registration_completed_at IS NOT NULL
+    AND (u.invite_status IS NULL OR u.invite_status <> 'pending')
+    AND (u.block_end_at IS NULL OR u.block_end_at < now())

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/input_question_answer_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/input_question_answer_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::InputQuestionAnswer do
+  describe 'survey answers (form on the creation phase)' do
+    let(:project) { create(:single_phase_native_survey_project) }
+    let(:form) { create(:custom_form, participation_context: project.phases.first) }
+    let!(:select_question) { create(:custom_field_select, :with_options, resource: form) }
+    let!(:scale_question) { create(:custom_field_linear_scale, resource: form) }
+    let!(:multiselect_question) { create(:custom_field_multiselect, :with_options, resource: form) }
+
+    let(:response) do
+      create(:idea_status_proposed)
+      create(:native_survey_response, project: project).tap do |response|
+        response.update_column(:custom_field_values, {
+          select_question.key => 'option1',
+          scale_question.key => 4,
+          multiselect_question.key => %w[option1 option2]
+        })
+      end
+    end
+
+    it 'explodes the answers with the right value column per question type' do
+      rows = described_class.where(input_id: response.id)
+
+      select_row = rows.find_by!(question_id: select_question.id)
+      expect(select_row.value_text).to eq 'option1'
+      expect(select_row.value_numeric).to be_nil
+      expect(select_row.question_label).to eq 'Member of councils?'
+
+      scale_row = rows.find_by!(question_id: scale_question.id)
+      expect(scale_row.value_text).to be_nil
+      expect(scale_row.value_numeric).to eq 4
+
+      expect(rows.where(question_id: multiselect_question.id).pluck(:value_text))
+        .to match_array %w[option1 option2]
+    end
+
+    it 'has no rows for skipped questions' do
+      create(:idea_status_proposed)
+      empty_response = create(:native_survey_response, project: project)
+      empty_response.update_column(:custom_field_values, {})
+
+      expect(described_class.where(input_id: empty_response.id)).to be_empty
+    end
+  end
+
+  describe 'idea form answers (form on the project)' do
+    it 'exposes extra idea-form answers' do
+      project = create(:single_phase_ideation_project)
+      form = create(:custom_form, participation_context: project)
+      question = create(:custom_field, resource: form, input_type: 'text')
+      idea = create(:idea, project: project)
+      idea.update_column(:custom_field_values, { question.key => 'By bicycle' })
+      row = described_class.find_by!(input_id: idea.id)
+
+      expect(row.question_id).to eq question.id
+      expect(row.value_text).to eq 'By bicycle'
+    end
+  end
+
+  it 'excludes structurally complex question types' do
+    project = create(:single_phase_native_survey_project)
+    form = create(:custom_form, participation_context: project.phases.first)
+    ranking = create(:custom_field_ranking, :with_options, resource: form)
+    create(:idea_status_proposed)
+    response = create(:native_survey_response, project: project)
+    response.update_column(:custom_field_values, { ranking.key => %w[option1 option2] })
+
+    expect(described_class.where(input_id: response.id)).to be_empty
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/user_question_answer_parity_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/user_question_answer_parity_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# The demographics distributions must agree with the product's counter
+# (UserCustomFields::FieldValueCounter), which powers the Users dashboard tab
+# and the demographics widgets.
+RSpec.describe 'reporting_user_question_answers parity with FieldValueCounter' do # rubocop:disable RSpec/DescribeClass
+  it 'produces the same distribution as the product demographics counter' do
+    field = create(:custom_field_gender, :with_options)
+    create_list(:user, 2, custom_field_values: { 'gender' => 'male' })
+    create(:user, custom_field_values: { 'gender' => 'female' })
+    create(:user) # unanswered
+
+    counts = Analytics::Reporting::UserQuestionAnswer
+      .where(question_id: field.id)
+      .group(:answer_value)
+      .count
+    product_counts = UserCustomFields::FieldValueCounter.counts_by_field_option(User.active, field)
+
+    expect(counts).to eq('male' => 2, 'female' => 1)
+    expect(product_counts.slice('male', 'female')).to eq('male' => 2, 'female' => 1)
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/user_question_answer_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/user_question_answer_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::UserQuestionAnswer do
+  it 'exposes select answers with their question metadata' do
+    field = create(:custom_field_gender, :with_options)
+    user = create(:user, custom_field_values: { 'gender' => 'male' })
+    row = described_class.find_by!(user_id: user.id)
+
+    expect(row.question_id).to eq field.id
+    expect(row.question_key).to eq 'gender'
+    expect(row.question_type).to eq 'select'
+    expect(row.question_label).to eq 'gender'
+    expect(row.answer_value).to eq 'male'
+  end
+
+  it 'explodes multi-select answers into one row per selected option' do
+    field = create(:custom_field_multiselect, :with_options)
+    user = create(:user)
+    user.update_column(:custom_field_values, { field.key => %w[option1 option2] })
+
+    expect(described_class.where(user_id: user.id).pluck(:answer_value)).to match_array %w[option1 option2]
+  end
+
+  it 'exposes number answers like birthyear as text' do
+    create(:custom_field_birthyear)
+    user = create(:user)
+    user.update_column(:custom_field_values, { 'birthyear' => 1990 })
+
+    expect(described_class.find_by!(user_id: user.id).answer_value).to eq '1990'
+  end
+
+  it 'has no rows for unanswered questions or disabled fields' do
+    create(:custom_field_gender, :with_options, enabled: false)
+    unanswered = create(:user)
+    answered_disabled = create(:user)
+    answered_disabled.update_column(:custom_field_values, { 'gender' => 'male' })
+
+    expect(described_class.where(user_id: [unanswered.id, answered_disabled.id])).to be_empty
+  end
+
+  it 'has no rows for users excluded from reporting_users' do
+    create(:custom_field_gender, :with_options)
+    pending_invite = create(:user, invite_status: 'pending', registration_completed_at: nil)
+    pending_invite.update_column(:custom_field_values, { 'gender' => 'male' })
+
+    expect(described_class.where(user_id: pending_invite.id)).to be_empty
+  end
+end

--- a/back/engines/commercial/analytics/spec/models/analytics/reporting/user_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/reporting/user_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analytics::Reporting::User do
+  it 'exposes active registered users with their highest role' do
+    user = create(:user)
+    admin = create(:admin)
+    moderator = create(:project_moderator)
+
+    expect(described_class.find(user.id).highest_role).to eq 'user'
+    expect(described_class.find(admin.id).highest_role).to eq 'admin'
+    expect(described_class.find(moderator.id).highest_role).to eq 'project_moderator'
+    expect(described_class.find(user.id).registered_at).to eq user.reload.registration_completed_at
+  end
+
+  it 'excludes pending invites, incomplete registrations and blocked users' do
+    create(:user, invite_status: 'pending', registration_completed_at: nil)
+    # a callback completes registration on save, so unset it directly
+    create(:user).update_column(:registration_completed_at, nil)
+    create(:user, block_end_at: 1.month.from_now)
+
+    expect(described_class.count).to eq 0
+  end
+
+  it 'includes users whose block has expired' do
+    unblocked = create(:user, block_end_at: 1.day.ago)
+
+    expect(described_class.ids).to eq [unblocked.id]
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_reporting_sql_schema.rb
@@ -23,7 +23,10 @@ class McpServer::Tools::GetReportingSqlSchema < McpServer::BaseTool
     Analytics::Reporting::InputTag,
     Analytics::Reporting::InputStatus,
     Analytics::Reporting::InputVote,
-    Analytics::Reporting::InputReaction
+    Analytics::Reporting::InputReaction,
+    Analytics::Reporting::User,
+    Analytics::Reporting::UserQuestionAnswer,
+    Analytics::Reporting::InputQuestionAnswer
   ].freeze
 
   REPORTING_TABLE_NAMES = REPORTING_TABLES.map(&:table_name).freeze


### PR DESCRIPTION
# Changelog

## Added
- The AI reporting tools can now answer questions about registered users and their demographics (age, gender, place of residence, any custom registration question), and about survey answers and extra idea-form fields, including average scores for scale questions like the community monitor.

## Technical
- `reporting_users` deliberately carries no PII (no names, no emails) and filters to active accounts: pending invites, incomplete registrations and blocked users are excluded. Demographics distributions are parity-guarded against `UserCustomFields::FieldValueCounter`.
- Question answers are exploded from the `custom_field_values` JSONB against the resolved form (creation phase, falling back to the project form), one row per answer and per selected option for multi-selects; numeric question types land in `value_numeric`.
- Structurally complex question types (ranking, matrix, mapping, file upload, pages) are deliberately not modeled, and documented as absent in the schema tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KkM7j4XfjYwsh3Ffh5Nvyk