### PR TITLE
 Prevent non-stretched report images from overflowing the UI

### DIFF
--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ImageMultiloc/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/ImageMultiloc/index.tsx
@@ -56,6 +56,7 @@ const ImageMultiloc = ({ alt = {}, image, stretch = true }: Props) => {
       {image?.imageUrl && (
         <ImageComponent
           width={stretch ? '100%' : undefined}
+          maxWidth="100%"
           // TODO: Fix this the next time the file is edited.
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           src={image?.imageUrl}


### PR DESCRIPTION
# Changelog
## Fixed 
- Prevent non-stretched report images from overflowing the UI

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
