### PR TITLE
[TAN-6826] Invalidate JWT on highest_role change at the model level

### DIFF
--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -137,10 +137,10 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
     highest_role_for roles
   end
 
-  # Highest role implied by an arbitrary roles array (defaults to the user's
-  # current roles via #highest_role). Array-based so we can compare the
-  # persisted vs pending roles when deciding whether a save actually changes the
-  # user's highest_role — see #rotate_token_expiry_key_on_highest_role_change.
+  # Highest role implied by an arbitrary roles array, so that the persisted and the
+  # pending roles of one user can be compared — see
+  # #rotate_token_expiry_key_on_highest_role_change. #highest_role passes the user's
+  # current roles.
   def highest_role_for(role_list)
     roles_array = role_list.to_a
     if roles_array.any? { |role| role['type'] == 'admin' }

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -126,16 +126,8 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
 
     attr_reader :highest_role_after_initialize
 
-    # Invalidate any outstanding JWT when the user's highest_role changes, so a
-    # stale `highest_role` claim can't persist (TAN-6826). Kept on the model
-    # (rather than in a side-effect service) so no role-mutation path can bypass
-    # it. Done inline in before_update to persist in the same UPDATE and to keep
-    # previous_changes intact for the other role side effects.
-    #
-    # NOTE: this relies on `roles` being changed through normal persistence
-    # (save/update/add_role/delete_role). Do NOT change `roles` via
-    # update_column(s)/update_all/insert_all — those skip callbacks and would
-    # silently leave a stale highest_role claim valid.
+    # Never change `roles` via update_column(s)/update_all/insert_all: those skip
+    # this callback, leaving a stale highest_role claim valid in outstanding JWTs.
     before_update :rotate_token_expiry_key_on_highest_role_change
 
     validates :roles, json: { schema: -> { UserRoles.roles_json_schema } }
@@ -164,13 +156,9 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
     end
   end
 
-  # A moderator role only counts when it carries its scope id, mirroring the
-  # moderated_*_ids helpers (which compact out nil ids). Without this, a
-  # type-only role hash (e.g. one built in memory before validation) would be
-  # misclassified as a moderator, diverging from #project_moderator? et al.
-  # The roles JSON schema already requires the scope id for each moderator type,
-  # so checking it here keeps in-memory classification equivalent to persisted,
-  # schema-validated data.
+  # The scope id is required so that a type-only role hash, built in memory before
+  # validation, isn't classified as a moderator. Mirrors the moderated_*_ids
+  # helpers, which compact out nil ids.
   def moderator_role_present?(roles_array, type, id_key)
     roles_array.any? { |role| role['type'] == type && !role[id_key].nil? }
   end
@@ -267,18 +255,12 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
     self
   end
 
-  # Rotates token_expiry_key (which invalidates every outstanding JWT, forcing a
-  # fresh mint with the correct claim on next login) only when this save actually
-  # changes the user's highest_role. A moderator gaining an extra project role,
-  # whose highest_role is unchanged, is therefore not logged out. Scoped to
-  # before_update: on create there is no prior token to invalidate. See the
-  # before_update declaration above.
+  # Rotating token_expiry_key invalidates every outstanding JWT, so the next login
+  # mints one with the correct highest_role claim. Only a change of highest_role
+  # rotates it: a moderator gaining a further project moderator role is not logged out.
   def rotate_token_expiry_key_on_highest_role_change
     return unless has_attribute?('roles')
     return unless will_save_change_to_roles?
-    # Compare the persisted roles against the pending ones (rather than an
-    # after_initialize snapshot) so detection is accurate regardless of how the
-    # in-memory object was built.
     return if highest_role_for(roles_in_database) == highest_role_for(roles)
 
     self.token_expiry_key = SecureRandom.hex(10)

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -137,15 +137,22 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   end
 
   def highest_role
-    if super_admin?
-      :super_admin
-    elsif admin?
-      :admin
-    elsif space_moderator?
+    highest_role_for roles
+  end
+
+  # Highest role implied by an arbitrary roles array (defaults to the user's
+  # current roles via #highest_role). Array-based so we can compare the
+  # persisted vs pending roles when deciding whether a save actually changes the
+  # user's highest_role — see #rotate_token_expiry_key_on_highest_role_change.
+  def highest_role_for(role_list)
+    types = role_list.to_a.filter_map { |role| role['type'] }
+    if types.include?('admin')
+      govocal_or_citizenlab_email? ? :super_admin : :admin
+    elsif types.include?('space_moderator')
       :space_moderator
-    elsif project_folder_moderator?
+    elsif types.include?('project_folder_moderator')
       :project_folder_moderator
-    elsif project_moderator?
+    elsif types.include?('project_moderator')
       :project_moderator
     else
       :user
@@ -153,7 +160,11 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   end
 
   def super_admin?
-    admin? && !!(email =~ Regexp.new(CITIZENLAB_MEMBER_REGEX_CONTENT, 'i') || email =~ Regexp.new(GOVOCAL_MEMBER_REGEX_CONTENT, 'i'))
+    admin? && govocal_or_citizenlab_email?
+  end
+
+  def govocal_or_citizenlab_email?
+    !!(email =~ Regexp.new(CITIZENLAB_MEMBER_REGEX_CONTENT, 'i') || email =~ Regexp.new(GOVOCAL_MEMBER_REGEX_CONTENT, 'i'))
   end
 
   def admin?
@@ -247,7 +258,10 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   def rotate_token_expiry_key_on_highest_role_change
     return unless has_attribute?('roles')
     return unless will_save_change_to_roles?
-    return if highest_role_after_initialize == highest_role
+    # Compare the persisted roles against the pending ones (rather than an
+    # after_initialize snapshot) so detection is accurate regardless of how the
+    # in-memory object was built.
+    return if highest_role_for(roles_in_database) == highest_role_for(roles)
 
     self.token_expiry_key = SecureRandom.hex(10)
   end

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -150,18 +150,29 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   # persisted vs pending roles when deciding whether a save actually changes the
   # user's highest_role — see #rotate_token_expiry_key_on_highest_role_change.
   def highest_role_for(role_list)
-    types = role_list.to_a.filter_map { |role| role['type'] }
-    if types.include?('admin')
+    roles_array = role_list.to_a
+    if roles_array.any? { |role| role['type'] == 'admin' }
       govocal_or_citizenlab_email? ? :super_admin : :admin
-    elsif types.include?('space_moderator')
+    elsif moderator_role_present?(roles_array, 'space_moderator', 'space_id')
       :space_moderator
-    elsif types.include?('project_folder_moderator')
+    elsif moderator_role_present?(roles_array, 'project_folder_moderator', 'project_folder_id')
       :project_folder_moderator
-    elsif types.include?('project_moderator')
+    elsif moderator_role_present?(roles_array, 'project_moderator', 'project_id')
       :project_moderator
     else
       :user
     end
+  end
+
+  # A moderator role only counts when it carries its scope id, mirroring the
+  # moderated_*_ids helpers (which compact out nil ids). Without this, a
+  # type-only role hash (e.g. one built in memory before validation) would be
+  # misclassified as a moderator, diverging from #project_moderator? et al.
+  # The roles JSON schema already requires the scope id for each moderator type,
+  # so checking it here keeps in-memory classification equivalent to persisted,
+  # schema-validated data.
+  def moderator_role_present?(roles_array, type, id_key)
+    roles_array.any? { |role| role['type'] == type && !role[id_key].nil? }
   end
 
   def super_admin?

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -126,6 +126,13 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
 
     attr_reader :highest_role_after_initialize
 
+    # Invalidate any outstanding JWT when the user's highest_role changes, so a
+    # stale `highest_role` claim can't persist (TAN-6826). Kept on the model
+    # (rather than in a side-effect service) so no role-mutation path can bypass
+    # it. Done inline in before_update to persist in the same UPDATE and to keep
+    # previous_changes intact for the other role side effects.
+    before_update :rotate_token_expiry_key_on_highest_role_change
+
     validates :roles, json: { schema: -> { UserRoles.roles_json_schema } }
   end
 
@@ -229,5 +236,19 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   def delete_role(type, options = {})
     roles.delete({ 'type' => type.to_s }.merge(options.stringify_keys))
     self
+  end
+
+  # Rotates token_expiry_key (which invalidates every outstanding JWT, forcing a
+  # fresh mint with the correct claim on next login) only when this save actually
+  # changes the user's highest_role. A moderator gaining an extra project role,
+  # whose highest_role is unchanged, is therefore not logged out. Scoped to
+  # before_update: on create there is no prior token to invalidate. See the
+  # before_update declaration above.
+  def rotate_token_expiry_key_on_highest_role_change
+    return unless has_attribute?('roles')
+    return unless will_save_change_to_roles?
+    return if highest_role_after_initialize == highest_role
+
+    self.token_expiry_key = SecureRandom.hex(10)
   end
 end

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -131,6 +131,11 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
     # (rather than in a side-effect service) so no role-mutation path can bypass
     # it. Done inline in before_update to persist in the same UPDATE and to keep
     # previous_changes intact for the other role side effects.
+    #
+    # NOTE: this relies on `roles` being changed through normal persistence
+    # (save/update/add_role/delete_role). Do NOT change `roles` via
+    # update_column(s)/update_all/insert_all — those skip callbacks and would
+    # silently leave a stale highest_role claim valid.
     before_update :rotate_token_expiry_key_on_highest_role_change
 
     validates :roles, json: { schema: -> { UserRoles.roles_json_schema } }

--- a/back/app/models/concerns/user_roles.rb
+++ b/back/app/models/concerns/user_roles.rb
@@ -180,6 +180,8 @@ module UserRoles # rubocop:disable Metrics/ModuleLength
   end
 
   def govocal_or_citizenlab_email?
+    return false if email.blank?
+
     !!(email =~ Regexp.new(CITIZENLAB_MEMBER_REGEX_CONTENT, 'i') || email =~ Regexp.new(GOVOCAL_MEMBER_REGEX_CONTENT, 'i'))
   end
 

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -102,7 +102,9 @@ class SideFxUserService
     gained_roles(user).each { |role| role_created_side_fx(role, user, current_user) }
     lost_roles(user).each { |role| role_destroyed_side_fx(role, user, current_user) }
     AdditionalSeatsIncrementer.increment_if_necessary(user, current_user)
-    expire_token_on_role_change!(user)
+    # Token invalidation on highest_role change now lives on the User model
+    # (before_update), so it can't be bypassed by role-mutation paths that skip
+    # this service. See UserRoles#rotate_token_expiry_key_on_highest_role_change.
   end
 
   def role_created_side_fx(role, user, current_user)
@@ -149,14 +151,6 @@ class SideFxUserService
   def gained_roles(user)
     old_roles, new_roles = user.roles_previous_change
     new_roles.to_a - old_roles.to_a
-  end
-
-  # Expire the user's token when they first get roles or all roles are removed.
-  # NOTE: Must be called after all other side effects that depend on previous_changes,
-  # since expire_token! calls update! which resets previous_changes.
-  def expire_token_on_role_change!(user)
-    old_roles, new_roles = user.roles_previous_change
-    user.expire_token! if old_roles.blank? || new_roles.blank?
   end
 
   def create_followers(user)

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -102,9 +102,6 @@ class SideFxUserService
     gained_roles(user).each { |role| role_created_side_fx(role, user, current_user) }
     lost_roles(user).each { |role| role_destroyed_side_fx(role, user, current_user) }
     AdditionalSeatsIncrementer.increment_if_necessary(user, current_user)
-    # Token invalidation on highest_role change now lives on the User model
-    # (before_update), so it can't be bypassed by role-mutation paths that skip
-    # this service. See UserRoles#rotate_token_expiry_key_on_highest_role_change.
   end
 
   def role_created_side_fx(role, user, current_user)

--- a/back/engines/commercial/idea_custom_fields/spec/acceptance/ideas_spec.rb
+++ b/back/engines/commercial/idea_custom_fields/spec/acceptance/ideas_spec.rb
@@ -252,6 +252,7 @@ resource 'Ideas' do
       example 'Moving an idea to a project with required custom custom field', document: false do
         user.add_role 'admin'
         user.save!
+        header_token_for user # role change invalidates the earlier token; re-authenticate
         form = create(:custom_form, participation_context: project)
         create(:custom_field, :for_custom_form, resource: form, required: true, input_type: 'number')
         do_request

--- a/back/spec/acceptance/idea_reactions_spec.rb
+++ b/back/spec/acceptance/idea_reactions_spec.rb
@@ -159,6 +159,7 @@ resource 'Reactions' do
         Permissions::PermissionsUpdateService.new.update_all_permissions
         @project.phases.first.permissions.find_by(action: 'reacting_idea').update!(permitted_by: 'admins_moderators')
         @user.update!(roles: [])
+        header_token_for @user # role change invalidates the earlier token; re-authenticate
       end
 
       example_request '[error] Like an idea in a phase where reacting is not permitted' do

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -441,6 +441,7 @@ resource 'Users' do
     context 'when admin' do
       before do
         @user.update!(roles: [{ type: 'admin' }])
+        header_token_for @user # role change invalidates the earlier token; re-authenticate
       end
 
       get 'web_api/v1/users' do
@@ -1883,6 +1884,7 @@ resource 'Users' do
 
         before do
           @user.update!(roles: [{ type: 'admin' }])
+          header_token_for @user # role change invalidates the earlier token; re-authenticate
           @subject_user = create(:admin)
         end
 
@@ -1996,6 +1998,7 @@ resource 'Users' do
       before do
         project = create(:project)
         @user.update!(roles: [{ type: 'project_moderator', project_id: project.id }])
+        header_token_for @user # role change invalidates the earlier token; re-authenticate
       end
 
       get 'web_api/v1/users/me/ping' do

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -149,6 +149,20 @@ RSpec.describe Project do
 
       expect { project.destroy }.not_to raise_error
     end
+
+    it "invalidates a sole-role moderator's token when destroyed" do
+      # after_destroy -> remove_moderators strips the project_moderator role,
+      # dropping the user's highest_role to :user, which must invalidate their
+      # JWT (TAN-6826). Guards against this destroy path bypassing the model
+      # callback (e.g. if it were switched to update_columns).
+      project = create(:project)
+      moderator = create(:project_moderator, projects: [project])
+      moderator.update_column(:token_expiry_key, 'initial-key') # bypasses the callback
+
+      project.destroy!
+
+      expect(moderator.reload.token_expiry_key).not_to eq('initial-key')
+    end
   end
 
   describe 'generate_slug' do

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Project do
     it "invalidates a sole-role moderator's token when destroyed" do
       # after_destroy -> remove_moderators strips the project_moderator role,
       # dropping the user's highest_role to :user, which must invalidate their
-      # JWT (TAN-6826). Guards against this destroy path bypassing the model
+      # JWT. Guards against this destroy path bypassing the model
       # callback (e.g. if it were switched to update_columns).
       project = create(:project)
       moderator = create(:project_moderator, projects: [project])

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -798,35 +798,77 @@ RSpec.describe User do
       User.find(user.id)
     end
 
-    it 'rotates when a regular user gains a role' do
-      user = with_known_key(create(:user, roles: []))
-      user.update!(roles: [{ 'type' => 'admin' }])
-      expect(user.token_expiry_key).not_to eq('initial-key')
+    context 'when the change alters highest_role' do
+      it 'rotates when a regular user becomes an admin' do
+        user = with_known_key(create(:user, roles: []))
+        user.update!(roles: [{ 'type' => 'admin' }])
+        expect(user.token_expiry_key).not_to eq('initial-key')
+      end
+
+      it 'rotates when a project moderator is promoted to admin' do
+        user = with_known_key(create(:project_moderator, projects: [create(:project)]))
+        user.update!(roles: user.roles + [{ 'type' => 'admin' }])
+        expect(user.token_expiry_key).not_to eq('initial-key')
+      end
+
+      it 'rotates when an admin is demoted to project moderator' do
+        user = with_known_key(create(:admin))
+        user.update!(roles: [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
+        expect(user.token_expiry_key).not_to eq('initial-key')
+      end
+
+      it 'rotates when a moderator gains a higher-ranked role' do
+        # project_moderator + a folder-moderator role => highest_role rises to folder
+        user = with_known_key(create(:project_moderator, projects: [create(:project)]))
+        user.update!(roles: user.roles + [{ 'type' => 'project_folder_moderator', 'project_folder_id' => create(:project_folder).id }])
+        expect(user.token_expiry_key).not_to eq('initial-key')
+      end
+
+      it 'rotates when all roles are removed' do
+        user = with_known_key(create(:admin))
+        user.update!(roles: [])
+        expect(user.token_expiry_key).not_to eq('initial-key')
+      end
     end
 
-    it 'rotates when highest_role changes between two non-empty role sets' do
-      user = with_known_key(create(:admin))
-      project = create(:project)
-      user.update!(roles: [{ 'type' => 'project_moderator', 'project_id' => project.id }])
-      expect(user.token_expiry_key).not_to eq('initial-key')
-    end
+    context 'when the change leaves highest_role unchanged' do
+      it 'does not rotate when an admin also gains a moderator role' do
+        # admin + a lower-ranked moderator role => highest_role stays admin
+        user = with_known_key(create(:admin))
+        user.update!(roles: user.roles + [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
 
-    it 'rotates when all roles are removed' do
-      user = with_known_key(create(:admin))
-      user.update!(roles: [])
-      expect(user.token_expiry_key).not_to eq('initial-key')
-    end
+      it 'does not rotate when a moderator gains a lower-ranked role' do
+        # space_moderator + a lower-ranked project-moderator role => highest_role stays space
+        user = with_known_key(create(:space_moderator, spaces: [create(:space)]))
+        user.update!(roles: user.roles + [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
 
-    it 'does not rotate when a moderator gains an extra project role' do
-      user = with_known_key(create(:project_moderator, projects: [create(:project)]))
-      user.update!(roles: user.roles + [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
-      expect(user.token_expiry_key).to eq('initial-key')
-    end
+      it 'does not rotate when a project moderator gains an extra project role' do
+        user = with_known_key(create(:project_moderator, projects: [create(:project)]))
+        user.update!(roles: user.roles + [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
 
-    it 'does not rotate on a non-role update' do
-      user = with_known_key(create(:admin))
-      user.update!(first_name: 'Updated')
-      expect(user.token_expiry_key).to eq('initial-key')
+      it 'does not rotate when a folder moderator gains an extra folder role' do
+        user = with_known_key(create(:project_folder_moderator, project_folders: [create(:project_folder)]))
+        user.update!(roles: user.roles + [{ 'type' => 'project_folder_moderator', 'project_folder_id' => create(:project_folder).id }])
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
+
+      it 'does not rotate when a space moderator gains an extra space role' do
+        user = with_known_key(create(:space_moderator, spaces: [create(:space)]))
+        user.update!(roles: user.roles + [{ 'type' => 'space_moderator', 'space_id' => create(:space).id }])
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
+
+      it 'does not rotate on a non-role update' do
+        user = with_known_key(create(:admin))
+        user.update!(first_name: 'Updated')
+        expect(user.token_expiry_key).to eq('initial-key')
+      end
     end
 
     it 'does not rotate on create (no prior token to invalidate)' do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -785,6 +785,14 @@ RSpec.describe User do
     it 'correctly returns the highest role a moderator posesses' do
       expect(build_stubbed(:project_moderator).highest_role).to eq :project_moderator
     end
+
+    it 'ignores a moderator role that is missing its scope id' do
+      # Mirrors moderated_*_ids (which compact out nil ids): a type-only role
+      # hash does not make the user a moderator.
+      user = build_stubbed(:user, roles: [{ 'type' => 'project_moderator' }])
+      expect(user.highest_role).to eq :user
+      expect(user.project_moderator?).to be false
+    end
   end
 
   describe 'token_expiry_key rotation on highest_role change' do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -787,6 +787,53 @@ RSpec.describe User do
     end
   end
 
+  describe 'token_expiry_key rotation on highest_role change' do
+    # Rotating token_expiry_key invalidates any outstanding JWT, so its
+    # highest_role claim can't go stale after a role change (TAN-6826).
+
+    # Set a known key, then reload so highest_role_after_initialize reflects the
+    # persisted roles. update_column bypasses the callback we're testing.
+    def with_known_key(user)
+      user.update_column(:token_expiry_key, 'initial-key')
+      User.find(user.id)
+    end
+
+    it 'rotates when a regular user gains a role' do
+      user = with_known_key(create(:user, roles: []))
+      user.update!(roles: [{ 'type' => 'admin' }])
+      expect(user.token_expiry_key).not_to eq('initial-key')
+    end
+
+    it 'rotates when highest_role changes between two non-empty role sets' do
+      user = with_known_key(create(:admin))
+      project = create(:project)
+      user.update!(roles: [{ 'type' => 'project_moderator', 'project_id' => project.id }])
+      expect(user.token_expiry_key).not_to eq('initial-key')
+    end
+
+    it 'rotates when all roles are removed' do
+      user = with_known_key(create(:admin))
+      user.update!(roles: [])
+      expect(user.token_expiry_key).not_to eq('initial-key')
+    end
+
+    it 'does not rotate when a moderator gains an extra project role' do
+      user = with_known_key(create(:project_moderator, projects: [create(:project)]))
+      user.update!(roles: user.roles + [{ 'type' => 'project_moderator', 'project_id' => create(:project).id }])
+      expect(user.token_expiry_key).to eq('initial-key')
+    end
+
+    it 'does not rotate on a non-role update' do
+      user = with_known_key(create(:admin))
+      user.update!(first_name: 'Updated')
+      expect(user.token_expiry_key).to eq('initial-key')
+    end
+
+    it 'does not rotate on create (no prior token to invalidate)' do
+      expect(create(:admin).token_expiry_key).to be_nil
+    end
+  end
+
   describe 'onboarding' do
     it 'is valid when empty' do
       u = build(:user, onboarding: {})

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -221,33 +221,9 @@ describe SideFxUserService do
     end
   end
 
-  describe 'after_update - expire_token! on role change' do
-    it 'expires the token when a regular user gains roles' do
-      user.update!(roles: [{ 'type' => 'admin' }])
-      expect(user).to receive(:expire_token!)
-      service.after_update(user, current_user)
-    end
-
-    it 'does not expire the token when roles change but user already had roles' do
-      user.update!(roles: [{ 'type' => 'admin' }])
-      user.update!(roles: [{ 'type' => 'project_moderator', 'project_id' => 'some-id' }])
-      expect(user).not_to receive(:expire_token!)
-      service.after_update(user, current_user)
-    end
-
-    it 'expires the token when all roles are removed' do
-      user.update!(roles: [{ 'type' => 'admin' }])
-      user.update!(roles: [])
-      expect(user).to receive(:expire_token!)
-      service.after_update(user, current_user)
-    end
-
-    it 'does not expire the token when roles are unchanged' do
-      user.update!(first_name: 'Updated')
-      expect(user).not_to receive(:expire_token!)
-      service.after_update(user, current_user)
-    end
-  end
+  # Token invalidation on highest_role change moved to the User model
+  # (UserRoles#rotate_token_expiry_key_on_highest_role_change). Its coverage
+  # lives in spec/models/user_spec.rb.
 
   describe 'after_destroy' do
     it "logs a 'deleted' action job when the user is destroyed" do

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -221,10 +221,6 @@ describe SideFxUserService do
     end
   end
 
-  # Token invalidation on highest_role change moved to the User model
-  # (UserRoles#rotate_token_expiry_key_on_highest_role_change). Its coverage
-  # lives in spec/models/user_spec.rb.
-
   describe 'after_destroy' do
     it "logs a 'deleted' action job when the user is destroyed" do
       freeze_time do


### PR DESCRIPTION
We have at least 5 flows where a user's `highest_role` could change and invalidating the user's JWT should therefore occur, but never does. See [Research Findings (audit)](https://github.com/CitizenLabDotCo/citizenlab-claude/blob/main/plans/TAN-6826-always-invalidate-jwt-on-role-change.md#research-findings-audit) in Claude plan.

**Solution:** Token invalidation is moved from the (bypassable) `SideFxUserService` into a `before_update` callback on `User` itself, so it fires on every role-mutation path rather than only those routed through the service. The callback rotates the user's `token_expiry_key` — which invalidates all outstanding JWTs and forces a fresh, correctly-claimed token on next login — but only when the save actually changes the user's `highest_role` (comparing the persisted roles against the pending ones), so unrelated role edits don't needlessly log anyone out.

# Changelog
## Fixed
- [TAN-6826] Always invalidate JWT when `highest_role` changes
