### PR TITLE
[TAN-8184] Add travel_back to specs that travel_to in a before hook

### DIFF
--- a/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/common_ground_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/native_survey_phase_insights_spec.rb
@@ -15,6 +15,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/poll_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/proposals_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/volunteering_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, resource_type: 'User', key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/voting_phase_insights_spec.rb
@@ -9,6 +9,8 @@ resource 'Phase insights' do
     travel_to(Time.zone.parse('2025-12-02 12:00:00'))
   end
 
+  after { travel_back }
+
   let!(:custom_field_gender) { create(:custom_field, :for_registration, key: 'gender', input_type: 'select', title_multiloc: { en: 'Gender' }) }
   let!(:custom_field_option_male) { create(:custom_field_option, custom_field: custom_field_gender, key: 'male', title_multiloc: { en: 'Male' }) }
   let!(:custom_field_option_female) { create(:custom_field_option, custom_field: custom_field_gender, key: 'female', title_multiloc: { en: 'Female' }) }

--- a/back/spec/models/custom_field_bins/age_bin_spec.rb
+++ b/back/spec/models/custom_field_bins/age_bin_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe CustomFieldBins::AgeBin do
     travel_to Time.zone.local(2025, 3, 21)
   end
 
+  after { travel_back }
+
   describe 'Default factory' do
     it 'is valid' do
       expect(build(:age_bin)).to be_valid

--- a/back/spec/services/community_monitor_service_spec.rb
+++ b/back/spec/services/community_monitor_service_spec.rb
@@ -127,6 +127,8 @@ describe CommunityMonitorService do
       create(:native_survey_response, project: project, published_at: '2025-05-23')
     end
 
+    after { travel_back }
+
     context 'when there is no previous quarter report' do
       it 'creates a new report' do
         report = service.find_or_create_previous_quarter_report

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -424,6 +424,7 @@ RSpec.describe Insights::BasePhaseInsightsService do
 
     # Ensure consistent date as stats will be different in first six months of year vs last six months
     before { travel_to(Date.parse('2025-10-01')) }
+    after { travel_back }
 
     context 'without reference distribution' do
       it 'calculates demographics data correctly' do

--- a/back/spec/services/insights/visits_service_spec.rb
+++ b/back/spec/services/insights/visits_service_spec.rb
@@ -6,6 +6,8 @@ describe Insights::VisitsService do
     travel_to(Time.zone.parse('2025-12-12'))
   end
 
+  after { travel_back }
+
   context 'Phase visits' do
     # rubocop:disable RSpec/ScatteredLet
     let(:phase) { create(:single_voting_phase, start_at: 20.days.ago, end_at: 2.days.ago) }


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-8184] Add travel_back to specs that travel_to in a before hook (fixes some test flakiness on CI)
