### PR TITLE
TAN-8156: Re-enable disabled description layouts from copied and imported templates

### DIFF
--- a/back/engines/commercial/content_builder/app/services/content_builder/description_layout_service.rb
+++ b/back/engines/commercial/content_builder/app/services/content_builder/description_layout_service.rb
@@ -49,9 +49,19 @@ module ContentBuilder
     end
 
     # Puts one buildable's description on the Content Builder, picking the widget by
-    # content (blank / media / text). Skips if a layout exists.
+    # content (blank / media / text). Skips if an enabled layout exists.
     def ensure_on_content_builder!(buildable)
-      return if buildable.content_builder_layouts.exists?
+      existing = ContentBuilder::Layout.find_by(
+        content_buildable: buildable,
+        code: layout_code(buildable)
+      )
+
+      if existing
+        unless existing.enabled
+          existing.update!(enabled: true, craftjs_json: content_aware_craftjs_json(buildable))
+        end
+        return
+      end
 
       create_layout!(buildable, content_aware_craftjs_json(buildable))
     end

--- a/back/engines/commercial/content_builder/spec/services/content_builder/description_layout_service_spec.rb
+++ b/back/engines/commercial/content_builder/spec/services/content_builder/description_layout_service_spec.rb
@@ -141,6 +141,19 @@ describe ContentBuilder::DescriptionLayoutService do
       expect { service.ensure_on_content_builder!(project) }
         .not_to change { project.content_builder_layouts.count }
     end
+
+    it 're-points a disabled layout at the description and enables it' do
+      project = create(:project, description_multiloc: { 'en' => '<p>Hi</p>' })
+      layout = create(:layout, content_buildable: project, code: 'project_description', enabled: false)
+
+      expect { service.ensure_on_content_builder!(project) }
+        .not_to change { project.content_builder_layouts.count }
+
+      expect(layout.reload.enabled).to be(true)
+      node = description_node(layout)
+      expect(node['type']['resolvedName']).to eq('TextMultiloc')
+      expect(node['props']['text']).to eq({ 'en' => '<p>Hi</p>' })
+    end
   end
 
   describe '#text_node / #bridge_node (generic builders reused by the migration)' do

--- a/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/FolderFullScreenPreview.tsx
+++ b/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/FolderFullScreenPreview.tsx
@@ -11,7 +11,6 @@ export const FolderFullScreenPreview = () => {
   const { data: folder } = useProjectFolderById(folderId);
 
   if (!folder) return null;
-  if (!folder.data.attributes.uses_content_builder) return null;
 
   return (
     <FullScreenPreview

--- a/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/index.tsx
+++ b/front/app/containers/DescriptionBuilder/FolderDescriptionBuilder/index.tsx
@@ -11,7 +11,6 @@ const FolderDescriptionBuilderPage = () => {
   const { data: folder } = useProjectFolderById(folderId);
 
   if (!folder) return null;
-  if (!folder.data.attributes.uses_content_builder) return null;
 
   return (
     <DescriptionBuilderPage

--- a/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/ProjectFullScreenPreview.tsx
+++ b/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/ProjectFullScreenPreview.tsx
@@ -11,7 +11,6 @@ export const ProjectFullScreenPreview = () => {
   const { data: project } = useProjectById(projectId);
 
   if (!project) return null;
-  if (!project.data.attributes.uses_content_builder) return null;
 
   return (
     <FullScreenPreview

--- a/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/index.tsx
+++ b/front/app/containers/DescriptionBuilder/ProjectDescriptionBuilder/index.tsx
@@ -14,7 +14,6 @@ const ProjectDescriptionBuilderPage = () => {
   const parallelParticipation = useParallelParticipation();
 
   if (!project) return null;
-  if (!project.data.attributes.uses_content_builder) return null;
 
   const backPath = parallelParticipation
     ? `/admin/projects/${projectId}/project-page`


### PR DESCRIPTION
# Changelog

## Fixed
- Newly created projects and folders no longer end up with an invisible, uneditable description when they are made from an old template or copy. Templates snapshotted before the descriptions migration still carry a switched-off description layout; importing one now rebuilds the layout from the description and switches it on at creation.
- The description builder no longer shows a blank page when a project or folder has a disabled description layout; it opens normally and saving enables the layout.
