### PR TITLE
 allow long topic and area titles to wrap within badges

### DIFF
--- a/front/app/components/Areas/FollowArea/BaseUpdateFollowArea.tsx
+++ b/front/app/components/Areas/FollowArea/BaseUpdateFollowArea.tsx
@@ -99,6 +99,7 @@ const BaseUpdateFollowArea = ({
         iconPos="right"
         padding="0px"
         my="0px"
+        whiteSpace="normal"
         processing={isLoading}
         textColor={areaButtonContentColor}
         ariaPressed={!isLoading ? isFollowing : undefined}

--- a/front/app/components/Areas/UpdateOnboardingArea.tsx
+++ b/front/app/components/Areas/UpdateOnboardingArea.tsx
@@ -49,6 +49,7 @@ const UpdateOnboardingArea = ({ area }: Props) => {
           iconPos="right"
           padding="0px"
           my="0px"
+          whiteSpace="normal"
           processing={isLoading}
           textColor={areaButtonContentColor}
           iconColor={areaButtonContentColor}

--- a/front/app/components/Topics/UpdateFollowTopic.tsx
+++ b/front/app/components/Topics/UpdateFollowTopic.tsx
@@ -94,6 +94,7 @@ const UpdateFollowTopic = ({ topic }: Props) => {
         iconPos="right"
         padding="0px"
         my="0px"
+        whiteSpace="normal"
         processing={isLoading}
         textColor={topicButtonContentColor}
         ariaPressed={!isLoading ? isFollowing : undefined}

--- a/front/app/components/Topics/UpdateOnboardingTopic.tsx
+++ b/front/app/components/Topics/UpdateOnboardingTopic.tsx
@@ -49,6 +49,7 @@ const UpdateOnboardingTopic = ({ topic }: Props) => {
           iconPos="right"
           padding="0px"
           my="0px"
+          whiteSpace="normal"
           processing={isLoading}
           textColor={topicButtonContentColor}
           iconColor={topicButtonContentColor}


### PR DESCRIPTION
Before : 
<img width="678" height="543" alt="Screenshot 2026-07-07 at 15 27 57" src="https://github.com/user-attachments/assets/f9b1bd34-12be-4777-a358-4ee2c3c3b94e" />

<img width="1215" height="517" alt="Screenshot 2026-07-07 at 15 38 24" src="https://github.com/user-attachments/assets/2fabf749-3413-4cf5-848d-69fbd85178b7" />
-----
After : 
<img width="619" height="538" alt="Screenshot 2026-07-07 at 15 29 50" src="https://github.com/user-attachments/assets/8be47a0f-7dd1-40e5-b129-ad2d7b667bba" />

<img width="745" height="696" alt="Screenshot 2026-07-07 at 15 36 23" src="https://github.com/user-attachments/assets/6fb0c4ea-b8c8-4bfb-83b9-1cbb09d35bdc" />

# Changelog
## Fixed 
-  Allow long topic and area titles to wrap within badges

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
