### PR TITLE
[TAN-8188] Bugfix: can save an edit to folder settings when no folder description set

### DIFF
--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/ProjectFolderForm.test.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/ProjectFolderForm.test.tsx
@@ -9,8 +9,6 @@ jest.mock('hooks/useFeatureFlag', () => jest.fn(() => true));
 
 const mockUpdateProjectFolder = jest.fn();
 
-// A folder created through this form: the description is only ever authored in
-// the Content Builder, so description_multiloc comes back null.
 const folderWithoutDescription = {
   data: {
     id: 'folder-id',
@@ -55,7 +53,6 @@ describe('ProjectFolderForm', () => {
     it('saves — the description is optional, so it must not block the save', async () => {
       render(<ProjectFolderForm mode="edit" projectFolderId="folder-id" />);
 
-      // Editing a field enables the Save button.
       const titleInput = await screen.findByDisplayValue('A folder');
       await userEvent.type(titleInput, '!');
 

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/ProjectFolderForm.test.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/ProjectFolderForm.test.tsx
@@ -1,13 +1,72 @@
 import React from 'react';
 
-import { screen, render } from 'utils/testUtils/rtl';
+import { screen, render, userEvent, waitFor } from 'utils/testUtils/rtl';
 
 import ProjectFolderForm from '.';
 
 jest.mock('hooks/useAppConfigurationLocales', () => jest.fn(() => ['en']));
 jest.mock('hooks/useFeatureFlag', () => jest.fn(() => true));
 
+const mockUpdateProjectFolder = jest.fn();
+
+// A folder created through this form: the description is only ever authored in
+// the Content Builder, so description_multiloc comes back null.
+const folderWithoutDescription = {
+  data: {
+    id: 'folder-id',
+    attributes: {
+      title_multiloc: { en: 'A folder' },
+      description_multiloc: null,
+      description_preview_multiloc: { en: 'Short description' },
+      header_bg_alt_text_multiloc: {},
+      slug: 'a-folder',
+      space_id: null,
+    },
+    relationships: {
+      admin_publication: { data: { id: 'admin-publication-id' } },
+    },
+  },
+};
+
+jest.mock('api/project_folders/useProjectFolderById', () =>
+  jest.fn((id?: string) => ({
+    data: id ? folderWithoutDescription : undefined,
+  }))
+);
+jest.mock('api/project_folders/useUpdateProjectFolder', () =>
+  jest.fn(() => ({ mutateAsync: mockUpdateProjectFolder }))
+);
+jest.mock('api/project_folder_images/useProjectFolderImages', () =>
+  jest.fn(() => ({ data: undefined }))
+);
+jest.mock('api/project_folder_files/useProjectFolderFiles', () =>
+  jest.fn(() => ({ data: undefined }))
+);
+jest.mock('api/admin_publications/useAdminPublication', () =>
+  jest.fn(() => ({ data: undefined }))
+);
+
 describe('ProjectFolderForm', () => {
+  beforeEach(() => {
+    mockUpdateProjectFolder.mockClear();
+  });
+
+  describe('when editing a folder with no description (edit mode)', () => {
+    it('saves — the description is optional, so it must not block the save', async () => {
+      render(<ProjectFolderForm mode="edit" projectFolderId="folder-id" />);
+
+      // Editing a field enables the Save button.
+      const titleInput = await screen.findByDisplayValue('A folder');
+      await userEvent.type(titleInput, '!');
+
+      await userEvent.click(screen.getByRole('button', { name: /save/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProjectFolder).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('when creating a folder (new mode)', () => {
     it('does not render a description editor — the description is added in the Content Builder after creation', () => {
       render(<ProjectFolderForm mode="new" />);

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
@@ -395,8 +395,6 @@ const ProjectFolderForm = ({ mode, projectFolderId }: Props) => {
         }
       } else {
         try {
-          // The description is optional: it is authored in the Content Builder,
-          // never in this form, so it is null on every folder created here.
           if (
             titleMultiloc &&
             shortDescriptionMultiloc &&

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
@@ -395,9 +395,10 @@ const ProjectFolderForm = ({ mode, projectFolderId }: Props) => {
         }
       } else {
         try {
+          // The description is optional: it is authored in the Content Builder,
+          // never in this form, so it is null on every folder created here.
           if (
             titleMultiloc &&
-            descriptionMultiloc &&
             shortDescriptionMultiloc &&
             !isNilOrError(projectFolder)
           ) {

--- a/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
+++ b/front/app/containers/Admin/projectFolders/containers/settings/ProjectFolderForm/index.tsx
@@ -492,9 +492,10 @@ const ProjectFolderForm = ({ mode, projectFolderId }: Props) => {
                   ? titleMultiloc
                   : undefined,
                 slug: changedSlug ? slug : undefined,
-                description_multiloc: changedDescriptionMultiloc
-                  ? descriptionMultiloc
-                  : undefined,
+                description_multiloc:
+                  changedDescriptionMultiloc && descriptionMultiloc
+                    ? descriptionMultiloc
+                    : undefined,
                 description_preview_multiloc: changedShortDescriptionMultiloc
                   ? shortDescriptionMultiloc
                   : undefined,


### PR DESCRIPTION
### The bug
Every project folder created through the admin form since **2026-06-16** is permanently unsavable in its settings. Clicking Save shows "Something went wrong, please try again later" — with no request made, and nothing in the console. It happens on every attempt, forever, for that folder.

Reported by a customer who created a folder, wrote its description in the Content Builder, and then could not save any folder settings at all.

### Source
`2285cb66752` — "Make folder description optional and Content Builder-only at creation" — removed the rich-text description editor from the folder form and made the description optional in `validate()`, in the new-mode save guard, and in the create payload. It left `descriptionMultiloc &&` standing in the **edit-mode** save guard.

Since nothing in the form can set a description any more, and the create no longer sends `description_multiloc` (the column has no DB default), every folder created here is stored with `description_multiloc = NULL`. On edit, that load  as `null`, the guard is falsy, and `saveForm` falls into an `else` that sets `submitState = 'apiError'` without ever calling the API. The Content Builder writes a *layout*, not `description_multiloc`, so nothing repopulates the column -  hence "permanently".

Confirmed against the customer's request logs: a `POST /project_folders` (201), twelve Content Builder layout upserts, and zero settings writes.

### The fix
Drop `descriptionMultiloc` from the edit-mode save guard. The description is optional in the form's own validation and on the backend (`validates :description_multiloc, multiloc: { presence: false }`), so requiring it here was simply stale.

No data repair needed — a NULL `description_multiloc` is valid; the guard was the only thing rejecting it.

Functional testing (locally) reproduced the original bug, and confirms the fix.

### Test
Adds an edit-mode case to `ProjectFolderForm.test.tsx`: a folder with `description_multiloc: null`, edit the title, save, assert the update fires. Verified it fails against the old guard.  happens on every attempt, forever, for that folder.

Reported by a customer who created a folder, wrote its description in the Content Builder, and then could not save any folder settings at all.

### Found but not addressed
- **`ProjectFolderForm/index.tsx:213-216`** — `files.filter((file) => file);` discards its result, and the `as UploadFile[]` cast hides that `convertUrlToUploadFile` returns `null` on a rejected fetch. A `null` in `projectFolderFiles` crashes the save (`useSyncFolderFiles` dereferences `file.remote`). Latent; unrelated to this ticket.
- **`saveForm`'s `catch` blocks** swallow every throw into the same generic message and never report to Sentry. This is why the bug ran for a month with no error event, and it's the ticket's original "give a more useful error" ask. Worth its own PR.
- **`input.franklintn.gov`** — admins load the platform on a trailing-dot hostname, making every upload cross-origin; the CORS failure means folder images silently fail to load in the admin form. 38 Sentry issues since May. They are one folder attachment away from the crash above.
- **`/admin/dashboard/overview`** — an unrelated backend `PG::SyntaxError` (an `Arel::Table` interpolated into a `COUNT` query), 82k events across 1.2k users.

# Changelog
## Fixed
- [TAN-8188] Bugfix: can save an edit to folder settings when no folder description set
