### PR TITLE
[TAN-6826] Require positive moderator role for admin route access (prevent back-office access when no role parsed)

### DIFF
--- a/front/app/utils/permissions/rules/routePermissions.test.ts
+++ b/front/app/utils/permissions/rules/routePermissions.test.ts
@@ -1,0 +1,58 @@
+import { appConfigurationData } from 'api/app_configuration/__mocks__/useAppConfiguration';
+import { makeUser, makeAdmin } from 'api/users/__mocks__/useUsers';
+
+import { IRouteItem } from 'utils/permissions/permissions';
+
+import { canAccessRoute } from './routePermissions';
+
+const tenant = appConfigurationData;
+
+const route = (path: string): IRouteItem => ({ type: 'route', path });
+
+// A route that only admins and moderators may access.
+const MODERATOR_ROUTE = route('/admin/inspiration-hub');
+
+describe('canAccessRoute', () => {
+  describe('moderator-route gate must not fail open', () => {
+    // Regression guard for the fail-open bug (TAN-6826).
+    //
+    // The gate used to be `!isRegularUser(user)`. `isRegularUser` is a strict
+    // check for `highest_role === 'user'`, so it returns `false` for ANY other
+    // value — including when the private attributes (`roles` / `highest_role`)
+    // are absent from the `/users/me` payload. `!false === true` then opened
+    // every moderator route to a user who holds no moderator role at all.
+    //
+    // A user with no moderator/admin role must be denied, whether that shows up
+    // as `highest_role: 'user'` or as the private attributes being missing.
+    it('denies a user whose highest_role and roles are missing', () => {
+      const user = makeUser({ highest_role: undefined, roles: undefined });
+      expect(canAccessRoute(MODERATOR_ROUTE, user, tenant)).toBe(false);
+    });
+
+    it('denies a plain regular user', () => {
+      const user = makeUser({ highest_role: 'user', roles: [] });
+      expect(canAccessRoute(MODERATOR_ROUTE, user, tenant)).toBe(false);
+    });
+  });
+
+  describe('legitimate access is preserved', () => {
+    it('allows an admin', () => {
+      expect(canAccessRoute(MODERATOR_ROUTE, makeAdmin(), tenant)).toBe(true);
+    });
+
+    it('allows a project moderator', () => {
+      const user = makeUser({
+        highest_role: 'project_moderator',
+        roles: [{ type: 'project_moderator', project_id: 'project-1' }],
+      });
+      expect(canAccessRoute(MODERATOR_ROUTE, user, tenant)).toBe(true);
+    });
+  });
+
+  describe('non-admin routes stay public', () => {
+    it('allows a user with missing role attributes on a non-admin route', () => {
+      const user = makeUser({ highest_role: undefined, roles: undefined });
+      expect(canAccessRoute(route('/ideas'), user, tenant)).toBe(true);
+    });
+  });
+});

--- a/front/app/utils/permissions/rules/routePermissions.test.ts
+++ b/front/app/utils/permissions/rules/routePermissions.test.ts
@@ -14,16 +14,8 @@ const MODERATOR_ROUTE = route('/admin/inspiration-hub');
 
 describe('canAccessRoute', () => {
   describe('moderator-route gate must not fail open', () => {
-    // Regression guard for the fail-open bug (TAN-6826).
-    //
-    // The gate used to be `!isRegularUser(user)`. `isRegularUser` is a strict
-    // check for `highest_role === 'user'`, so it returns `false` for ANY other
-    // value — including when the private attributes (`roles` / `highest_role`)
-    // are absent from the `/users/me` payload. `!false === true` then opened
-    // every moderator route to a user who holds no moderator role at all.
-    //
-    // A user with no moderator/admin role must be denied, whether that shows up
-    // as `highest_role: 'user'` or as the private attributes being missing.
+    // Regression guard: a negative role check granted access when the role
+    // attributes were absent from the /users/me payload (TAN-6826).
     it('denies a user whose highest_role and roles are missing', () => {
       const user = makeUser({ highest_role: undefined, roles: undefined });
       expect(canAccessRoute(MODERATOR_ROUTE, user, tenant)).toBe(false);

--- a/front/app/utils/permissions/rules/routePermissions.ts
+++ b/front/app/utils/permissions/rules/routePermissions.ts
@@ -8,7 +8,7 @@ import {
 
 import {
   isAdmin,
-  isRegularUser,
+  isModerator,
   isProjectModerator,
   isSuperAdmin,
 } from '../roles';
@@ -99,7 +99,11 @@ export const canAccessRoute = (
       return isCommunityMonitorModerator(user, tenant);
     }
 
-    if (user && !isRegularUser(user) && isModeratorRoute(item)) {
+    // Require a positive moderator signal. A negative `!isRegularUser` check
+    // fails open when the role attributes are missing from the user payload,
+    // granting moderator routes to users who hold no moderator role (TAN-6826).
+    // Admins are already handled above.
+    if (user && isModerator(user) && isModeratorRoute(item)) {
       return true;
     }
 

--- a/front/app/utils/permissions/rules/routePermissions.ts
+++ b/front/app/utils/permissions/rules/routePermissions.ts
@@ -99,10 +99,6 @@ export const canAccessRoute = (
       return isCommunityMonitorModerator(user, tenant);
     }
 
-    // Require a positive moderator signal. A negative `!isRegularUser` check
-    // fails open when the role attributes are missing from the user payload,
-    // granting moderator routes to users who hold no moderator role (TAN-6826).
-    // Admins are already handled above.
     if (user && isModerator(user) && isModeratorRoute(item)) {
       return true;
     }


### PR DESCRIPTION
The admin route guard used `!isRegularUser(user)`, which returns true whenever `highest_role` isn't exactly `'user'` — including when role attributes are absent — admitting role-less users to moderator routes.
Replaced with a positive `isModerator(user)` check.

Evidence: the ticket reported a PM with `roles: []` / `JWT highest_role: user` still reaching parts of the back office — exactly what this gate allows. New regression test returned `true` (access granted) before the fix, `false` after.

# Changelog
## Fixed
- [TAN-6826] Require positive moderator role for admin route access (prevent back-office access when no role parsed)
