### PR TITLE
TAN-8175: Fix uneditable content inside the Info & accordions widget

### DIFF
--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/index.ts
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/index.ts
@@ -186,7 +186,6 @@ const WIDGETS_WITHOUT_POINTER_EVENTS = new Set<string>([
   'FolderFiles',
 
   // Project description builder widgets
-  'InfoWithAccordions',
   'AboutBox',
 ] satisfies WidgetName[]);
 


### PR DESCRIPTION
# Changelog

## Fixed

- In the project and folder description builder, content placed inside the "Info & accordions" widget could not be selected or edited: clicking any accordion, text or column inside it selected the whole widget instead, and the only available action was deleting it. Everything inside the widget is now selectable and editable again. 