### PR TITLE
[TAN-8184] Fix two flaky tests using random date-times from projects factory

### DIFF
--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -586,7 +586,9 @@ RSpec.describe Phase do
     context 'and a bounded phase is added' do
       it 'after the last phase, it closes the previous phase' do
         new_phase_start = last_phase.start_at + 15.days
-        new_phase = create(:phase, project:, start_at: new_phase_start, end_at: new_phase_start + 1.day)
+        # 2 days, not 1: a 1-day phase whose start lands the day before a DST
+        # spring-forward is only 23h, which is < MIN_DURATION (24h).
+        new_phase = create(:phase, project:, start_at: new_phase_start, end_at: new_phase_start + 2.days)
 
         expect(last_phase.reload.end_at).to eq(new_phase_start)
         expect(new_phase.previous_phase_end_at_updated?).to be true
@@ -596,7 +598,8 @@ RSpec.describe Phase do
     context 'and a standalone phase is added' do
       it 'after the last phase, it does not close the previous phase' do
         new_phase_start = last_phase.start_at + 15.days
-        new_phase = create(:phase, :standalone, project:, start_at: new_phase_start, end_at: new_phase_start + 1.day)
+        # 2 days, not 1: guards against a DST-shortened 23h day (< MIN_DURATION).
+        new_phase = create(:phase, :standalone, project:, start_at: new_phase_start, end_at: new_phase_start + 2.days)
 
         expect(last_phase.reload.end_at).to be_nil
         expect(new_phase.previous_phase_end_at_updated?).to be false

--- a/back/spec/serializers/web_api/v1/idea_serializer_spec.rb
+++ b/back/spec/serializers/web_api/v1/idea_serializer_spec.rb
@@ -129,7 +129,9 @@ describe WebApi::V1::IdeaSerializer do
     before do
       create(:baskets_idea, basket: create(:basket, phase: phase), idea: input, votes: 1)
       create(:baskets_idea, basket: create(:basket, phase: phase), idea: input, votes: 1)
-      phase.update!(end_at: phase.start_at + 1.day)
+      # 2 days, not 1: a 1-day phase whose start lands on a DST spring-forward day is
+      # only 23h, which is < MIN_DURATION (24h) and fails validation.
+      phase.update!(end_at: phase.start_at + 2.days)
       other_phase = create(:budgeting_phase, project: phase.project, start_at: phase.end_at + 1.day, end_at: phase.end_at + 10.days)
       create(:baskets_idea, basket: create(:basket, phase: other_phase), idea: input, votes: 1)
       Basket.update_counts(phase)


### PR DESCRIPTION
[Example flaky failure on CI](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/343308/workflows/6391faa3-146d-4f85-89a0-f4afb57ba91d/jobs/778662/tests)

# Changelog
## Technical
- [TAN-8184] Fix two flaky tests using random date-times from projects factory
