### PR TITLE
[No-ticket] Fix e2e specs broken by project_page layout becoming the source of truth

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
@@ -172,7 +172,7 @@ const RenderNode = ({ render }) => {
         // widget's editable children unselectable in the editor.
         ref={(element: HTMLElement | null) => {
           if (!element) return;
-          if (noPointerEvents && !hasChildren(name)) {
+          if (noPointerEvents && name && !hasChildren(name)) {
             element.setAttribute('inert', '');
           } else {
             element.removeAttribute('inert');

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
@@ -167,12 +167,9 @@ const RenderNode = ({ render }) => {
         // `pointer-events: none` still leaves the preview content keyboard-
         // focusable; `inert` removes it from the tab order too. React 18 has
         // no `inert` prop, so the attribute is set on the element directly.
-        // Never on a widget with children: unlike `pointer-events`, `inert` is
-        // inherited and a nested node cannot opt back in, which would make the
-        // widget's editable children unselectable in the editor.
         ref={(element: HTMLElement | null) => {
           if (!element) return;
-          if (noPointerEvents && name && !hasChildren(name)) {
+          if (noPointerEvents) {
             element.setAttribute('inert', '');
           } else {
             element.removeAttribute('inert');

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
@@ -167,9 +167,12 @@ const RenderNode = ({ render }) => {
         // `pointer-events: none` still leaves the preview content keyboard-
         // focusable; `inert` removes it from the tab order too. React 18 has
         // no `inert` prop, so the attribute is set on the element directly.
+        // Never on a widget with children: unlike `pointer-events`, `inert` is
+        // inherited and a nested node cannot opt back in, which would make the
+        // widget's editable children unselectable in the editor.
         ref={(element: HTMLElement | null) => {
           if (!element) return;
-          if (noPointerEvents) {
+          if (noPointerEvents && !hasChildren(name)) {
             element.setAttribute('inert', '');
           } else {
             element.removeAttribute('inert');

--- a/front/cypress/e2e/project_description_builder/components/about_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/about_component.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder About component', () => {
   });
 
   it('handles About component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -56,7 +56,7 @@ describe('Project description builder About component', () => {
   });
 
   it('deletes About component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/accordion_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/accordion_component.cy.ts
@@ -40,7 +40,7 @@ describe('Project description builder Accordion component', () => {
   });
 
   it('displays Accordion component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-accordion').dragAndDrop(
@@ -73,7 +73,7 @@ describe('Project description builder Accordion component', () => {
   });
 
   it('handles Accordion open by default correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);
@@ -107,7 +107,7 @@ describe('Project description builder Accordion component', () => {
   });
 
   it('deletes Accordion component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/button_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/button_component.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder Button component', () => {
   });
 
   it('handles Button component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -83,7 +83,7 @@ describe('Project description builder Button component', () => {
   });
 
   it('deletes Button component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/iframe_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/iframe_component.cy.ts
@@ -39,7 +39,7 @@ describe('Project description builder Iframe component', () => {
   });
 
   it('handles Iframe component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     // Add iframe with valid url
@@ -59,7 +59,7 @@ describe('Project description builder Iframe component', () => {
   });
 
   it('handles Iframe errors correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);
@@ -94,7 +94,7 @@ describe('Project description builder Iframe component', () => {
   });
 
   it('deletes Iframe component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('.e2e-content-builder-iframe-component').should('exist');

--- a/front/cypress/e2e/project_description_builder/components/image_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/image_component.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder Image component', () => {
   });
 
   it('handles Image component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -75,7 +75,7 @@ describe('Project description builder Image component', () => {
   });
 
   it('deletes Image component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/text_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/text_component.cy.ts
@@ -39,7 +39,7 @@ describe('Project description builder Text component', () => {
   });
 
   it('handles Text component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-content-builder-frame', {
@@ -58,7 +58,7 @@ describe('Project description builder Text component', () => {
   });
 
   it('deletes Text component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/three_column_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/three_column_component.cy.ts
@@ -39,7 +39,7 @@ describe('Project description builder Three Column component', () => {
   });
 
   it('handles Three Column component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-three-column').dragAndDrop(
@@ -71,7 +71,7 @@ describe('Project description builder Three Column component', () => {
   });
 
   it('deletes Three Column component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/two_column_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/two_column_component.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder Two Column component', () => {
   });
 
   it('handles Two Column component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-two-column').dragAndDrop(
@@ -69,7 +69,7 @@ describe('Project description builder Two Column component', () => {
   });
 
   it('deletes Two Column component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/components/white_space_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/white_space_component.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder White space component', () => {
   });
 
   it('handles white space component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -61,7 +61,7 @@ describe('Project description builder White space component', () => {
   });
 
   it('deletes white space component correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/language_switch.cy.ts
+++ b/front/cypress/e2e/project_description_builder/language_switch.cy.ts
@@ -48,7 +48,7 @@ describe('Project description builder language switch', () => {
   });
 
   it('handles language specific content correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -76,7 +76,7 @@ describe('Project description builder language switch', () => {
   });
 
   it('deletes language specific content correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 

--- a/front/cypress/e2e/project_description_builder/project_description_builder_display.cy.ts
+++ b/front/cypress/e2e/project_description_builder/project_description_builder_display.cy.ts
@@ -58,7 +58,7 @@ describe('Project description builder display', () => {
   });
 
   it('shows a description authored in the Content Builder on the project page', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 
@@ -85,7 +85,7 @@ describe('Project description builder display', () => {
 
   it('shows attachments added to the project alongside the Content Builder description', () => {
     cy.intercept(`**/files`).as('saveProjectFiles');
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
 

--- a/front/cypress/e2e/project_description_builder/sections/image_text_cards_section.cy.ts
+++ b/front/cypress/e2e/project_description_builder/sections/image_text_cards_section.cy.ts
@@ -38,7 +38,7 @@ describe('Project description builder Image Text Cards section', () => {
   });
 
   it('handles Image Text Cards section correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-image-text-cards').dragAndDrop(
@@ -79,7 +79,7 @@ describe('Project description builder Image Text Cards section', () => {
   });
 
   it('deletes Image Text Cards section correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.visit(`/admin/description-builder/projects/${projectId}/description`);

--- a/front/cypress/e2e/project_description_builder/sections/info_accordions_section.cy.ts
+++ b/front/cypress/e2e/project_description_builder/sections/info_accordions_section.cy.ts
@@ -40,7 +40,7 @@ describe('Project description builder Info & Accordions section', () => {
   });
 
   it('handles Info & Accordions section correctly', () => {
-    cy.intercept('**/content_builder_layouts/project_description/upsert').as(
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
     cy.get('#e2e-draggable-info-accordions').dragAndDrop(

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -883,7 +883,7 @@ function apiRemoveComment(commentId: string) {
 
 // The participation AboutBox widget node, serialised as the Content Builder editor
 // produces it. It renders the project sidebar (action buttons / "see ideas" etc).
-function aboutBoxNode() {
+function aboutBoxNode(parent: string) {
   return {
     type: { resolvedName: 'AboutBox' },
     isCanvas: false,
@@ -896,15 +896,15 @@ function aboutBoxNode() {
       },
       noPointerEvents: true,
     },
-    parent: 'ROOT',
+    parent,
     hidden: false,
     nodes: [],
     linkedNodes: {},
   };
 }
 
-// Appends the participation AboutBox to a project's existing Content Builder
-// description layout, so its page renders the sidebar/CTAs. Idempotent — a no-op if
+// Appends the participation AboutBox to the description section of a project's
+// project_page layout, so its page renders the sidebar/CTAs. Idempotent — a no-op if
 // the AboutBox is already there.
 function apiAddAboutBox(projectId: string) {
   return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
@@ -912,7 +912,7 @@ function apiAddAboutBox(projectId: string) {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${response.body.jwt}`,
     };
-    const layoutPath = `web_api/v1/projects/${projectId}/content_builder_layouts/project_description`;
+    const layoutPath = `web_api/v1/projects/${projectId}/content_builder_layouts/project_page`;
 
     return cy
       .request({ headers: authHeaders, method: 'GET', url: layoutPath })
@@ -923,8 +923,18 @@ function apiAddAboutBox(projectId: string) {
         );
         if (hasAboutBox) return;
 
-        craftjs.aboutBox = aboutBoxNode();
-        craftjs.ROOT.nodes = [...craftjs.ROOT.nodes, 'aboutBox'];
+        const sectionId = Object.keys(craftjs).find(
+          (id) =>
+            craftjs[id]?.type?.resolvedName === 'ProjectDescriptionSection'
+        );
+        if (!sectionId) {
+          throw new Error(
+            `project_page layout of project ${projectId} has no description section`
+          );
+        }
+
+        craftjs.aboutBox = aboutBoxNode(sectionId);
+        craftjs[sectionId].nodes = [...craftjs[sectionId].nodes, 'aboutBox'];
 
         return cy.request({
           headers: authHeaders,


### PR DESCRIPTION
## What
#14174 made the `project_page` layout the source of truth for a project's description: it's created (enabled) on project creation, and the description builder now reads and writes it instead of  `project_description`.

Our e2e fixtures still used the legacy layout, so:
  
- `apiAddAboutBox` upserted `project_description`, which the front end no longer reads → the participation sidebar and its CTA buttons never rendered (11 specs).
- The description-builder specs intercepted `project_description/upsert`, but saves now hit `project_page/upsert` → `cy.wait('@saveProjectDescriptionBuilder')` timed out (13 specs).

This repoints both at `project_page`; `apiAddAboutBox` now splices the AboutBox into the layout's description section rather than onto `ROOT`. No product code changes.

## Verification
Ran against a local stack carrying the same flags as the e2e tenant, each with a control:

- `project_page_information` and `text_component` pass; both fail on the same stack with the fix stashed.
- After merging master (which brings in #14260), re-ran `info_accordions_section`, `about_component`, `text_component`, `image_text_cards_section` and `project_page_information` — 8 tests, all green.

CI on this branch went from 49 failures to 5, and #14260 clears the 5th.

## Not addressed
The remaining 4 are pre-existing flakes that CI flags as such (`image_component` ×2, `homepage_builder/landing_page`, `project_page_voting_multi`) — they pass on retry and fail in runs both before and after #14174. `admin/projects/add_project.cy.ts` is the same story (fails ~40% of runs on both sides; it asserts `.first()` on a recency-sorted list, and the e2e tenant is shared across all 16 parallel containers).

@EdwinKato This just gets the e2e tests working again. May not be the best fix, and does not address whether the tests now test the correct things in the light of your recent changes, I'll leave these follow up(s) to you.

# Changelog
## Technical
- [No-ticket] Fix e2e specs broken by project_page layout becoming the source of truth
