### PR TITLE
[TAN-7194] Fix issues related to orphaned DeleteUserJobs

### DIFF
--- a/back/app/jobs/delete_user_job.rb
+++ b/back/app/jobs/delete_user_job.rb
@@ -3,7 +3,8 @@
 class DeleteUserJob < ApplicationJob
   self.priority = 90 # pretty low priority (lowest is 100)
 
-  # @param [User,String] user user or user identifier
+  # @param [User,String] user user or user identifier. When an identifier is given and
+  #   no such user exists (anymore), the job is a no-op.
   # @param [User,NilClass] current_user
   # @param [Boolean] delete_participation_data When true, permanently deletes all user
   #   content instead of anonymizing it
@@ -17,7 +18,20 @@ class DeleteUserJob < ApplicationJob
     ban_reason: nil,
     update_member_counts: true
   )
-    user = User.find(user) unless user.respond_to?(:id)
+    unless user.respond_to?(:id)
+      user_id = user
+      user = User.find_by(id: user_id)
+
+      # The user can be deleted between the moment the job is enqueued and the moment it
+      # runs, e.g. by an overlapping `User.destroy_all_async` sweep. The user is gone,
+      # which is what this job is for, so there is nothing left to do. Raising instead
+      # would only retry the job until it expires, days later.
+      if user.nil?
+        Rails.logger.warn("DeleteUserJob: user #{user_id} no longer exists, skipping.")
+        return
+      end
+    end
+
     email_to_ban = user.email if ban_email
 
     ActiveRecord::Base.transaction do

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -69,13 +69,52 @@ class User < ApplicationRecord
   class << self
     # Asynchronously deletes all users in a specified scope with associated side effects.
     # By default, this method deletes all users on the platform.
+    #
+    # Users that already have a pending +DeleteUserJob+ are skipped. Because the jobs are
+    # spread out over time, a sweep is still in flight long after it was started, and a
+    # second sweep would otherwise enqueue a duplicate job for every remaining user.
     def destroy_all_async(scope = User)
-      scope.pluck(:id).each.with_index do |id, idx|
+      pending = user_ids_with_pending_deletion_job
+      ids, skipped = scope.pluck(:id).partition { |id| pending.exclude?(id) }
+
+      if skipped.any?
+        Rails.logger.warn(
+          "User.destroy_all_async: skipping #{skipped.size} user(s) that already have a pending DeleteUserJob."
+        )
+      end
+
+      ids.each.with_index do |id, idx|
         # Spread out the deletion of users to avoid throttling.
         # Note: No need to update member counts if we're deleting all users, as the count will never be seen.
         DeleteUserJob.set(wait: (idx / 5.0).seconds).perform_later(id, update_member_counts: false)
       end
     end
+
+    # @return [Set<String>] ids of the users of the current tenant that have a
+    #   +DeleteUserJob+ enqueued which has not run to completion yet.
+    def user_ids_with_pending_deletion_job
+      QueJob
+        .by_job_class(DeleteUserJob)
+        .all_by_tenant_schema_name(Apartment::Tenant.current)
+        .not_finished
+        .not_expired
+        .pluck(:args)
+        .filter_map { |args| deletion_job_user_id(args.first) }
+        .to_set
+    end
+    private :user_ids_with_pending_deletion_job
+
+    # +DeleteUserJob+ accepts either a user id or a user, the latter being serialized by
+    # ActiveJob as a global id.
+    def deletion_job_user_id(job_data)
+      argument = job_data&.dig('arguments', 0)
+
+      case argument
+      when String then argument
+      when Hash then argument['_aj_globalid']&.split('/')&.last
+      end
+    end
+    private :deletion_job_user_id
 
     def onboarding_json_schema
       {

--- a/back/engines/commercial/multi_tenancy/app/models/tenant.rb
+++ b/back/engines/commercial/multi_tenancy/app/models/tenant.rb
@@ -35,6 +35,7 @@ class Tenant < ApplicationRecord
   after_update :update_tenant_schema, if: :saved_change_to_host?
   after_update :update_app_configuration, if: :config_sync_enabled
   after_destroy :delete_apartment_tenant
+  after_destroy :delete_que_jobs
 
   scope :deleted, -> { where.not(deleted_at: nil) }
   scope :not_deleted, -> { where(deleted_at: nil) }
@@ -212,6 +213,13 @@ class Tenant < ApplicationRecord
 
   def delete_apartment_tenant
     Apartment::Tenant.drop(schema_name)
+  end
+
+  # Jobs are stored in the shared +public.que_jobs+ table and only reference their tenant
+  # by schema name. Once the schema is gone, a job left behind can no longer do anything
+  # but fail and retry until it expires, so its rows are removed along with the schema.
+  def delete_que_jobs
+    QueJob.all_by_tenant_schema_name(schema_name).delete_all
   end
 
   def update_tenant_schema

--- a/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
@@ -164,14 +164,7 @@ RSpec.describe Tenant do
       t.destroy
     end
 
-    it 'fails on a duplicate hostname' do
-      create(:tenant)
-      expect(build(:tenant, host: described_class.current.host)).to be_invalid
-    end
-  end
-
-  describe 'Que jobs' do
-    it 'are deleted on destroy' do
+    it 'deletes the tenant que_jobs on destroy' do
       tenant = create(:tenant, host: 'something.else-than-the-default-test-tenant')
       tenant_job = create(:que_job, tenant_schema_name: tenant.schema_name)
       other_job = create(:que_job, tenant_schema_name: described_class.current.schema_name)
@@ -180,6 +173,11 @@ RSpec.describe Tenant do
 
       expect(QueJob.exists?(tenant_job.id)).to be false
       expect(QueJob.exists?(other_job.id)).to be true
+    end
+
+    it 'fails on a duplicate hostname' do
+      create(:tenant)
+      expect(build(:tenant, host: described_class.current.host)).to be_invalid
     end
   end
 

--- a/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
@@ -170,6 +170,19 @@ RSpec.describe Tenant do
     end
   end
 
+  describe 'Que jobs' do
+    it 'are deleted on destroy' do
+      tenant = create(:tenant, host: 'something.else-than-the-default-test-tenant')
+      tenant_job = create(:que_job, tenant_schema_name: tenant.schema_name)
+      other_job = create(:que_job, tenant_schema_name: described_class.current.schema_name)
+
+      expect { tenant.destroy! }.to change(QueJob, :count).by(-1)
+
+      expect(QueJob.exists?(tenant_job.id)).to be false
+      expect(QueJob.exists?(other_job.id)).to be true
+    end
+  end
+
   describe 'Getting the current tenant' do
     it 'succeeds with the correct tenant' do
       tenant = described_class.find_by(host: 'example.org')

--- a/back/spec/factories/que_jobs.rb
+++ b/back/spec/factories/que_jobs.rb
@@ -5,6 +5,10 @@ FactoryBot.define do
     transient do
       enqueued_at { Time.zone.now }
       tenant_schema_name { nil }
+      # The ActiveJob class and its arguments, as opposed to the +job_class+ column, which
+      # holds the ActiveJob wrapper for any job enqueued through ActiveJob.
+      active_job_class { 'TestJob' }
+      job_arguments { [] }
     end
 
     priority { 100 }
@@ -22,8 +26,8 @@ FactoryBot.define do
         locale: 'en',
         priority: nil,
         timezone: 'UTC',
-        arguments: [],
-        job_class: 'TestJob',
+        arguments: job_arguments,
+        job_class: active_job_class,
         executions: 0,
         queue_name: 'default',
         enqueued_at: enqueued_at.iso8601,

--- a/back/spec/factories/que_jobs.rb
+++ b/back/spec/factories/que_jobs.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
   factory :que_job do
     transient do
       enqueued_at { Time.zone.now }
+      tenant_schema_name { nil }
     end
 
     priority { 100 }
@@ -27,7 +28,7 @@ FactoryBot.define do
         queue_name: 'default',
         enqueued_at: enqueued_at.iso8601,
         provider_job_id: nil,
-        tenant_schema_name: nil,
+        tenant_schema_name: tenant_schema_name,
         exception_executions: {}
       }]
     end

--- a/back/spec/jobs/delete_user_job_spec.rb
+++ b/back/spec/jobs/delete_user_job_spec.rb
@@ -97,6 +97,26 @@ RSpec.describe DeleteUserJob do
       end
     end
 
+    # `perform_now` callers pass a user object, which skips the lookup by id, but the
+    # record can still be gone by the time the job runs.
+    context 'when a user object is given whose record was already deleted' do
+      before do
+        User.where(id: user.id).delete_all
+      end
+
+      it 'does not raise an error' do
+        expect { described_class.perform_now(user) }.not_to raise_error
+      end
+
+      it 'does not log the missing-user warning' do
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.perform_now(user)
+
+        expect(Rails.logger).not_to have_received(:warn).with(/no longer exists/)
+      end
+    end
+
     context 'with ban_email: true' do
       let(:current_user) { create(:admin) }
       let(:user) { create(:user, email: 'banned.user+test@gmail.com') }

--- a/back/spec/jobs/delete_user_job_spec.rb
+++ b/back/spec/jobs/delete_user_job_spec.rb
@@ -70,9 +70,30 @@ RSpec.describe DeleteUserJob do
         user.destroy!
       end
 
-      it 'raise an error' do
-        expect { described_class.perform_now(user.id) }
-          .to raise_error(ActiveRecord::RecordNotFound)
+      it 'does not raise an error' do
+        expect { described_class.perform_now(user.id) }.not_to raise_error
+      end
+
+      it 'does not trigger after_destroy side effects' do
+        sidefx_service = instance_spy(SideFxUserService, 'sidefx_service')
+        allow(SideFxUserService).to receive(:new).and_return(sidefx_service)
+
+        described_class.perform_now(user.id)
+
+        expect(sidefx_service).not_to have_received(:after_destroy)
+      end
+
+      it 'does not ban the email' do
+        expect { described_class.perform_now(user.id, create(:admin), ban_email: true) }
+          .not_to change(EmailBan, :count)
+      end
+
+      it 'logs a warning' do
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.perform_now(user.id)
+
+        expect(Rails.logger).to have_received(:warn).with(/user #{user.id} no longer exists/)
       end
     end
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -69,6 +69,61 @@ RSpec.describe User do
       expect { described_class.destroy_all_async(scope) }
         .to have_enqueued_job(DeleteUserJob).exactly(scope.count).times
     end
+
+    context 'when a user already has a pending deletion job' do
+      let(:schema_name) { Apartment::Tenant.current }
+      let(:user) { described_class.first }
+
+      def create_deletion_job(arguments, **attrs)
+        attrs = { tenant_schema_name: schema_name }.merge(attrs)
+        create(:que_job, active_job_class: 'DeleteUserJob', job_arguments: arguments, **attrs)
+      end
+
+      it 'does not enqueue a second job for that user' do
+        create_deletion_job([user.id])
+
+        expect { described_class.destroy_all_async }
+          .not_to have_enqueued_job(DeleteUserJob).with(user.id, update_member_counts: false)
+      end
+
+      it 'still enqueues a job for the other users' do
+        create_deletion_job([user.id])
+
+        expect { described_class.destroy_all_async }
+          .to have_enqueued_job(DeleteUserJob).exactly(described_class.count - 1).times
+      end
+
+      it 'recognizes a job that was enqueued with a user rather than a user id' do
+        create_deletion_job([{ '_aj_globalid' => "gid://citizenlab/User/#{user.id}" }])
+
+        expect { described_class.destroy_all_async }
+          .to have_enqueued_job(DeleteUserJob).exactly(described_class.count - 1).times
+      end
+
+      it 'logs the users it skips' do
+        create_deletion_job([user.id])
+        allow(Rails.logger).to receive(:warn)
+
+        described_class.destroy_all_async
+
+        expect(Rails.logger).to have_received(:warn).with(/skipping 1 user/)
+      end
+
+      it 'still enqueues a job when the pending job belongs to another tenant' do
+        create_deletion_job([user.id], tenant_schema_name: 'another_tenant')
+
+        expect { described_class.destroy_all_async }
+          .to have_enqueued_job(DeleteUserJob).exactly(described_class.count).times
+      end
+
+      it 'still enqueues a job when the existing job has finished or expired' do
+        create_deletion_job([user.id], finished_at: Time.zone.now)
+        create_deletion_job([described_class.last.id], expired_at: Time.zone.now)
+
+        expect { described_class.destroy_all_async }
+          .to have_enqueued_job(DeleteUserJob).exactly(described_class.count).times
+      end
+    end
   end
 
   describe 'generate_slug' do


### PR DESCRIPTION
## Why
  
`DeleteUserJob` raised `RecordNotFound` ~439k times for one tenant ([example Sentry error](https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/114495/events/1b84d70a3090437f92d61cdc77a3bdb9/?project=2&statsPeriod=24h)). Two overlapping `User.destroy_all_async` sweeps: `pluck(:id)` has no `ORDER BY`, so both walked the table in the same order and the later sweep lost the race on every user — 7,062 users, each retried 10 times.

## What   
  
- **`DeleteUserJob` no-ops on an already-deleted user** — logs and returns instead of raising, like `ExpireConfirmationCodeOrDeleteJob` already does. A missing row is never transient, so retrying could only waste work.
- **Destroying a tenant deletes its `que_jobs`** — jobs live in the shared `public.que_jobs` and reference their tenant only by schema name, so dropping a schema stranded them.
- **`destroy_all_async` skips users with a pending `DeleteUserJob`** — sweeps run at ~5 jobs/sec, so one is still in flight long after it starts.

## Notes
Dedupe narrows the race, doesn't close it; a duplicate is now a logged no-op. Existing orphaned rows have all expired and are inert, so no cleanup here.

# Changelog
## Technical
- [TAN-7194] Fix issues related to orphaned DeleteUserJobs
