### PR TITLE
bump: websocket-driver

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -1205,7 +1205,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     webrick (1.9.1)
-    websocket-driver (0.7.7)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
# Changelog
## Technical
- bump websocket-driver to 0.8.2 to avoid CVE-2026-54463, CVE-2026-54464, CVE-2026-54465
From Claude, transitive dependency of actioncable, no major changes, very low risk.

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
