### PR TITLE
MCP engine test suite

### DIFF
--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/custom_field.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/custom_field.rb
@@ -4,4 +4,11 @@ class McpServer::Serializers::CustomField < McpServer::Serializers::Base
   wraps ::WebApi::V1::CustomFieldSerializer
 
   inline :options, :matrix_statements
+
+  # Drop the per-field `constraints` emitted by the web serializer: get_form_fields
+  # reports constraints at the top level, and `constraints` is not a CustomField
+  # attribute, so echoing it back would crash replace_form_fields' round-trip.
+  def attributes(record)
+    super.except(:constraints)
+  end
 end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/replace_form_fields.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/replace_form_fields.rb
@@ -71,6 +71,9 @@ class McpServer::Tools::ReplaceFormFields < McpServer::BaseTool
         return not_found_error("Container (#{params[:container_type]})", params[:container_id])
       end
 
+      authorize_project!(container.is_a?(Phase) ? container.project : container)
+      authorize(container, :update?)
+
       pmethod = container.pmethod
       return unsupported_error(pmethod) unless SUPPORTED_METHODS.include?(pmethod.class.method_str)
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_phase.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_phase.rb
@@ -38,6 +38,9 @@ class McpServer::Tools::UpdatePhase < McpServer::BaseTool
       phase = Phase.find_by(id: params[:phase_id])
       return not_found_error('Phase', params[:phase_id]) unless phase
 
+      authorize_project!(phase.project)
+      authorize(phase, :update?)
+
       attributes = params.except(:phase_id)
 
       # manual_voters_amount goes through a dedicated setter that records who/when, before other assigns.

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_project.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_project.rb
@@ -38,6 +38,9 @@ class McpServer::Tools::UpdateProject < McpServer::BaseTool
       project = Project.find_by(id: params[:project_id])
       return not_found_error('Project', params[:project_id]) unless project
 
+      authorize_project!(project)
+      authorize(project, :update?)
+
       attributes = params.except(:project_id)
       project.assign_attributes(merge_multilocs(project, attributes))
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_resource.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_resource.rb
@@ -85,6 +85,9 @@ class McpServer::Tools::UpdateResource < McpServer::BaseTool
     def run
       return not_found_error("Resource (#{params[:type]})", params[:id]) unless record
 
+      authorize_project!(record.project)
+      authorize(record, :update?)
+
       attributes = params[:attributes].symbolize_keys
       rejected = attributes.keys - config[:attrs]
 

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/multiloc_merge_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/multiloc_merge_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::BaseTool::MultilocMerge do
+  subject(:host) { Class.new { include McpServer::BaseTool::MultilocMerge }.new }
+
+  def merge(record, attributes)
+    host.send(:merge_multilocs, record, attributes)
+  end
+
+  let(:project) { build(:project, title_multiloc: { 'en' => 'Hi', 'fr-FR' => 'Bonjour' }) }
+
+  it 'merges multiloc values per locale, keeping locales the caller did not pass' do
+    merged = merge(project, title_multiloc: { 'fr-FR' => 'Salut', 'nl-BE' => 'Hallo' })
+
+    expect(merged).to eq(
+      title_multiloc: { 'en' => 'Hi', 'fr-FR' => 'Salut', 'nl-BE' => 'Hallo' }
+    )
+  end
+
+  it 'uses the incoming value verbatim when the current value is blank' do
+    project.title_multiloc = {}
+
+    merged = merge(project, title_multiloc: { 'en' => 'New' })
+
+    expect(merged).to eq(title_multiloc: { 'en' => 'New' })
+  end
+
+  it 'passes non-multiloc attributes through unchanged' do
+    merged = merge(project, listed: false, slug: 'new-slug')
+
+    expect(merged).to eq(listed: false, slug: 'new-slug')
+  end
+
+  it 'handles mixed attribute hashes' do
+    merged = merge(project, title_multiloc: { 'en' => 'New' }, listed: false)
+
+    expect(merged).to eq(
+      title_multiloc: { 'en' => 'New', 'fr-FR' => 'Bonjour' },
+      listed: false
+    )
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/multiloc_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/multiloc_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::BaseTool::Multiloc do
+  subject(:host) { Class.new { include McpServer::BaseTool::Multiloc }.new }
+
+  it 'restricts the property names to the tenant locales' do
+    locales = AppConfiguration.instance.settings.dig('core', 'locales')
+
+    schema = host.multiloc_schema
+
+    expect(locales).to be_present
+    expect(schema[:propertyNames]).to eq(enum: locales)
+    expect(schema[:minProperties]).to eq(1)
+    expect(schema[:additionalProperties]).to eq(type: 'string')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/pagination_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/pagination_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::BaseTool::Pagination do
+  subject(:host) { Class.new { include McpServer::BaseTool::Pagination }.new }
+
+  let_it_be(:areas) { create_list(:area, 3) }
+
+  let(:scope) { Area.order(:ordering) }
+
+  def paginate(**options)
+    host.paginated_response('areas', scope, page: nil, per_page: nil, **options)
+  end
+
+  it 'returns the data and pagination envelope with defaults' do
+    response = paginate
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].size).to eq(3)
+    expect(response.structured_content[:pagination]).to eq(
+      page: 1,
+      per_page: described_class::DEFAULT_PER_PAGE,
+      total_count: 3,
+      total_pages: 1
+    )
+  end
+
+  it 'summarizes the result in the text block' do
+    response = paginate
+
+    expect(response.content.first[:text])
+      .to include('Found 3 areas (showing page 1, 20 per page)')
+  end
+
+  it 'serves subsequent pages' do
+    response = paginate(page: 2, per_page: 2)
+
+    expect(response.structured_content[:data].size).to eq(1)
+    expect(response.structured_content[:pagination]).to eq(
+      page: 2, per_page: 2, total_count: 3, total_pages: 2
+    )
+  end
+
+  it 'clamps per_page between 1 and MAX_PER_PAGE' do
+    expect(paginate(per_page: 999).structured_content.dig(:pagination, :per_page))
+      .to eq(described_class::MAX_PER_PAGE)
+    expect(paginate(per_page: 0).structured_content.dig(:pagination, :per_page))
+      .to eq(1)
+  end
+
+  it 'serializes with as_json options when no serializer is given' do
+    response = paginate(only: %i[id])
+
+    expect(response.structured_content[:data]).to match_array(areas.map { |a| { 'id' => a.id } })
+  end
+
+  it 'serializes with the given MCP serializer' do
+    response = paginate(serializer: McpServer::Serializers::Area, params: { current_user: create(:super_admin) })
+
+    expect(response.structured_content[:data].pluck(:id)).to eq(scope.pluck(:id))
+    expect(response.structured_content[:data].first).to include(:title_multiloc)
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/response_helpers_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool/response_helpers_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::BaseTool::ResponseHelpers do
+  subject(:host) { Class.new { include McpServer::BaseTool::ResponseHelpers }.new }
+
+  describe '#response' do
+    it 'builds a success response with the text' do
+      response = host.response('All good')
+
+      expect(response).not_to be_error
+      expect(response.content).to eq([{ type: 'text', text: 'All good' }])
+      expect(response.structured_content).to be_nil
+    end
+
+    it 'duplicates the structured content into the text block' do
+      response = host.response('All good', structured: { id: '123' })
+
+      expect(response.structured_content).to eq(id: '123')
+      expect(response.content.first[:text]).to eq("All good\n\n#{{ id: '123' }.to_json}")
+    end
+  end
+
+  describe '#error' do
+    it 'builds an error response' do
+      response = host.error('Something broke', structured: { id: '123' })
+
+      expect(response).to be_error
+      expect(response.structured_content).to eq(id: '123')
+    end
+  end
+
+  describe '#invalid_record_error' do
+    it 'reports each validation error with its attribute and message' do
+      record = Project.new.tap(&:valid?)
+
+      response = host.invalid_record_error(record)
+
+      expect(response).to be_error
+      expect(response.content.first[:text]).to include('Validation failed:')
+
+      errors = response.structured_content[:errors]
+      expect(errors).to be_present
+      expect(errors).to all(include(:attribute, :message, :error))
+      expect(errors.pluck(:attribute)).to include('title_multiloc')
+    end
+  end
+
+  describe '#not_found_error' do
+    it 'builds the standard not-found error' do
+      response = host.not_found_error('Phase', 'some-id')
+
+      expect(response).to be_not_found('Phase')
+      expect(response.content.first[:text]).to eq('Phase not found: some-id')
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool_spec.rb
@@ -15,4 +15,34 @@ describe McpServer::BaseTool do
       ), "#{tool_class.name} annotations: #{annotations.inspect}"
     end
   end
+
+  it 'every registered tool has a well-formed definition' do
+    McpServer::McpController::TOOL_CLASSES.each do |tool_class|
+      tool = tool_class.new
+
+      expect(tool.name).to match(/\A[a-z_]+\z/), "#{tool_class.name} name: #{tool.name.inspect}"
+      expect(tool.description).to be_present, "#{tool_class.name} has no description"
+
+      schema = tool.input_schema
+      expect(schema[:properties]).to be_a(Hash), "#{tool_class.name} has no properties"
+
+      unknown_required = Array(schema[:required]).map(&:to_sym) - schema[:properties].keys.map(&:to_sym)
+      expect(unknown_required).to be_empty,
+        "#{tool_class.name} requires fields missing from properties: #{unknown_required.inspect}"
+    end
+  end
+
+  describe '.unauthorized_message' do
+    it 'includes the reason of a NotAuthorizedErrorWithReason' do
+      error = Pundit::NotAuthorizedErrorWithReason.new(reason: 'the project has inputs')
+
+      expect(described_class.unauthorized_message(error)).to eq('Not allowed: the project has inputs.')
+    end
+
+    it 'falls back to a generic message for a plain NotAuthorizedError' do
+      error = Pundit::NotAuthorizedError.new('secret internals')
+
+      expect(described_class.unauthorized_message(error)).to eq('Not allowed: authorization failed.')
+    end
+  end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/base_tool_spec.rb
@@ -32,6 +32,12 @@ describe McpServer::BaseTool do
     end
   end
 
+  it 'requires Runner subclasses to implement #run' do
+    runner = described_class::Runner.new(params: {}, server_context: {}, current_user: nil, token_scopes: [])
+
+    expect { runner.run }.to raise_error(NotImplementedError)
+  end
+
   describe '.unauthorized_message' do
     it 'includes the reason of a NotAuthorizedErrorWithReason' do
       error = Pundit::NotAuthorizedErrorWithReason.new(reason: 'the project has inputs')

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/jsonapi_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/jsonapi_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Jsonapi do
+  def resource(id, type, attributes = {}, relationships = nil)
+    { id:, type:, attributes:, relationships: }.compact
+  end
+
+  it 'flattens a single resource by hoisting id and attributes' do
+    jsonapi = { data: resource('p1', :project, { title: 'Hello' }) }
+
+    expect(described_class.flatten(jsonapi)).to eq(id: 'p1', title: 'Hello')
+  end
+
+  it 'flattens an array of resources' do
+    jsonapi = { data: [resource('p1', :project, { title: 'A' }), resource('p2', :project, { title: 'B' })] }
+
+    expect(described_class.flatten(jsonapi)).to eq(
+      [{ id: 'p1', title: 'A' }, { id: 'p2', title: 'B' }]
+    )
+  end
+
+  it 'surfaces a one-to-one relationship as <name>_id' do
+    jsonapi = {
+      data: resource('p1', :project, {}, { folder: { data: { id: 'f1', type: :folder } } })
+    }
+
+    expect(described_class.flatten(jsonapi)).to eq(id: 'p1', folder_id: 'f1')
+  end
+
+  it 'surfaces a nil one-to-one relationship as <name>_id: nil' do
+    jsonapi = { data: resource('p1', :project, {}, { folder: { data: nil } }) }
+
+    expect(described_class.flatten(jsonapi)).to eq(id: 'p1', folder_id: nil)
+  end
+
+  it 'surfaces a one-to-many relationship as <name_singular>_ids' do
+    jsonapi = {
+      data: resource('p1', :project, {}, { areas: { data: [{ id: 'a1', type: :area }, { id: 'a2', type: :area }] } })
+    }
+
+    expect(described_class.flatten(jsonapi)).to eq(id: 'p1', area_ids: %w[a1 a2])
+  end
+
+  describe 'inline relationships' do
+    it 'embeds a one-to-many relationship from the included section' do
+      jsonapi = {
+        data: resource('q1', :question, { title: 'Q' }, { options: { data: [{ id: 'o1', type: :option }] } }),
+        included: [resource('o1', :option, { title: 'O1' })]
+      }
+
+      expect(described_class.flatten(jsonapi, inline_rels: [:options])).to eq(
+        id: 'q1', title: 'Q', options: [{ id: 'o1', title: 'O1' }]
+      )
+    end
+
+    it 'embeds a one-to-one relationship as a single hash' do
+      jsonapi = {
+        data: resource('p1', :phase, {}, { form: { data: { id: 'f1', type: :form } } }),
+        included: [resource('f1', :form, { opened: true })]
+      }
+
+      expect(described_class.flatten(jsonapi, inline_rels: [:form])).to eq(
+        id: 'p1', form: { id: 'f1', opened: true }
+      )
+    end
+
+    it 'embeds nil when the relationship is empty' do
+      jsonapi = { data: resource('p1', :phase, {}, { form: { data: nil } }) }
+
+      expect(described_class.flatten(jsonapi, inline_rels: [:form])).to eq(id: 'p1', form: nil)
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/serializers/base_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/serializers/base_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Serializers::Base do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  describe 'wrapping a web API serializer' do
+    it 'flattens the JSONAPI output into a plain hash' do
+      project = create(:project)
+
+      serialized = McpServer::Serializers::Project.serialize(project, params: { current_user: })
+
+      expect(serialized).to be_a(Hash)
+      expect(serialized[:id]).to eq(project.id)
+      expect(serialized[:title_multiloc]).to eq(project.title_multiloc)
+      expect(serialized).not_to include(:data, :attributes, :relationships)
+    end
+
+    it 'merges the click-through URLs when the serializer opts in' do
+      project = create(:project)
+
+      serialized = McpServer::Serializers::Project.serialize(project, params: { current_user: })
+
+      expect(serialized[:admin_url]).to end_with("/admin/projects/#{project.id}")
+      expect(serialized[:public_url]).to end_with("/projects/#{project.slug}")
+    end
+  end
+
+  describe 'inline relationships' do
+    it 'embeds the related resources instead of exposing ids' do
+      field = create(:custom_field_select, :with_options)
+
+      serialized = McpServer::Serializers::CustomField.serialize(field)
+
+      expect(serialized[:options]).to be_an(Array)
+      expect(serialized[:options].pluck(:id)).to match_array(field.options.pluck(:id))
+      expect(serialized[:options].first).to include(:title_multiloc)
+      expect(serialized).not_to include(:option_ids)
+    end
+  end
+
+  describe 'building from scratch (no wraps)' do
+    it 'uses the #attributes override' do
+      permission = create(:permission)
+
+      serialized = McpServer::Serializers::Permission.serialize(permission)
+
+      expect(serialized.keys).to eq(
+        %i[action permitted_by group_ids demographic_questions verification_expiry access_denied_explanation_multiloc]
+      )
+    end
+
+    it 'raises when neither wraps nor #attributes is provided' do
+      serializer = Class.new(described_class)
+
+      expect { serializer.serialize(create(:area)) }
+        .to raise_error(NotImplementedError, /wraps/)
+    end
+  end
+
+  describe 'collection semantics' do
+    it 'returns an array for a relation and a hash for a single record' do
+      create_list(:area, 2)
+      params = { current_user: }
+
+      expect(McpServer::Serializers::Area.serialize(Area.all, params:)).to be_an(Array)
+      expect(McpServer::Serializers::Area.serialize(Area.first, params:)).to be_a(Hash)
+    end
+
+    it 'returns an empty array for an empty relation' do
+      expect(McpServer::Serializers::Area.serialize(Area.none)).to eq([])
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/attach_file_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/attach_file_spec.rb
@@ -70,6 +70,20 @@ describe McpServer::Tools::AttachFile do
     end
   end
 
+  it 'returns an error when the download fails' do
+    failing_url = 'https://example.com/missing.pdf'
+    stub_failing_remote_download(failing_url)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { resource_type: 'project', resource_id: project.id, name: 'doc.pdf', remote_url: failing_url },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(Files::FileAttachment.where(attachable: project).count).to eq(0)
+  end
+
   it 'refuses when the project is published' do
     published = create(:project, admin_publication_attributes: { publication_status: 'published' })
 

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/attach_image_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/attach_image_spec.rb
@@ -34,6 +34,21 @@ describe McpServer::Tools::AttachImage do
     expect(event.event_images.first.image.file.read).to eq(fixture_path.binread)
   end
 
+  it 'returns an error when the download fails' do
+    failing_url = 'https://example.com/missing.jpg'
+    stub_failing_remote_download(failing_url)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { resource_type: 'project', resource_id: project.id, remote_url: failing_url },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(response.structured_content[:errors].pluck(:error)).to include(:carrierwave_download_error)
+    expect(project.reload.project_images.count).to eq(0)
+  end
+
   it 'refuses when the project is published' do
     published = create(:project, admin_publication_attributes: { publication_status: 'published' })
 

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_cause_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_cause_spec.rb
@@ -23,6 +23,29 @@ describe McpServer::Tools::CreateCause do
       end.to change { phase.reload.causes.count }.by(1)
 
       expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(phase.causes.sole.id)
+    end
+
+    it 'returns structured validation errors for invalid params' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(title_multiloc: {}),
+        current_user:
+      )
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('title_multiloc')
+      expect(phase.reload.causes.count).to eq(0)
+    end
+
+    it 'returns a not-found error when the phase is missing' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(phase_id: SecureRandom.uuid),
+        current_user:
+      )
+
+      expect(response).to be_not_found('Phase')
     end
 
     it 'attaches a remote image by URL' do

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_event_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_event_spec.rb
@@ -24,6 +24,20 @@ describe McpServer::Tools::CreateEvent do
       end.to change { project.reload.events.count }.by(1)
 
       expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(project.events.sole.id)
+      expect(response.structured_content[:title_multiloc]).to eq('en' => 'Event 1')
+    end
+
+    it 'returns structured validation errors for invalid params' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(maximum_attendees: 0),
+        current_user:
+      )
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('maximum_attendees')
+      expect(project.reload.events.count).to eq(0)
     end
   end
 
@@ -48,8 +62,7 @@ describe McpServer::Tools::CreateEvent do
         current_user:
       )
 
-      expect(response).to be_error
-      expect(response.content.first[:text]).to include('Project not found')
+      expect(response).to be_not_found('Project')
     end
   end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_phase_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_phase_spec.rb
@@ -15,6 +15,40 @@ describe McpServer::Tools::CreatePhase do
     }
   end
 
+  describe '#input_schema' do
+    # A method, not a let: the schema is rebuilt to observe feature-flag changes.
+    def schema = described_class.new.input_schema
+
+    it 'only offers gated participation methods when their feature flag is active' do
+      SettingsService.new.deactivate_feature!('polls')
+      expect(schema.dig(:properties, :participation_method, :enum)).not_to include('poll')
+
+      SettingsService.new.activate_feature!('polls')
+      expect(schema.dig(:properties, :participation_method, :enum)).to include('poll')
+    end
+
+    it 'grows the prescreening_mode enum with the prescreening feature flags' do
+      settings = SettingsService.new
+      %w[prescreening prescreening_ideation flag_inappropriate_content].each { |flag| settings.deactivate_feature!(flag) }
+      expect(schema.dig(:properties, :prescreening_mode, :enum)).to eq([nil])
+
+      settings.activate_feature!('prescreening')
+      expect(schema.dig(:properties, :prescreening_mode, :enum)).to eq([nil, 'all'])
+
+      settings.activate_feature!('flag_inappropriate_content')
+      expect(schema.dig(:properties, :prescreening_mode, :enum)).to eq([nil, 'all', 'flagged_only'])
+    end
+
+    it 'only exposes the disliking fields when disable_disliking is active' do
+      SettingsService.new.deactivate_feature!('disable_disliking')
+      expect(schema[:properties]).not_to have_key(:reacting_dislike_enabled)
+
+      SettingsService.new.activate_feature!('disable_disliking')
+      expect(schema[:properties].keys)
+        .to include(:reacting_dislike_enabled, :reacting_dislike_method, :reacting_dislike_limited_max)
+    end
+  end
+
   context 'when the project is draft' do
     let(:status) { 'draft' }
 
@@ -25,6 +59,66 @@ describe McpServer::Tools::CreatePhase do
       end.to change { project.reload.phases.count }.by(1)
 
       expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(project.phases.sole.id)
+    end
+
+    it 'creates a native survey phase' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(
+          participation_method: 'native_survey',
+          native_survey_title_multiloc: { 'en' => 'Survey' },
+          native_survey_button_multiloc: { 'en' => 'Take the survey' }
+        ),
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      phase = project.phases.sole
+      expect(phase.participation_method).to eq('native_survey')
+      expect(phase.native_survey_title_multiloc).to eq('en' => 'Survey')
+    end
+
+    it 'creates a budgeting voting phase' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(
+          participation_method: 'voting',
+          voting_method: 'budgeting',
+          voting_max_total: 1000
+        ),
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      phase = project.phases.sole
+      expect(phase.voting_method).to eq('budgeting')
+      expect(phase.voting_max_total).to eq(1000)
+    end
+
+    it 'creates a poll phase when the polls feature is active' do
+      SettingsService.new.activate_feature!('polls')
+
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(participation_method: 'poll'),
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(project.phases.sole.participation_method).to eq('poll')
+    end
+
+    it 'returns structured validation errors for invalid params' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(end_at: '2026-06-01'),
+        current_user:
+      )
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors]).to be_present
+      expect(project.reload.phases.count).to eq(0)
     end
   end
 
@@ -49,8 +143,7 @@ describe McpServer::Tools::CreatePhase do
         current_user:
       )
 
-      expect(response).to be_error
-      expect(response.content.first[:text]).to include('Project not found')
+      expect(response).to be_not_found('Project')
     end
   end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_poll_option_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_poll_option_spec.rb
@@ -24,6 +24,29 @@ describe McpServer::Tools::CreatePollOption do
       end.to change { question.reload.options.count }.by(1)
 
       expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(question.options.sole.id)
+    end
+
+    it 'returns structured validation errors for invalid params' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(title_multiloc: {}),
+        current_user:
+      )
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('title_multiloc')
+      expect(question.reload.options.count).to eq(0)
+    end
+
+    it 'returns a not-found error when the question is missing' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(question_id: SecureRandom.uuid),
+        current_user:
+      )
+
+      expect(response).to be_not_found('Poll question')
     end
   end
 

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_poll_question_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_poll_question_spec.rb
@@ -23,6 +23,40 @@ describe McpServer::Tools::CreatePollQuestion do
       end.to change { phase.reload.poll_questions.count }.by(1)
 
       expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(phase.poll_questions.sole.id)
+    end
+
+    it 'creates the question with its options in one transaction' do
+      options = [{ title_multiloc: { 'en' => 'Yes' } }, { title_multiloc: { 'en' => 'No' } }]
+
+      response = run_mcp_tool(described_class, params: params.merge(options:), current_user:)
+
+      expect(response).not_to be_error
+      question = phase.poll_questions.sole
+      expect(question.options.order(:ordering).map { |o| o.title_multiloc['en'] }).to eq(%w[Yes No])
+      expect(response.structured_content[:options].size).to eq(2)
+    end
+
+    it 'rolls back the question when an option is invalid' do
+      options = [{ title_multiloc: { 'en' => 'Yes' } }, { title_multiloc: {} }]
+
+      response = nil
+      expect do
+        response = run_mcp_tool(described_class, params: params.merge(options:), current_user:)
+      end.not_to change { phase.reload.poll_questions.count }
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('title_multiloc')
+    end
+
+    it 'returns a not-found error when the phase is missing' do
+      response = run_mcp_tool(
+        described_class,
+        params: params.merge(phase_id: SecureRandom.uuid),
+        current_user:
+      )
+
+      expect(response).to be_not_found('Phase')
     end
   end
 

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_project_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_project_spec.rb
@@ -24,6 +24,16 @@ describe McpServer::Tools::CreateProject do
     expect(response.structured_content[:public_url]).to end_with("/projects/#{project.slug}")
   end
 
+  it 'returns structured validation errors for invalid params' do
+    response = nil
+    expect do
+      response = run_mcp_tool(described_class, params: params.merge(visible_to: 'everybody'), current_user:)
+    end.not_to change(Project, :count)
+
+    expect(response).to be_error
+    expect(response.structured_content[:errors].pluck(:attribute)).to include('visible_to')
+  end
+
   it 'attaches a remote header_bg by URL' do
     remote_url = 'https://example.com/header.jpg'
     fixture_path = stub_remote_image_download(remote_url)

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/destroy_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/destroy_resource_spec.rb
@@ -71,12 +71,13 @@ describe McpServer::Tools::DestroyResource do
     expect { image.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
-  it 'destroys a file attachment' do
+  it 'destroys a file attachment but keeps the file in the project pool' do
     file = create(:file, projects: [draft_project])
     attachment = create(:file_attachment, file: file, attachable: draft_project)
     response = destroy('file_attachment', attachment.id)
     expect(response).not_to be_error
     expect { attachment.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(file.reload.projects).to include(draft_project)
   end
 
   it 'refuses when the target project is published' do
@@ -119,7 +120,6 @@ describe McpServer::Tools::DestroyResource do
 
   it 'returns a not-found error when the record does not exist' do
     response = destroy('phase', SecureRandom.uuid)
-    expect(response).to be_error
-    expect(response.content.first[:text]).to match(/not found/i)
+    expect(response).to be_not_found('Resource (phase)')
   end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_form_fields_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_form_fields_spec.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::GetFormFields do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  context 'with an ideation project' do
+    let(:project) { create(:project_with_active_ideation_phase) }
+
+    it 'returns the default form fields and the built-in constraints' do
+      response = run_mcp_tool(
+        described_class,
+        params: { container_type: 'project', container_id: project.id },
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(response.structured_content[:container_id]).to eq(project.id)
+      expect(response.structured_content[:participation_method]).to eq('ideation')
+
+      field_codes = response.structured_content[:fields].pluck(:code)
+      expect(field_codes).to include('title_multiloc', 'body_multiloc')
+
+      expect(response.structured_content[:constraints]).to include(:title_multiloc)
+      expect(response.structured_content.dig(:constraints, :title_multiloc, :locks)).to be_present
+    end
+  end
+
+  context 'with a native survey phase' do
+    let(:phase) { create(:native_survey_phase) }
+    let(:custom_form) { create(:custom_form, participation_context: phase) }
+
+    it 'returns the fields in display order with the stale-data timestamp' do
+      field_a = create(:custom_field, resource: custom_form, input_type: 'text')
+      field_b = create(:custom_field, resource: custom_form, input_type: 'text')
+
+      response = run_mcp_tool(
+        described_class,
+        params: { container_type: 'phase', container_id: phase.id },
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(response.structured_content[:participation_method]).to eq('native_survey')
+      expect(response.structured_content[:fields_last_updated_at]).to be_present
+
+      fields = response.structured_content[:fields]
+      expect(fields.pluck(:id)).to eq([field_a.id, field_b.id])
+      expect(fields.first).to include(:input_type, :title_multiloc, :required)
+    end
+  end
+
+  it 'returns an error for an unsupported participation method' do
+    phase = create(:information_phase)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { container_type: 'phase', container_id: phase.id },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include("Unsupported participation method: 'information'")
+  end
+
+  it 'returns a not-found error for a missing phase' do
+    response = run_mcp_tool(
+      described_class,
+      params: { container_type: 'phase', container_id: SecureRandom.uuid },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Container (phase)')
+  end
+
+  it 'returns a not-found error for a missing project' do
+    response = run_mcp_tool(
+      described_class,
+      params: { container_type: 'project', container_id: SecureRandom.uuid },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Container (project)')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::GetResource do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  def get(type, id)
+    run_mcp_tool(described_class, params: { type: type, id: id }, current_user:)
+  end
+
+  it 'gets a project' do
+    project = create(:project)
+    response = get('project', project.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(project.id)
+    expect(response.structured_content[:admin_url]).to be_present
+  end
+
+  it 'gets a phase' do
+    phase = create(:phase)
+    response = get('phase', phase.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(phase.id)
+    expect(response.structured_content[:admin_url]).to be_present
+  end
+
+  it 'gets an event' do
+    event = create(:event)
+    response = get('event', event.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(event.id)
+  end
+
+  it 'gets a folder' do
+    folder = create(:project_folder)
+    response = get('folder', folder.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(folder.id)
+  end
+
+  it 'gets an area' do
+    area = create(:area)
+    response = get('area', area.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(area.id)
+  end
+
+  it 'gets a global topic' do
+    topic = create(:global_topic)
+    response = get('global_topic', topic.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(topic.id)
+  end
+
+  it 'gets a volunteering cause' do
+    cause = create(:cause)
+    response = get('cause', cause.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(cause.id)
+  end
+
+  it 'gets a poll question' do
+    question = create(:poll_question)
+    response = get('poll_question', question.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(question.id)
+  end
+
+  it 'gets a poll option' do
+    option = create(:poll_option)
+    response = get('poll_option', option.id)
+    expect(response).not_to be_error
+    expect(response.structured_content[:id]).to eq(option.id)
+  end
+
+  it 'returns a not-found error when the record does not exist' do
+    response = get('phase', SecureRandom.uuid)
+    expect(response).to be_not_found('Resource (phase)')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_areas_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_areas_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListAreas do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists areas in display order' do
+    area_a = create(:area)
+    area_b = create(:area)
+    area_b.move_to_top
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([area_b.id, area_a.id])
+  end
+
+  it 'serializes area fields' do
+    create(:area)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :description_multiloc, :ordering)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:area) } }
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_causes_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_causes_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListCauses do
+  let(:current_user) { create(:super_admin) }
+  let(:project) { create(:project) }
+  let(:phase) { create(:volunteering_phase, project:) }
+
+  it 'lists causes of the phase in display order' do
+    cause_a = create(:cause, phase:)
+    cause_b = create(:cause, phase:)
+    create(:cause) # cause in another phase
+    cause_b.move_to_top
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([cause_b.id, cause_a.id])
+  end
+
+  it 'serializes cause fields' do
+    create(:cause, phase:)
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :volunteers_count, :ordering)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { { phase_id: phase.id } }
+    let(:create_record) { -> { create(:cause, phase:) } }
+  end
+
+  it 'returns an empty list when the phase does not exist' do
+    response = run_mcp_tool(described_class, params: { phase_id: SecureRandom.uuid }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data]).to eq([])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_events_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_events_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListEvents do
+  let(:current_user) { create(:super_admin) }
+  let(:project) { create(:project) }
+
+  it 'lists events of the project ordered by start date' do
+    later_event = create(:event, project:, start_at: '2030-03-01', end_at: '2030-03-01 02:00')
+    earlier_event = create(:event, project:, start_at: '2030-01-01', end_at: '2030-01-01 02:00')
+    create(:event) # event in another project
+
+    response = run_mcp_tool(described_class, params: { project_id: project.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([earlier_event.id, later_event.id])
+  end
+
+  it 'serializes event fields' do
+    create(:event, project:)
+
+    response = run_mcp_tool(described_class, params: { project_id: project.id }, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :start_at, :project_id)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { { project_id: project.id } }
+    let(:create_record) { -> { create(:event, project:) } }
+  end
+
+  it 'returns an empty list when the project does not exist' do
+    response = run_mcp_tool(described_class, params: { project_id: SecureRandom.uuid }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data]).to eq([])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_folders_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_folders_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListFolders do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists folders' do
+    folder_a, folder_b = create_list(:project_folder, 2)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to match_array([folder_a.id, folder_b.id])
+  end
+
+  it 'serializes folder fields' do
+    create(:project_folder)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :slug)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:project_folder) } }
+  end
+
+  it 'filters by search on the title' do
+    matching = create(:project_folder, title_multiloc: { 'en' => 'Green spaces' })
+    create(:project_folder, title_multiloc: { 'en' => 'Mobility' })
+
+    response = run_mcp_tool(described_class, params: { search: 'Green' }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([matching.id])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_global_topics_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_global_topics_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListGlobalTopics do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists global topics in display order' do
+    topic_a = create(:global_topic)
+    topic_b = create(:global_topic)
+    topic_b.move_to_top
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([topic_b.id, topic_a.id])
+  end
+
+  it 'serializes topic fields' do
+    create(:global_topic)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :icon, :ordering)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:global_topic) } }
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_groups_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_groups_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListGroups do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists groups ordered by newest first' do
+    group_a = create(:group)
+    group_b = create(:group)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck('id')).to eq([group_b.id, group_a.id])
+  end
+
+  it 'serializes group fields' do
+    create(:group)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include('title_multiloc', 'membership_type', 'memberships_count')
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:group) } }
+  end
+
+  it 'filters by search on the title' do
+    matching = create(:group, title_multiloc: { 'en' => 'Seniors club' })
+    create(:group, title_multiloc: { 'en' => 'Youth council' })
+
+    response = run_mcp_tool(described_class, params: { search: 'Seniors' }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck('id')).to eq([matching.id])
+  end
+
+  it 'filters by project_id' do
+    project = create(:project)
+    matching = create(
+      :smart_group,
+      rules: [{ ruleType: 'participated_in_project', predicate: 'in', value: [project.id] }]
+    )
+    create(:group)
+
+    response = run_mcp_tool(described_class, params: { project_id: project.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck('id')).to eq([matching.id])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phase_permissions_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phase_permissions_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListPhasePermissions do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists the permissions of the phase' do
+    phase = create(:phase, with_permissions: true)
+    create(:phase, with_permissions: true) # phase with its own permissions
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:phase_id]).to eq(phase.id)
+    permissions = response.structured_content[:permissions]
+    expect(permissions).to be_an(Array)
+    expect(permissions.pluck(:action)).to match_array(phase.permissions.pluck(:action))
+  end
+
+  it 'serializes permission fields' do
+    phase = create(:phase, with_permissions: true)
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    expect(response.structured_content[:permissions].first)
+      .to include(:action, :permitted_by, :group_ids)
+  end
+
+  it 'returns a not-found error when the phase is missing' do
+    response = run_mcp_tool(described_class, params: { phase_id: SecureRandom.uuid }, current_user:)
+
+    expect(response).to be_not_found('Phase')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phases_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phases_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListPhases do
+  let(:current_user) { create(:super_admin) }
+  let(:project) { create(:project) }
+
+  it 'lists phases of the project ordered by start date' do
+    later_phase = create(:phase, project:, start_at: '2030-03-01', end_at: '2030-03-20')
+    earlier_phase = create(:phase, project:, start_at: '2030-01-01', end_at: '2030-01-20')
+    create(:phase) # phase in another project
+
+    response = run_mcp_tool(described_class, params: { project_id: project.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([earlier_phase.id, later_phase.id])
+  end
+
+  it 'serializes summary fields' do
+    create(:phase, project:)
+
+    response = run_mcp_tool(described_class, params: { project_id: project.id }, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :participation_method, :start_at)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { { project_id: project.id } }
+    let(:create_record) do
+      months = (1..).each
+      lambda do
+        month = months.next
+        create(:phase, project:, start_at: Date.new(2030, month, 1), end_at: Date.new(2030, month, 20))
+      end
+    end
+  end
+
+  it 'returns a not-found error when the project is missing' do
+    response = run_mcp_tool(described_class, params: { project_id: SecureRandom.uuid }, current_user:)
+
+    expect(response).to be_not_found('Project')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_poll_questions_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_poll_questions_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListPollQuestions do
+  let(:current_user) { create(:super_admin) }
+  let(:project) { create(:project) }
+  let(:phase) { create(:poll_phase, project:) }
+
+  it 'lists poll questions of the phase in display order' do
+    question_a = create(:poll_question, phase:)
+    question_b = create(:poll_question, phase:)
+    create(:poll_question) # question in another phase
+    question_b.move_to_top
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([question_b.id, question_a.id])
+  end
+
+  it 'serializes question fields with the options inlined' do
+    question = create(:poll_question, :with_options, phase:)
+
+    response = run_mcp_tool(described_class, params: { phase_id: phase.id }, current_user:)
+
+    data = response.structured_content[:data]
+    expect(data.first).to include(:title_multiloc, :question_type, :options)
+    expect(data.first[:options].pluck(:id)).to match_array(question.options.pluck(:id))
+    expect(data.first[:options].first).to include(:title_multiloc)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { { phase_id: phase.id } }
+    let(:create_record) { -> { create(:poll_question, phase:) } }
+  end
+
+  it 'returns a not-found error when the phase is missing' do
+    response = run_mcp_tool(described_class, params: { phase_id: SecureRandom.uuid }, current_user:)
+
+    expect(response).to be_not_found('Phase')
+  end
+
+  it 'returns an error when the phase is not a poll phase' do
+    ideation_phase = create(:phase, project:)
+
+    response = run_mcp_tool(described_class, params: { phase_id: ideation_phase.id }, current_user:)
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include("only 'poll' phases have poll questions")
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_projects_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_projects_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListProjects do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists projects' do
+    project_a, project_b = create_list(:project, 2)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to match_array([project_a.id, project_b.id])
+  end
+
+  it 'serializes summary fields' do
+    create(:project)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first)
+      .to include(:title_multiloc, :slug, :publication_status)
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:project) } }
+  end
+
+  it 'filters by search on the title' do
+    matching = create(:project, title_multiloc: { 'en' => 'Park renovation' })
+    create(:project, title_multiloc: { 'en' => 'Traffic plan' })
+
+    response = run_mcp_tool(described_class, params: { search: 'Park' }, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck(:id)).to eq([matching.id])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_user_custom_fields_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_user_custom_fields_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListUserCustomFields do
+  let(:current_user) { create(:super_admin) }
+
+  it 'lists registration fields in display order' do
+    field_a = create(:custom_field)
+    field_b = create(:custom_field)
+    field_b.move_to_top
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck('id')).to eq([field_b.id, field_a.id])
+  end
+
+  it 'serializes exactly id, title_multiloc, input_type, code and required' do
+    create(:custom_field)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response.structured_content[:data].first.keys)
+      .to match_array(%w[id title_multiloc input_type code required])
+  end
+
+  it_behaves_like 'a paginated list tool' do
+    let(:base_params) { {} }
+    let(:create_record) { -> { create(:custom_field) } }
+  end
+
+  it 'excludes disabled and hidden fields' do
+    enabled_field = create(:custom_field)
+    create(:custom_field, enabled: false)
+    create(:custom_field, hidden: true)
+
+    response = run_mcp_tool(described_class, params: {}, current_user:)
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:data].pluck('id')).to eq([enabled_field.id])
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/replace_form_fields_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/replace_form_fields_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ReplaceFormFields do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  let(:project) { create(:project, :draft) }
+  let(:phase) { create(:native_survey_phase, project:) }
+  let!(:custom_form) { create(:custom_form, participation_context: phase) }
+
+  def run(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  context 'with a native survey phase' do
+    let!(:page) { create(:custom_field_page, resource: custom_form, page_layout: 'default') }
+    let!(:question) { create(:custom_field, resource: custom_form, title_multiloc: { 'en' => 'Old question' }) }
+    let!(:dropped_question) { create(:custom_field, resource: custom_form) }
+    let!(:end_page) { create(:custom_field_page, resource: custom_form, key: 'form_end') }
+
+    it 'round-trips the fields returned by get_form_fields' do
+      fetched = run_mcp_tool(
+        McpServer::Tools::GetFormFields,
+        params: { container_type: 'phase', container_id: phase.id },
+        current_user:
+      ).structured_content
+
+      fields = fetched[:fields].reject { |f| f[:id] == dropped_question.id }
+      fields = fields.map do |field|
+        next field unless field[:id] == question.id
+
+        field.merge(title_multiloc: { 'en' => 'New question' })
+      end
+      added = { input_type: 'text', title_multiloc: { 'en' => 'Added question' }, required: false, enabled: true }
+      fields.insert(-2, added) # before the form_end page
+
+      response = run(
+        container_type: 'phase',
+        container_id: phase.id,
+        fields: fields,
+        fields_last_updated_at: fetched[:fields_last_updated_at]
+      )
+
+      expect(response).not_to be_error
+      expect(question.reload.title_multiloc).to eq('en' => 'New question')
+      expect(CustomField.exists?(dropped_question.id)).to be(false)
+
+      returned_titles = response.structured_content[:fields].pluck(:title_multiloc)
+      expect(returned_titles).to include('en' => 'Added question')
+      expect(response.structured_content[:fields_last_updated_at]).to be_present
+    end
+
+    it 'refuses when responses have already been submitted' do
+      create(:idea, project:, phases: [phase], creation_phase: phase)
+
+      response = run(
+        container_type: 'phase',
+        container_id: phase.id,
+        fields: [{ input_type: 'text', title_multiloc: { 'en' => 'Q' }, required: false, enabled: true }]
+      )
+
+      expect(response).to be_error
+      expect(response.content.first[:text]).to include('already')
+      expect(question.reload.title_multiloc).to eq('en' => 'Old question')
+    end
+
+    it 'aborts on a stale fields_last_updated_at' do
+      response = run(
+        container_type: 'phase',
+        container_id: phase.id,
+        fields: [{ input_type: 'text', title_multiloc: { 'en' => 'Q' }, required: false, enabled: true }],
+        fields_last_updated_at: 1.hour.ago(custom_form.fields_last_updated_at).iso8601
+      )
+
+      expect(response).to be_error
+      expect(question.reload.title_multiloc).to eq('en' => 'Old question')
+    end
+
+    it 'refuses when the project is published' do
+      project.admin_publication.update!(publication_status: 'published')
+
+      response = run(
+        container_type: 'phase',
+        container_id: phase.id,
+        fields: []
+      )
+
+      expect(response).to be_unauthorized_project
+      expect(CustomField.exists?(question.id)).to be(true)
+    end
+  end
+
+  it 'creates fields from scratch on an empty form' do
+    response = run(
+      container_type: 'phase',
+      container_id: phase.id,
+      fields: [
+        { input_type: 'page', page_layout: 'default', title_multiloc: {} },
+        { input_type: 'text', title_multiloc: { 'en' => 'First question' }, required: false, enabled: true },
+        { input_type: 'text', title_multiloc: { 'en' => 'Second question' }, required: false, enabled: true },
+        { input_type: 'page', page_layout: 'default', key: 'form_end', title_multiloc: {} }
+      ]
+    )
+
+    expect(response).not_to be_error
+    titles = custom_form.reload.custom_fields.order(:ordering).pluck(:title_multiloc)
+    expect(titles).to include({ 'en' => 'First question' }, { 'en' => 'Second question' })
+    expect(titles.index('en' => 'First question')).to be < titles.index('en' => 'Second question')
+  end
+
+  it 'refuses to drop a locked built-in field on an ideation form' do
+    project = create(:project_with_active_ideation_phase, admin_publication_attributes: { publication_status: 'draft' })
+
+    response = run(
+      container_type: 'project',
+      container_id: project.id,
+      fields: [{ input_type: 'text', title_multiloc: { 'en' => 'Only question' }, required: false, enabled: true }]
+    )
+
+    expect(response).to be_error
+  end
+
+  it 'returns an error for an unsupported participation method' do
+    phase = create(:information_phase, project: create(:project, :draft))
+
+    response = run(
+      container_type: 'phase',
+      container_id: phase.id,
+      fields: []
+    )
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include("Unsupported participation method: 'information'")
+  end
+
+  it 'returns a not-found error when the container is missing' do
+    response = run(
+      container_type: 'phase',
+      container_id: SecureRandom.uuid,
+      fields: []
+    )
+
+    expect(response).to be_not_found('Container (phase)')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
@@ -27,6 +27,127 @@ describe McpServer::Tools::UpdatePhasePermission do
       expect(response).not_to be_error
     end
 
+    it 'returns the serialized permission' do
+      response = run_mcp_tool(described_class, params:, current_user:)
+
+      expect(response.structured_content).to match(
+        action: permission.action,
+        permitted_by: 'admins_moderators',
+        group_ids: [],
+        demographic_questions: [],
+        verification_expiry: nil,
+        access_denied_explanation_multiloc: permission.access_denied_explanation_multiloc
+      )
+    end
+
+    it 'sets and clears group restrictions' do
+      groups = create_list(:group, 2)
+
+      run_mcp_tool(described_class, params: params.merge(permitted_by: 'users', group_ids: groups.map(&:id)), current_user:)
+      expect(permission.reload.group_ids).to match_array(groups.map(&:id))
+
+      run_mcp_tool(described_class, params: params.merge(permitted_by: 'users', group_ids: []), current_user:)
+      expect(permission.reload.group_ids).to be_empty
+    end
+
+    it 'replaces (does not merge) the access-denied explanation' do
+      permission.update!(access_denied_explanation_multiloc: { 'en' => 'Old', 'fr-FR' => 'Ancien' })
+
+      run_mcp_tool(
+        described_class,
+        params: params.merge(access_denied_explanation_multiloc: { 'en' => 'New' }),
+        current_user:
+      )
+
+      expect(permission.reload.access_denied_explanation_multiloc).to eq('en' => 'New')
+    end
+
+    context 'with a verification method enabled' do
+      before do
+        config = AppConfiguration.instance
+        config.settings['id_config'] = { allowed: true, enabled: true, id_methods: [{ name: 'fake_sso', enabled_for_verified_actions: true }] }
+        config.save!
+      end
+
+      it 'sets the verification expiry for a verified permitted_by' do
+        response = run_mcp_tool(
+          described_class,
+          params: params.merge(permitted_by: 'verified', verification_expiry: 7),
+          current_user:
+        )
+
+        expect(response).not_to be_error
+        expect(permission.reload.permitted_by).to eq('verified')
+        expect(permission.verification_expiry).to eq(7)
+      end
+    end
+
+    it 'returns structured validation errors for an invalid update' do
+      response = run_mcp_tool(described_class, params: params.merge(permitted_by: 'verified'), current_user:)
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('permitted_by')
+      expect(permission.reload.permitted_by).not_to eq('verified')
+    end
+
+    describe 'demographic_questions' do
+      let!(:existing_field) { create(:custom_field) }
+
+      before do
+        permission.update!(global_custom_fields: false)
+        permission.permissions_custom_fields.create!(custom_field: existing_field, required: true)
+      end
+
+      it 'leaves the existing configuration unchanged when omitted' do
+        response = run_mcp_tool(described_class, params:, current_user:)
+
+        expect(response).not_to be_error
+        expect(permission.reload.global_custom_fields).to be(false)
+        expect(permission.permissions_custom_fields.pluck(:custom_field_id)).to eq([existing_field.id])
+      end
+
+      it 'resets to the platform defaults when null' do
+        response = run_mcp_tool(described_class, params: params.merge(demographic_questions: nil), current_user:)
+
+        expect(response).not_to be_error
+        expect(permission.reload.global_custom_fields).to be(true)
+        expect(permission.permissions_custom_fields).to be_empty
+      end
+
+      it 'asks no questions when empty' do
+        response = run_mcp_tool(described_class, params: params.merge(demographic_questions: []), current_user:)
+
+        expect(response).not_to be_error
+        expect(permission.reload.global_custom_fields).to be(false)
+        expect(permission.permissions_custom_fields).to be_empty
+      end
+
+      it 'replaces the rows in array order' do
+        field_a, field_b = create_list(:custom_field, 2)
+        demographic_questions = [
+          { custom_field_id: field_b.id, required: false },
+          { custom_field_id: field_a.id }
+        ]
+
+        response = run_mcp_tool(described_class, params: params.merge(demographic_questions:), current_user:)
+
+        expect(response).not_to be_error
+        rows = permission.reload.permissions_custom_fields.order(:ordering)
+        expect(rows.pluck(:custom_field_id)).to eq([field_b.id, field_a.id])
+        expect(rows.pluck(:required)).to eq([false, true])
+      end
+
+      it 'rolls back the whole update when a custom field is unknown' do
+        demographic_questions = [{ custom_field_id: SecureRandom.uuid }]
+
+        response = run_mcp_tool(described_class, params: params.merge(demographic_questions:), current_user:)
+
+        expect(response).to be_error
+        expect(permission.reload.permitted_by).not_to eq('admins_moderators')
+        expect(permission.permissions_custom_fields.pluck(:custom_field_id)).to eq([existing_field.id])
+      end
+    end
+
     context 'with an invalid action' do
       let(:params) do
         {
@@ -55,5 +176,15 @@ describe McpServer::Tools::UpdatePhasePermission do
 
       expect(response).to be_unauthorized_project
     end
+  end
+
+  it 'returns a not-found error when the phase is missing' do
+    response = run_mcp_tool(
+      described_class,
+      params: { phase_id: SecureRandom.uuid, action: 'commenting_idea', permitted_by: 'users' },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Phase')
   end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::UpdatePhase do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  let(:project) { create(:project, :draft) }
+  let(:phase) { create(:phase, project:) }
+
+  describe '#input_schema' do
+    it "reuses create_phase's schema without project_id" do
+      create_properties = McpServer::Tools::CreatePhase.new.input_schema[:properties].except(:project_id)
+      schema = described_class.new.input_schema
+
+      expect(schema[:properties].keys).to eq([:phase_id, *create_properties.keys])
+      expect(schema[:required]).to eq(%w[phase_id])
+      expect(schema[:additionalProperties]).to be(false)
+    end
+  end
+
+  context 'when the project is draft' do
+    it 'updates only the given attributes' do
+      response = nil
+      expect { response = run_mcp_tool(described_class, params: { phase_id: phase.id, commenting_enabled: false }, current_user:) }
+        .to change { phase.reload.commenting_enabled }.to(false)
+        .and not_change { phase.reload.title_multiloc }
+
+      expect(response).not_to be_error
+      expect(response.structured_content[:id]).to eq(phase.id)
+    end
+
+    it 'merges multiloc fields per locale' do
+      phase.update!(title_multiloc: { 'en' => 'Old', 'fr-FR' => 'Ancien' })
+
+      response = run_mcp_tool(
+        described_class,
+        params: { phase_id: phase.id, title_multiloc: { 'en' => 'New' } },
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(phase.reload.title_multiloc).to eq('en' => 'New', 'fr-FR' => 'Ancien')
+      expect(response.structured_content[:title_multiloc]).to eq('en' => 'New', 'fr-FR' => 'Ancien')
+    end
+
+    it 'records manual voters through the dedicated setter' do
+      phase = create(:single_voting_phase, project:)
+
+      response = run_mcp_tool(
+        described_class,
+        params: { phase_id: phase.id, manual_voters_amount: 25 },
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(phase.reload.manual_voters_amount).to eq(25)
+      expect(phase.manual_voters_last_updated_by).to eq(current_user)
+      expect(phase.manual_voters_last_updated_at).to be_present
+    end
+
+    it 'rejects changing the participation method when the phase has inputs' do
+      create(:idea, project:, phases: [phase])
+
+      response = run_mcp_tool(
+        described_class,
+        params: { phase_id: phase.id, participation_method: 'information' },
+        current_user:
+      )
+
+      expect(response).to be_error
+      expect(response.structured_content[:errors].pluck(:attribute)).to include('participation_method')
+      expect(phase.reload.participation_method).to eq('ideation')
+    end
+
+    it 'changes the participation method when the phase has no inputs' do
+      response = run_mcp_tool(
+        described_class,
+        params: { phase_id: phase.id, participation_method: 'information' },
+        current_user:
+      )
+
+      expect(response).not_to be_error
+      expect(phase.reload.participation_method).to eq('information')
+    end
+  end
+
+  context 'when the project is published' do
+    let(:project) { create(:project, admin_publication_attributes: { publication_status: 'published' }) }
+
+    it 'returns an isError response and does not update the phase' do
+      response = nil
+      expect { response = run_mcp_tool(described_class, params: { phase_id: phase.id, commenting_enabled: false }, current_user:) }
+        .not_to change { phase.reload.commenting_enabled }
+
+      expect(response).to be_unauthorized_project
+    end
+  end
+
+  it 'returns a not-found error when the phase is missing' do
+    response = run_mcp_tool(
+      described_class,
+      params: { phase_id: SecureRandom.uuid, commenting_enabled: false },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Phase')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_project_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_project_spec.rb
@@ -20,6 +20,15 @@ describe McpServer::Tools::UpdateProject do
     expect(project.reload.header_bg.file.read).to eq(fixture_path.binread)
   end
 
+  it 'updates only the given attributes' do
+    response = nil
+    expect { response = run_mcp_tool(described_class, params: { project_id: project.id, listed: false }, current_user:) }
+      .to change { project.reload.listed }.to(false)
+      .and not_change { project.reload.title_multiloc }
+
+    expect(response).not_to be_error
+  end
+
   it 'returns the serialized project with merged multiloc fields' do
     project.update!(title_multiloc: { 'en' => 'Old', 'fr-FR' => 'Ancien' })
 
@@ -32,5 +41,37 @@ describe McpServer::Tools::UpdateProject do
     expect(response).not_to be_error
     expect(response.structured_content[:id]).to eq(project.id)
     expect(response.structured_content[:title_multiloc]).to eq('en' => 'New', 'fr-FR' => 'Ancien')
+  end
+
+  it 'returns structured validation errors for an invalid update' do
+    response = run_mcp_tool(
+      described_class,
+      params: { project_id: project.id, visible_to: 'everybody' },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(response.structured_content[:errors].pluck(:attribute)).to include('visible_to')
+    expect(project.reload.visible_to).to eq('public')
+  end
+
+  it 'refuses when the project is published' do
+    published = create(:project, admin_publication_attributes: { publication_status: 'published' })
+
+    response = nil
+    expect { response = run_mcp_tool(described_class, params: { project_id: published.id, title_multiloc: { 'en' => 'New' } }, current_user:) }
+      .not_to change { published.reload.title_multiloc }
+
+    expect(response).to be_unauthorized_project
+  end
+
+  it 'returns a not-found error when the project is missing' do
+    response = run_mcp_tool(
+      described_class,
+      params: { project_id: SecureRandom.uuid, title_multiloc: { 'en' => 'New' } },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Project')
   end
 end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_resource_spec.rb
@@ -35,4 +35,92 @@ describe McpServer::Tools::UpdateResource do
     expect(response.structured_content[:id]).to eq(cause.id)
     expect(response.structured_content[:title_multiloc]).to eq('en' => 'New', 'fr-FR' => 'Ancienne')
   end
+
+  it 'updates an event' do
+    event = create(:event, project:)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'event', id: event.id, attributes: { online_link: 'https://example.com/meet' } },
+      current_user:
+    )
+
+    expect(response).not_to be_error
+    expect(event.reload.online_link).to eq('https://example.com/meet')
+    expect(response.structured_content[:id]).to eq(event.id)
+  end
+
+  it 'updates a poll question' do
+    poll_phase = create(:poll_phase, project:)
+    question = create(:poll_question, phase: poll_phase)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'poll_question', id: question.id, attributes: { title_multiloc: { 'en' => 'Renamed' } } },
+      current_user:
+    )
+
+    expect(response).not_to be_error
+    expect(question.reload.title_multiloc['en']).to eq('Renamed')
+  end
+
+  it 'updates a poll option' do
+    poll_phase = create(:poll_phase, project:)
+    option = create(:poll_option, question: create(:poll_question, phase: poll_phase))
+
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'poll_option', id: option.id, attributes: { title_multiloc: { 'en' => 'Renamed' } } },
+      current_user:
+    )
+
+    expect(response).not_to be_error
+    expect(option.reload.title_multiloc['en']).to eq('Renamed')
+  end
+
+  it 'rejects attributes outside the allowlist of the type' do
+    option = create(:poll_option, question: create(:poll_question, phase: create(:poll_phase, project:)))
+
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'poll_option', id: option.id, attributes: { question_type: 'multiple_options' } },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include("These fields can't be updated on poll_option: question_type")
+  end
+
+  it 'returns structured validation errors for an invalid update' do
+    event = create(:event, project:)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'event', id: event.id, attributes: { maximum_attendees: 0 } },
+      current_user:
+    )
+
+    expect(response).to be_error
+    expect(response.structured_content[:errors].pluck(:attribute)).to include('maximum_attendees')
+  end
+
+  it 'refuses when the project is published' do
+    project.admin_publication.update!(publication_status: 'published')
+
+    response = nil
+    expect { response = run_mcp_tool(described_class, params: { type: 'cause', id: cause.id, attributes: { title_multiloc: { 'en' => 'New' } } }, current_user:) }
+      .not_to change { cause.reload.title_multiloc }
+
+    expect(response).to be_unauthorized_project
+  end
+
+  it 'returns a not-found error when the resource is missing' do
+    response = run_mcp_tool(
+      described_class,
+      params: { type: 'event', id: SecureRandom.uuid, attributes: { online_link: 'https://example.com' } },
+      current_user:
+    )
+
+    expect(response).to be_not_found('Resource (event)')
+  end
 end

--- a/back/engines/commercial/mcp_server/spec/requests/mcp_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/requests/mcp_spec.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'POST /mcp' do
+  let(:user) { create(:super_admin) }
+  let(:application) do
+    Doorkeeper::Application.create!(
+      name: 'MCP client',
+      redirect_uri: 'https://client.example.com/callback',
+      confidential: false,
+      scopes: 'mcp:access'
+    )
+  end
+  let(:token) do
+    Doorkeeper::AccessToken.create!(application:, resource_owner_id: user.id, scopes: 'mcp:access')
+  end
+  let(:headers) do
+    {
+      'Authorization' => "Bearer #{token.plaintext_token}",
+      'Content-Type' => 'application/json',
+      'Accept' => 'application/json, text/event-stream'
+    }
+  end
+
+  before { SettingsService.new.activate_feature!('mcp_server') }
+
+  def rpc(method, params = {})
+    { jsonrpc: '2.0', id: 1, method:, params: }.to_json
+  end
+
+  def rpc_result
+    JSON.parse(response.body)['result']
+  end
+
+  describe 'authorization gating' do
+    it 'returns 401 with the RFC 9728 resource-metadata challenge when no token is given' do
+      post '/mcp', params: rpc('tools/list'), headers: headers.except('Authorization')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers['WWW-Authenticate'])
+        .to include('resource_metadata="', '/.well-known/oauth-protected-resource')
+    end
+
+    it 'returns 401 for an invalid token' do
+      post '/mcp', params: rpc('tools/list'), headers: headers.merge('Authorization' => 'Bearer bogus')
+
+      expect(response).to have_http_status(:unauthorized)
+      expect(response.headers['WWW-Authenticate']).to include('resource_metadata=')
+    end
+
+    it 'refuses a token without the mcp:access scope' do
+      token.update!(scopes: 'public')
+
+      post('/mcp', params: rpc('tools/list'), headers:)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'refuses a token whose owner is not a super admin' do
+      token.update!(resource_owner_id: create(:admin).id)
+
+      post('/mcp', params: rpc('tools/list'), headers:)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it 'refuses when the mcp_server feature is disabled' do
+      SettingsService.new.deactivate_feature!('mcp_server')
+
+      post('/mcp', params: rpc('tools/list'), headers:)
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+
+  describe 'tools/list' do
+    it 'lists every registered tool' do
+      post('/mcp', params: rpc('tools/list'), headers:)
+
+      expect(response).to have_http_status(:ok)
+
+      tool_names = rpc_result['tools'].pluck('name')
+      expect(tool_names.size).to eq(McpServer::McpController::TOOL_CLASSES.size)
+      expect(tool_names).to include('create_project', 'list_projects', 'destroy_resource')
+      expect(tool_names).not_to include('list_users')
+    end
+  end
+
+  describe 'tools/call' do
+    it 'runs a tool end to end' do
+      area = create(:area)
+
+      post('/mcp', params: rpc('tools/call', { name: 'list_areas', arguments: {} }), headers:)
+
+      expect(response).to have_http_status(:ok)
+      expect(rpc_result['isError']).to be_falsey
+      expect(rpc_result.dig('structuredContent', 'data').pluck('id')).to eq([area.id])
+      expect(rpc_result['content'].first['type']).to eq('text')
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/support/matchers/be_not_found.rb
+++ b/back/engines/commercial/mcp_server/spec/support/matchers/be_not_found.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Matches an MCP tool error response emitted by
+# McpServer::BaseTool::ResponseHelpers#not_found_error.
+#
+# Optional argument narrows the match to a specific label:
+#
+#   expect(response).to be_not_found
+#   expect(response).to be_not_found('Project')
+#   expect(response).to be_not_found('Resource (phase)')
+RSpec::Matchers.define :be_not_found do |label = nil|
+  match do |response|
+    values_match?(be_error, response) &&
+      response.content.any? do |c|
+        text = c[:text]
+        next false if text.nil?
+
+        label ? text.include?("#{label} not found") : text.match?(/not found/i)
+      end
+  end
+
+  failure_message do |response|
+    if !values_match?(be_error, response)
+      'expected response to be a not-found error, but it succeeded'
+    else
+      expected = label ? "a '#{label} not found' error" : 'a not-found error'
+      "expected #{expected}, got: #{response_text(response).inspect}"
+    end
+  end
+
+  def response_text(response)
+    response.content.filter_map { |c| c[:text] }.join(' / ')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/support/mcp_server/shared_examples/paginated_list_tool.rb
+++ b/back/engines/commercial/mcp_server/spec/support/mcp_server/shared_examples/paginated_list_tool.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# Shared examples for list tools built on McpServer::BaseTool::Pagination.
+#
+# The including spec must define:
+#   let(:current_user)  - user running the tool
+#   let(:base_params)   - valid params, without :page / :per_page
+#   let(:create_record) - proc creating ONE record in the listed scope
+#                         (the scope must otherwise be empty)
+#
+#   it_behaves_like 'a paginated list tool'
+RSpec.shared_examples 'a paginated list tool' do
+  describe 'pagination' do
+    before { 3.times { create_record.call } }
+
+    it 'returns the data and pagination envelope with defaults' do
+      response = run_mcp_tool(described_class, params: base_params, current_user:)
+
+      expect(response).not_to be_error
+      expect(response.structured_content[:data]).to be_an(Array)
+      expect(response.structured_content[:pagination]).to eq(
+        page: 1,
+        per_page: McpServer::BaseTool::Pagination::DEFAULT_PER_PAGE,
+        total_count: 3,
+        total_pages: 1
+      )
+    end
+
+    it 'serves subsequent pages' do
+      params = base_params.merge(page: 2, per_page: 2)
+      response = run_mcp_tool(described_class, params:, current_user:)
+
+      expect(response).not_to be_error
+      expect(response.structured_content[:data].size).to eq(1)
+      expect(response.structured_content[:pagination]).to eq(
+        page: 2, per_page: 2, total_count: 3, total_pages: 2
+      )
+    end
+
+    it 'clamps per_page to MAX_PER_PAGE' do
+      params = base_params.merge(per_page: 999)
+      response = run_mcp_tool(described_class, params:, current_user:)
+
+      expect(response.structured_content.dig(:pagination, :per_page))
+        .to eq(McpServer::BaseTool::Pagination::MAX_PER_PAGE)
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/support/mcp_server/stub_remote_download.rb
+++ b/back/engines/commercial/mcp_server/spec/support/mcp_server/stub_remote_download.rb
@@ -20,6 +20,14 @@ module McpServer
       stub_remote_download(url, fixture_path: fixture_path, content_type: content_type)
     end
 
+    # Stubs a failing remote download (CarrierWave raises CarrierWave::DownloadError).
+    def stub_failing_remote_download(url, status: 404)
+      allow_any_instance_of(ProcessableUriDownloader)
+        .to receive(:skip_ssrf_protection?).and_return(true)
+
+      stub_request(:get, url).to_return(status: status)
+    end
+
     private
 
     def stub_remote_download(url, fixture_path:, content_type:)


### PR DESCRIPTION
The MCP engine was built velocity-first with minimal test coverage. This PR adds a systematic test suite, plus fixes for two real bugs the new specs surfaced.

## Production fixes (found while writing the suite)

- **Missing authorization guards** — `update_project`, `update_phase`, `update_resource` and `replace_form_fields` called neither `authorize_project!` nor Pundit `authorize`, so the draft-only constraint was not enforced for updates: a super admin could mutate published projects through the MCP. Both guards are now in place, matching every other mutating tool.
- **Silent empty list for a bad parent id** — `list_events` and `list_causes` filtered without looking up the parent, so a nonexistent `project_id`/`phase_id` returned `[]` (an LLM reads that as "no events" rather than "wrong id"). They now return the standard not-found error like their siblings.
- **No way to remove a project header background** — `remote_header_bg_url` was a non-nullable string; it now accepts `null`, which `update_project` translates into `remove_header_bg!` (CarrierWave ignores plain nil assignment), mirroring the web API's `remove_image_if_requested!`.
- **Opaque `replace_form_fields` validation errors** — form-level error keys (`stale_data`, `locked_deletion`, …) were relayed as a raw JSON dump; they now map to actionable prose (re-fetch and retry, echo locked fields back, structural page rules), with the raw errors still in `structuredContent`.
- **Group visibility was invisible and unreachable** — with `visible_to: 'groups'`, the project payload carried no group information, the schemas had no way to set the group list, and `list_groups`' `project_id` filter matched smart-group *rules* referencing the project rather than the groups that can see it. The project schemas now accept `group_ids` (replace-wholesale, like `area_ids`), the serializer surfaces `group_ids`, and the misleading filter is removed (read ids from the payload, resolve names via `list_groups`).
- **Broken `get_form_fields` → `replace_form_fields` round-trip** — `Serializers::CustomField` emitted a `constraints` key (from the web serializer) that is not a `CustomField` attribute; echoing fetched fields back into `replace_form_fields` crashed `UpdateAllService` with `ActiveModel::UnknownAttributeError`. The MCP serializer now drops the key (constraints are reported at the top level of the `get_form_fields` response). The round-trip is covered by a spec.

## Test strategy

Depth follows risk: complex tools (`create_phase`'s feature-flag-driven schema, `update_phase_permission`'s `demographic_questions` semantics, form-fields round-trip/guards, `destroy_resource` cascades) get deep bespoke specs; thin list tools get short, deliberately uniform specs.

Similar tools are tested with an identical structure ("canvas" per category: list / create / update / get / attach), documented in the engine `CLAUDE.md` §12 (kept in the private claude repo since `**/CLAUDE.md` is gitignored here). New helpers:

- `be_not_found('Label')` matcher (`spec/support/matchers/be_not_found.rb`)
- `it_behaves_like 'a paginated list tool'` shared examples (`spec/support/mcp_server/shared_examples/paginated_list_tool.rb`), used by all 13 paginated list specs
- `stub_failing_remote_download` next to the existing download stubs

Shared examples deliberately **not** created (over-factorization would hurt more than help):
- *draft-only tool*: setup and no-side-effect assertion vary too much per tool; the published context stays inline (6 lines).
- *multiloc merge*: mechanics unit-tested once in `multiloc_merge_spec.rb`; each update tool keeps one small integration example proving it routes through the merge.
- *not-found*: the `be_not_found` matcher reduces it to a 3-line example.

Serializers: no direct specs for domain serializers — they're exercised through `get_resource_spec` (all 9 types), list-spec shape assertions and the form-fields specs. Only `Serializers::Base` and `McpServer::Jsonapi` (where the logic lives) have unit specs.

New layers beyond tools:
- `spec/requests/mcp_spec.rb` — the only place the HTTP gating is exercised: Doorkeeper `mcp:access` scope, `McpPolicy` (super admin + feature flag), RFC 9728 `WWW-Authenticate` challenge, end-to-end `tools/list` / `tools/call` with a real bearer token. Doubles as the `McpPolicy` spec.
- Unit specs for `BaseTool::Pagination`, `MultilocMerge`, `ResponseHelpers`, `Multiloc`, `Jsonapi`, `Serializers::Base`; suite-wide definition invariants in `base_tool_spec.rb`.

## Coverage (lines, `engines/commercial/mcp_server/app/**`)

| | Baseline | This PR |
|---|---|---|
| Total | 740/887 = **83.4%** | 923/928 = **99.5%** |
| Examples | 76 | 252 |

Remaining uncovered lines are defensive: the `CarrierWave::DownloadError` rescues in the attach tools (download failures actually surface as model validation errors — covered as such) and `Runner#run`'s `NotImplementedError` (covered) — plus `BaseTool::Authorization#pundit_user` (see below).

## Notes / follow-ups (not addressed here)

- List tools should go through Pundit policy scopes (`policy_scope`) instead of querying unscoped (`Group.all`, `Volunteering::Cause.where(...)`, …). Today `McpPolicy` restricts the endpoint to super admins so nothing leaks, but the tools silently rely on that outer gate; scoping them makes the invariant local and future-proofs any loosening of endpoint access.

- `update_phase_permission` **replaces** `access_denied_explanation_multiloc` wholesale instead of merging like other update tools — the spec encodes current behavior with an explicit test name; consider aligning.
- `BaseTool::Authorization#pundit_user` is dead code: the `included` hook includes `Pundit::Authorization` afterwards, whose identical `pundit_user` shadows it.
- Remaining "settable but not clearable" fields (same class as the header_bg fix): `update_phase` can't clear `end_at` (the only way to make the last phase open-ended); `update_phase_permission` can't clear `access_denied_explanation_multiloc` (schema rejects null and `{}`, and the Runner's `.compact` drops nils); `update_resource` silently no-ops on `remote_image_url: null` for causes (CarrierWave ignores nil — needs `remove_image!`). The embed-URL fields were checked and are fine as is (`presence` validations make clearing invalid where they matter).
- Mass-assignment gaps (implemented, currently stashed — `git stash`): `create_phase` splats params into `Phase.new` without `additionalProperties: false`; `replace_form_fields`' field/option/statement item schemas accept undeclared keys that reach `CustomField.new`/`assign_attributes`, including `resource_id` (re-parenting a field to another form). The stash closes both schemas, declares the read-only keys for round-tripping and strips them in the tool before saving.
- `Runner::NOT_DRAFT_MESSAGE` ends with a period, and `unauthorized_message` appends another one → "…via MCP..".
- Feature-gated participation methods are enforced **only** by schema validation at MCP dispatch (the gem's `validate_tool_call_arguments` default; pinned by a request-spec example) — consider a runtime flag check in `CreatePhase`'s Runner as defense-in-depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
