### PR TITLE
[Tan-8101] hide like/dislike btns in idea if reacting to inputs disabled

### DIFF
--- a/front/app/components/ReactionControl/utils.ts
+++ b/front/app/components/ReactionControl/utils.ts
@@ -15,7 +15,7 @@ export const showIdeationReactions = (idea: IIdeaData) => {
   // hide like/dislike buttons if Reacting to inputs is disabled
   // and idea is in active phase (disabled_reason equals reacting_disabled)
   if (!reactingActionDescriptor.enabled && reactingActionDescriptor .disabled_reason === 'reacting_disabled') {
-    return false;
+    return null;
   }
 
   return (

--- a/front/app/components/ReactionControl/utils.ts
+++ b/front/app/components/ReactionControl/utils.ts
@@ -9,9 +9,15 @@ export const showIdeationReactions = (idea: IIdeaData) => {
     reactingActionDescriptor.up.future_enabled_at ||
     reactingActionDescriptor.down.future_enabled_at
   );
-  const cancellingEnabled = reactingActionDescriptor.cancelling_enabled;
   const likesCount = idea.attributes.likes_count;
   const dislikesCount = idea.attributes.dislikes_count;
+  const cancellingEnabled = reactingActionDescriptor.cancelling_enabled;
+  // hide like/dislike buttons if Reacting to inputs is disabled
+  // and idea is in active phase (disabled_reason equals reacting_disabled)
+  if (!reactingActionDescriptor.enabled && reactingActionDescriptor .disabled_reason === 'reacting_disabled') {
+    return false;
+  }
+
   return (
     reactingActionDescriptor.enabled ||
     isFixableByAuthentication(reactingActionDescriptor.disabled_reason) ||

--- a/front/cypress/e2e/idea_card.cy.ts
+++ b/front/cypress/e2e/idea_card.cy.ts
@@ -140,19 +140,33 @@ describe('Idea card component', () => {
   });
 
   describe('Reaction to input disabled', () => {
+    const ideaTitle = randomString();
+    const ideaContent = randomString();
+
     before(() => {
-      cy.apiUpdatePhase({
-        phaseId: phaseId,
+      cy.apiCreatePhase({
+        projectId,
+        title: "Second phase",
+        startAt: moment().subtract(1, 'month').format('DD/MM/YYYY'),
+        participationMethod: 'ideation',
+        canPost: true,
+        canComment: true,
         canReact: false,
-      });
-      // reload the page with new permissions
-      cy.reload();
+        reacting_dislike_enabled: true,
+      })
+      .then((phase) => {
+        phaseId = phase.body.data.id;
+      })
+      .then((user) => {
+        return cy.apiCreateIdea({
+          projectId,
+          ideaTitle,
+          ideaContent,
+        });
+      })
     });
 
     it('does not show the up and dislike buttons if canReact is false', () => {
-      cy.visit(`/projects/${projectSlug}`);
-      cy.wait(2000);
-
       cy.get('#e2e-ideas-list')
         .find('.e2e-idea-card')
         .contains(ideaTitle)
@@ -166,12 +180,6 @@ describe('Idea card component', () => {
         .closest('.e2e-idea-card')
         .find('.e2e-ideacard-dislike-button')
         .should('not.exist');
-    });
-    after(() => {
-      cy.apiUpdatePhase({
-        phaseId: phaseId,
-        canReact: true,
-      });
     });
   });
 

--- a/front/cypress/e2e/idea_card.cy.ts
+++ b/front/cypress/e2e/idea_card.cy.ts
@@ -11,6 +11,7 @@ describe('Idea card component', () => {
   const commentContent = randomString();
   let projectId: string;
   let projectSlug: string;
+  let phaseId: string;
   let ideaId: string;
   let userId: string;
 
@@ -36,7 +37,8 @@ describe('Idea card component', () => {
           reacting_dislike_enabled: true,
         });
       })
-      .then(() => {
+      .then((phase) => {
+        phaseId = phase.body.data.id;
         return cy.apiSignup(firstName, lastName, email, password);
       })
       .then((user) => {
@@ -135,6 +137,42 @@ describe('Idea card component', () => {
       .closest('.e2e-idea-card')
       .find('.e2e-ideacard-comment-count')
       .contains('2');
+  });
+
+  describe('Reaction to input disabled', () => {
+    before(() => {
+      cy.apiUpdatePhase({
+        phaseId: phaseId,
+        canReact: false,
+      });
+      // reload the page with new permissions
+      cy.reload();
+    });
+
+    it('does not show the up and dislike buttons if canReact is false', () => {
+      cy.visit(`/projects/${projectSlug}`);
+      cy.wait(2000);
+
+      cy.get('#e2e-ideas-list')
+        .find('.e2e-idea-card')
+        .contains(ideaTitle)
+        .closest('.e2e-idea-card')
+        .find('.e2e-ideacard-like-button')
+        .should('not.exist');
+
+      cy.get('#e2e-ideas-list')
+        .find('.e2e-idea-card')
+        .contains(ideaTitle)
+        .closest('.e2e-idea-card')
+        .find('.e2e-ideacard-dislike-button')
+        .should('not.exist');
+    });
+    after(() => {
+      cy.apiUpdatePhase({
+        phaseId: phaseId,
+        canReact: true,
+      });
+    });
   });
 
   after(() => {

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -177,7 +177,10 @@ describe('Idea show page actions', () => {
     });
 
     describe('No reaction possible when canReact is false', () => {
-      beforeEach(() => {
+      let ideaIdBis = '';
+      let ideaSlugBis = '';
+
+      before(() => {
         const firstName = randomString();
         const lastName = randomString();
         const email = randomEmail();
@@ -185,30 +188,47 @@ describe('Idea show page actions', () => {
 
         cy.apiSignup(firstName, lastName, email, password);
         cy.setLoginCookie(email, password);
-        cy.apiUpdatePhase({
-          phaseId: phaseId,
+        cy.apiCreatePhase({
+          projectId,
+          title: "Second phase",
+          startAt: moment().subtract(1, 'month').format('DD/MM/YYYY'),
+          participationMethod: 'ideation',
+          canPost: true,
+          canComment: true,
           canReact: false,
+          reacting_dislike_enabled: true,
+        })
+        .then((phase) => {
+          phaseId = phase.body.data.id;
+        })
+        .then((user) => {
+          return cy.apiCreateIdea({
+            projectId,
+            ideaTitle: randomString(20),
+            ideaContent: randomString(),
+            phaseIds: [phaseId],
+          });
+        })
+        .then((idea) => {
+          ideaIdBis = idea.body.data.id;
+          ideaSlugBis = idea.body.data.attributes.slug;
         });
-        cy.reload();
+      });
+
+      after(() => {
+        cy.apiRemoveIdea(ideaIdBis);
       });
 
       it('has no up and dislike buttons', () => {
-        cy.visit(`/ideas/${ideaSlug}`);
-        cy.intercept(`**/ideas/by_slug/${ideaSlug}`).as('ideaRequest');
+        cy.visit(`/ideas/${ideaSlugBis}`);
+        cy.intercept(`**/ideas/by_slug/${ideaSlugBis}`).as('ideaRequestBis');
 
-        cy.wait('@ideaRequest');
+        cy.wait('@ideaRequestBis');
         cy.get('#e2e-idea-show').should('exist');
 
         cy.get('.e2e-reaction-controls').should('not.exist');
         cy.get('.e2e-ideacard-like-button').should('not.exist');
         cy.get('.e2e-ideacard-dislike-button').should('not.exist');
-      });
-
-      after(() => {
-        cy.apiUpdatePhase({
-          phaseId: phaseId,
-          canReact: true,
-        });
       });
     });
 

--- a/front/cypress/e2e/idea_page_action.cy.ts
+++ b/front/cypress/e2e/idea_page_action.cy.ts
@@ -4,6 +4,7 @@ import moment = require('moment');
 describe('Idea show page actions', () => {
   let projectId = '';
   let projectSlug = '';
+  let phaseId = '';
   let ideaId = '';
   let ideaSlug = '';
   const phaseTitle = randomString();
@@ -30,7 +31,8 @@ describe('Idea show page actions', () => {
         });
       })
       .then((phase) => {
-        cy.apiCreateIdea({
+        phaseId = phase.body.data.id;
+        return cy.apiCreateIdea({
           projectId,
           ideaTitle: randomString(20),
           ideaContent: randomString(),
@@ -171,6 +173,42 @@ describe('Idea show page actions', () => {
         cy.get('@dislikeBtn').contains('0');
         cy.get('@likeBtn').contains('2');
         cy.get('@likeBtn').click().wait(1000);
+      });
+    });
+
+    describe('No reaction possible when canReact is false', () => {
+      beforeEach(() => {
+        const firstName = randomString();
+        const lastName = randomString();
+        const email = randomEmail();
+        const password = randomString();
+
+        cy.apiSignup(firstName, lastName, email, password);
+        cy.setLoginCookie(email, password);
+        cy.apiUpdatePhase({
+          phaseId: phaseId,
+          canReact: false,
+        });
+        cy.reload();
+      });
+
+      it('has no up and dislike buttons', () => {
+        cy.visit(`/ideas/${ideaSlug}`);
+        cy.intercept(`**/ideas/by_slug/${ideaSlug}`).as('ideaRequest');
+
+        cy.wait('@ideaRequest');
+        cy.get('#e2e-idea-show').should('exist');
+
+        cy.get('.e2e-reaction-controls').should('not.exist');
+        cy.get('.e2e-ideacard-like-button').should('not.exist');
+        cy.get('.e2e-ideacard-dislike-button').should('not.exist');
+      });
+
+      after(() => {
+        cy.apiUpdatePhase({
+          phaseId: phaseId,
+          canReact: true,
+        });
       });
     });
 

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -64,6 +64,7 @@ declare global {
       apiCreateCustomPage: typeof apiCreateCustomPage;
       apiAddProjectsToFolder: typeof apiAddProjectsToFolder;
       apiCreatePhase: typeof apiCreatePhase;
+      apiUpdatePhase: typeof apiUpdatePhase;
       apiCreateCustomField: typeof apiCreateCustomField;
       apiCreateCustomFieldOption: typeof apiCreateCustomFieldOption;
       apiRemoveCustomField: typeof apiRemoveCustomField;
@@ -1395,6 +1396,93 @@ function apiCreatePhase({
   });
 }
 
+function apiUpdatePhase({
+  phaseId,
+  title,
+  startAt,
+  endAt,
+  participationMethod,
+  canPost,
+  canReact,
+  canComment,
+  description,
+  surveyUrl,
+  surveyService,
+  votingMaxTotal,
+  allow_anonymous_participation,
+  votingMethod,
+  votingMaxVotesPerIdea,
+  votingMinTotal,
+  nativeSurveyButtonMultiloc,
+  nativeSurveyTitleMultiloc,
+  presentation_mode,
+  reacting_dislike_enabled,
+  available_views,
+}: {
+  phaseId: string;
+  title?: string;
+  startAt?: string;
+  endAt?: string;
+  participationMethod?: ParticipationMethod;
+  canPost?: boolean;
+  canReact?: boolean;
+  canComment?: boolean;
+  description?: string;
+  surveyUrl?: string;
+  surveyService?: 'typeform' | 'survey_monkey' | 'google_forms';
+  presentation_mode?: 'card' | 'map' | 'feed';
+  available_views?: ('card' | 'map' | 'feed')[];
+  votingMaxTotal?: number;
+  allow_anonymous_participation?: boolean;
+  votingMethod?: VotingMethod;
+  votingMaxVotesPerIdea?: number;
+  votingMinTotal?: number;
+  nativeSurveyButtonMultiloc?: Multiloc;
+  nativeSurveyTitleMultiloc?: Multiloc;
+  reacting_dislike_enabled?: boolean;
+}) {
+  return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
+    const adminJwt = response.body.jwt;
+
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminJwt}`,
+      },
+      method: 'PATCH',
+      url: `web_api/v1/phases/${phaseId}`,
+      body: {
+        phase: {
+          start_at: startAt,
+          end_at: endAt,
+          title_multiloc: title
+            ? {
+              en: title,
+              'nl-BE': title,
+            }
+            : undefined,
+          participation_method: participationMethod,
+          voting_method: votingMethod,
+          submission_enabled: canPost,
+          reacting_enabled: canReact,
+          commenting_enabled: canComment,
+          presentation_mode,
+          available_views,
+          description_multiloc: description ? { en: description } : undefined,
+          survey_embed_url: surveyUrl,
+          survey_service: surveyService,
+          voting_max_total: votingMaxTotal,
+          allow_anonymous_participation: allow_anonymous_participation,
+          voting_max_votes_per_idea: votingMaxVotesPerIdea,
+          voting_min_total: votingMinTotal,
+          native_survey_button_multiloc: nativeSurveyButtonMultiloc,
+          native_survey_title_multiloc: nativeSurveyTitleMultiloc,
+          reacting_dislike_enabled,
+        },
+      },
+    });
+  });
+}
 function apiCreateCustomField(
   fieldName: string,
   required: boolean,
@@ -2390,6 +2478,7 @@ Cypress.Commands.add('apiRemoveProject', apiRemoveProject);
 Cypress.Commands.add('apiRemovePhase', apiRemovePhase);
 Cypress.Commands.add('apiAddProjectsToFolder', apiAddProjectsToFolder);
 Cypress.Commands.add('apiCreatePhase', apiCreatePhase);
+Cypress.Commands.add('apiUpdatePhase', apiUpdatePhase);
 Cypress.Commands.add('apiCreateCustomField', apiCreateCustomField);
 Cypress.Commands.add('apiCreateCustomFieldOption', apiCreateCustomFieldOption);
 Cypress.Commands.add('apiRemoveCustomField', apiRemoveCustomField);

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -64,7 +64,6 @@ declare global {
       apiCreateCustomPage: typeof apiCreateCustomPage;
       apiAddProjectsToFolder: typeof apiAddProjectsToFolder;
       apiCreatePhase: typeof apiCreatePhase;
-      apiUpdatePhase: typeof apiUpdatePhase;
       apiCreateCustomField: typeof apiCreateCustomField;
       apiCreateCustomFieldOption: typeof apiCreateCustomFieldOption;
       apiRemoveCustomField: typeof apiRemoveCustomField;
@@ -1396,93 +1395,6 @@ function apiCreatePhase({
   });
 }
 
-function apiUpdatePhase({
-  phaseId,
-  title,
-  startAt,
-  endAt,
-  participationMethod,
-  canPost,
-  canReact,
-  canComment,
-  description,
-  surveyUrl,
-  surveyService,
-  votingMaxTotal,
-  allow_anonymous_participation,
-  votingMethod,
-  votingMaxVotesPerIdea,
-  votingMinTotal,
-  nativeSurveyButtonMultiloc,
-  nativeSurveyTitleMultiloc,
-  presentation_mode,
-  reacting_dislike_enabled,
-  available_views,
-}: {
-  phaseId: string;
-  title?: string;
-  startAt?: string;
-  endAt?: string;
-  participationMethod?: ParticipationMethod;
-  canPost?: boolean;
-  canReact?: boolean;
-  canComment?: boolean;
-  description?: string;
-  surveyUrl?: string;
-  surveyService?: 'typeform' | 'survey_monkey' | 'google_forms';
-  presentation_mode?: 'card' | 'map' | 'feed';
-  available_views?: ('card' | 'map' | 'feed')[];
-  votingMaxTotal?: number;
-  allow_anonymous_participation?: boolean;
-  votingMethod?: VotingMethod;
-  votingMaxVotesPerIdea?: number;
-  votingMinTotal?: number;
-  nativeSurveyButtonMultiloc?: Multiloc;
-  nativeSurveyTitleMultiloc?: Multiloc;
-  reacting_dislike_enabled?: boolean;
-}) {
-  return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
-    const adminJwt = response.body.jwt;
-
-    return cy.request({
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${adminJwt}`,
-      },
-      method: 'PATCH',
-      url: `web_api/v1/phases/${phaseId}`,
-      body: {
-        phase: {
-          start_at: startAt,
-          end_at: endAt,
-          title_multiloc: title
-            ? {
-              en: title,
-              'nl-BE': title,
-            }
-            : undefined,
-          participation_method: participationMethod,
-          voting_method: votingMethod,
-          submission_enabled: canPost,
-          reacting_enabled: canReact,
-          commenting_enabled: canComment,
-          presentation_mode,
-          available_views,
-          description_multiloc: description ? { en: description } : undefined,
-          survey_embed_url: surveyUrl,
-          survey_service: surveyService,
-          voting_max_total: votingMaxTotal,
-          allow_anonymous_participation: allow_anonymous_participation,
-          voting_max_votes_per_idea: votingMaxVotesPerIdea,
-          voting_min_total: votingMinTotal,
-          native_survey_button_multiloc: nativeSurveyButtonMultiloc,
-          native_survey_title_multiloc: nativeSurveyTitleMultiloc,
-          reacting_dislike_enabled,
-        },
-      },
-    });
-  });
-}
 function apiCreateCustomField(
   fieldName: string,
   required: boolean,
@@ -2478,7 +2390,6 @@ Cypress.Commands.add('apiRemoveProject', apiRemoveProject);
 Cypress.Commands.add('apiRemovePhase', apiRemovePhase);
 Cypress.Commands.add('apiAddProjectsToFolder', apiAddProjectsToFolder);
 Cypress.Commands.add('apiCreatePhase', apiCreatePhase);
-Cypress.Commands.add('apiUpdatePhase', apiUpdatePhase);
 Cypress.Commands.add('apiCreateCustomField', apiCreateCustomField);
 Cypress.Commands.add('apiCreateCustomFieldOption', apiCreateCustomFieldOption);
 Cypress.Commands.add('apiRemoveCustomField', apiRemoveCustomField);


### PR DESCRIPTION
# Changelog
## Fixed
- if idea is active and reacting to inputs is disabled, always hide like/dislike btns.

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
