### PR TITLE
[NO-TICKET] Remove text from progress bar

### DIFF
--- a/front/app/components/CustomFieldsForm/ProgressBar.tsx
+++ b/front/app/components/CustomFieldsForm/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Text, colors } from '@citizenlab/cl2-component-library';
+import { Box, colors } from '@citizenlab/cl2-component-library';
 import { useTheme } from 'styled-components';
 
 import { useIntl } from 'utils/cl-intl';
@@ -33,20 +33,6 @@ const ProgressBar = ({ formCompletionPercentage = 0 }: Props) => {
           style={{ transition: 'width 0.3s ease-in-out' }}
         />
       </Box>
-      <Text
-        m="0"
-        fontSize="s"
-        color="textSecondary"
-        position="absolute"
-        top="4px"
-        left="0"
-        right="0"
-        textAlign="center"
-      >
-        {formatMessage(messages.progressPercentage, {
-          percentage: roundedPercentage,
-        })}
-      </Text>
     </Box>
   );
 };

--- a/front/app/components/CustomFieldsForm/messages.ts
+++ b/front/app/components/CustomFieldsForm/messages.ts
@@ -75,10 +75,6 @@ export default defineMessages({
     id: 'app.components.CustomFieldsForm.progressBarLabel',
     defaultMessage: 'Progress',
   },
-  progressPercentage: {
-    id: 'app.components.CustomFieldsForm.progressPercentage',
-    defaultMessage: '{percentage}% complete',
-  },
   selectMany: {
     id: 'app.components.CustomFieldsForm.selectMany',
     defaultMessage: '*Choose as many as you like',

--- a/front/app/translations/ar-MA.json
+++ b/front/app/translations/ar-MA.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*سيتم مشاركة هذه الإجابة فقط مع مديري المشاريع، وليس مع الجمهور.",
   "app.components.CustomFieldsForm.otherArea": "مكان آخر",
   "app.components.CustomFieldsForm.progressBarLabel": "تقدم",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% مكتمل",
   "app.components.CustomFieldsForm.removeAnswer": "إزالة الإجابة",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*اختر العدد الذي تريده",
   "app.components.CustomFieldsForm.selectBetween": "*اختر بين الخيارين {minItems} و {maxItems}",

--- a/front/app/translations/ar-SA.json
+++ b/front/app/translations/ar-SA.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*سيتم مشاركة هذه الإجابة فقط مع مديري المشاريع، وليس مع الجمهور.",
   "app.components.CustomFieldsForm.otherArea": "مكان آخر",
   "app.components.CustomFieldsForm.progressBarLabel": "تقدم",
-  "app.components.CustomFieldsForm.progressPercentage": "مكتمل بنسبة {percentage}%",
   "app.components.CustomFieldsForm.removeAnswer": "إزالة الإجابة",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*اختر العدد الذي تريده",
   "app.components.CustomFieldsForm.selectBetween": "*اختر بين الخيارين {minItems} و {maxItems}",

--- a/front/app/translations/ca-ES.json
+++ b/front/app/translations/ca-ES.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Aquesta resposta només es compartirà amb els gestors de projectes i no amb el públic.",
   "app.components.CustomFieldsForm.otherArea": "En algun altre lloc",
   "app.components.CustomFieldsForm.progressBarLabel": "Progrés",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% completat",
   "app.components.CustomFieldsForm.removeAnswer": "Elimina la resposta",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Seleccioneu-ne tants com vulgueu",
   "app.components.CustomFieldsForm.selectBetween": "*Seleccioneu entre les opcions {minItems} i {maxItems}",

--- a/front/app/translations/cy-GB.json
+++ b/front/app/translations/cy-GB.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dim ond gyda rheolwyr prosiectau y bydd yr ateb hwn yn cael ei rannu, ac nid gyda'r cyhoedd.",
   "app.components.CustomFieldsForm.otherArea": "Rhywle arall",
   "app.components.CustomFieldsForm.progressBarLabel": "Cynnydd",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% wedi'i gwblhau",
   "app.components.CustomFieldsForm.removeAnswer": "Dileu'r ateb",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Dewiswch gymaint ag y dymunwch",
   "app.components.CustomFieldsForm.selectBetween": "*Dewiswch rhwng yr opsiynau {minItems} a {maxItems}",

--- a/front/app/translations/da-DK.json
+++ b/front/app/translations/da-DK.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dette svar vil kun blive delt med projektledere og ikke med offentligheden.",
   "app.components.CustomFieldsForm.otherArea": "Et andet sted",
   "app.components.CustomFieldsForm.progressBarLabel": "Fremskridt",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% færdig",
   "app.components.CustomFieldsForm.removeAnswer": "Fjern svar",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Vælg så mange, som du vil",
   "app.components.CustomFieldsForm.selectBetween": "*Vælg mellem {minItems} og {maxItems} muligheder",

--- a/front/app/translations/de-AT.json
+++ b/front/app/translations/de-AT.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Diese Antwort wird nur an die Projektmanager*innen und nicht an die Öffentlichkeit weitergegeben.",
   "app.components.CustomFieldsForm.otherArea": "Anderswo",
   "app.components.CustomFieldsForm.progressBarLabel": "Fortschritt",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% abgeschlossen",
   "app.components.CustomFieldsForm.removeAnswer": "Antwort entfernen",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Beliebig viele auswählen",
   "app.components.CustomFieldsForm.selectBetween": "*Wähle zwischen {minItems} und {maxItems} Optionen",

--- a/front/app/translations/de-DE.json
+++ b/front/app/translations/de-DE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Diese Antwort wird nur an die Projektmanager*innen und nicht an die Öffentlichkeit weitergegeben.",
   "app.components.CustomFieldsForm.otherArea": "Anderswo",
   "app.components.CustomFieldsForm.progressBarLabel": "Fortschritt",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% abgeschlossen",
   "app.components.CustomFieldsForm.removeAnswer": "Antwort entfernen",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Beliebig viele auswählen",
   "app.components.CustomFieldsForm.selectBetween": "*Wählen Sie zwischen {minItems} und {maxItems} Optionen",

--- a/front/app/translations/el-GR.json
+++ b/front/app/translations/el-GR.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Η απάντηση αυτή θα κοινοποιηθεί μόνο στους διαχειριστές του έργου και όχι στο κοινό.",
   "app.components.CustomFieldsForm.otherArea": "Κάπου αλλού",
   "app.components.CustomFieldsForm.progressBarLabel": "Πρόοδος",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% ολοκληρώθηκε",
   "app.components.CustomFieldsForm.removeAnswer": "Αφαίρεση απάντησης",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Επιλέξτε όσα θέλετε",
   "app.components.CustomFieldsForm.selectBetween": "*Επιλέξτε από {minItems} έως {maxItems} απαντήσεις",

--- a/front/app/translations/en-CA.json
+++ b/front/app/translations/en-CA.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% complete",
   "app.components.CustomFieldsForm.removeAnswer": "Remove answer",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Select as many as you like",
   "app.components.CustomFieldsForm.selectBetween": "*Select between {minItems} and {maxItems} options",

--- a/front/app/translations/en-GB.json
+++ b/front/app/translations/en-GB.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% complete",
   "app.components.CustomFieldsForm.removeAnswer": "Remove answer",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Select as many as you like",
   "app.components.CustomFieldsForm.selectBetween": "*Select between {minItems} and {maxItems} options",

--- a/front/app/translations/en-IE.json
+++ b/front/app/translations/en-IE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% complete",
   "app.components.CustomFieldsForm.removeAnswer": "Remove answer",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Select as many as you like",
   "app.components.CustomFieldsForm.selectBetween": "*Select between {minItems} and {maxItems} options",

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% complete",
   "app.components.CustomFieldsForm.removeAnswer": "Remove answer",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Select as many as you like",
   "app.components.CustomFieldsForm.selectBetween": "*Select between {minItems} and {maxItems} options",

--- a/front/app/translations/es-CL.json
+++ b/front/app/translations/es-CL.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Esta respuesta sólo se compartirá con los gestores del proyecto, y no con el público.",
   "app.components.CustomFieldsForm.otherArea": "En algún otro lugar",
   "app.components.CustomFieldsForm.progressBarLabel": "Progreso",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% completado",
   "app.components.CustomFieldsForm.removeAnswer": "Eliminar respuesta",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Selecciona tantos como quieras",
   "app.components.CustomFieldsForm.selectBetween": "*Selecciona entre {minItems} y {maxItems} opciones",

--- a/front/app/translations/es-ES.json
+++ b/front/app/translations/es-ES.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Esta respuesta sólo se compartirá con los gestores del proyecto, y no con el público.",
   "app.components.CustomFieldsForm.otherArea": "En algún otro lugar",
   "app.components.CustomFieldsForm.progressBarLabel": "Progreso",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% completado",
   "app.components.CustomFieldsForm.removeAnswer": "Eliminar respuesta",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Selecciona tantos como quieras",
   "app.components.CustomFieldsForm.selectBetween": "*Selecciona entre {minItems} y {maxItems} opciones",

--- a/front/app/translations/fi-FI.json
+++ b/front/app/translations/fi-FI.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Tämä vastaus jaetaan vain projektipäälliköiden kanssa, eikä sitä jaeta julkisesti.",
   "app.components.CustomFieldsForm.otherArea": "Jossain muualla",
   "app.components.CustomFieldsForm.progressBarLabel": "Edistyminen",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage} % valmis",
   "app.components.CustomFieldsForm.removeAnswer": "Poista vastaus",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Valitse niin monta kuin haluat",
   "app.components.CustomFieldsForm.selectBetween": "*Valitse vaihtoehdoista {minItems} ja {maxItems}",

--- a/front/app/translations/fr-BE.json
+++ b/front/app/translations/fr-BE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Cette réponse sera partagée uniquement avec les gestionnaires de projet, et non avec le public.",
   "app.components.CustomFieldsForm.otherArea": "Autre lieu",
   "app.components.CustomFieldsForm.progressBarLabel": "Progression",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage} % complété",
   "app.components.CustomFieldsForm.removeAnswer": "Supprimer la réponse",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "* Sélectionnez autant d'options que vous le souhaitez",
   "app.components.CustomFieldsForm.selectBetween": "* Sélectionnez entre {minItems} et {maxItems} options",

--- a/front/app/translations/fr-FR.json
+++ b/front/app/translations/fr-FR.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Cette réponse sera partagée uniquement avec les gestionnaires de projet, et non avec le public.",
   "app.components.CustomFieldsForm.otherArea": "Autre lieu",
   "app.components.CustomFieldsForm.progressBarLabel": "Progression",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage} % complété",
   "app.components.CustomFieldsForm.removeAnswer": "Supprimer la réponse",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "* Sélectionnez autant d'options que vous le souhaitez",
   "app.components.CustomFieldsForm.selectBetween": "* Sélectionnez entre {minItems} et {maxItems} options",

--- a/front/app/translations/ga-IE.json
+++ b/front/app/translations/ga-IE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Ní roinnfear an freagra seo ach le bainisteoirí tionscadail, agus ní leis an bpobal.",
   "app.components.CustomFieldsForm.otherArea": "Áit éigin eile",
   "app.components.CustomFieldsForm.progressBarLabel": "Dul Chun Cinn",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% críochnaithe",
   "app.components.CustomFieldsForm.removeAnswer": "Bain an freagra",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Roghnaigh an oiread agus is mian leat",
   "app.components.CustomFieldsForm.selectBetween": "*Roghnaigh idir na roghanna {minItems} agus {maxItems}",

--- a/front/app/translations/hr-HR.json
+++ b/front/app/translations/hr-HR.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Ovaj odgovor bit će podijeljen samo s voditeljima projekata, a ne s javnošću.",
   "app.components.CustomFieldsForm.otherArea": "Negdje drugdje",
   "app.components.CustomFieldsForm.progressBarLabel": "Napredak",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% dovršeno",
   "app.components.CustomFieldsForm.removeAnswer": "Ukloni odgovor",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Odaberite koliko god želite",
   "app.components.CustomFieldsForm.selectBetween": "*Odaberite između opcija {minItems} i {maxItems}",

--- a/front/app/translations/hu-HU.json
+++ b/front/app/translations/hu-HU.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Ez a válasz csak a projektmenedzserekkel lesz megosztva, a nyilvánosság számára nem.",
   "app.components.CustomFieldsForm.otherArea": "Valahol máshol",
   "app.components.CustomFieldsForm.progressBarLabel": "Előrehalad",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% kész",
   "app.components.CustomFieldsForm.removeAnswer": "Válasz eltávolítása",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Válassz ki annyit, amennyit szeretnél",
   "app.components.CustomFieldsForm.selectBetween": "*Válasszon a {minItems} és a {maxItems} lehetőségek közül",

--- a/front/app/translations/it-IT.json
+++ b/front/app/translations/it-IT.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Questa risposta sarà condivisa solo con i responsabili del progetto e non con il pubblico.",
   "app.components.CustomFieldsForm.otherArea": "Da qualche altra parte",
   "app.components.CustomFieldsForm.progressBarLabel": "Progressi",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% completato",
   "app.components.CustomFieldsForm.removeAnswer": "Rimuovi la risposta",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Seleziona tutti quelli che vuoi",
   "app.components.CustomFieldsForm.selectBetween": "*Seleziona tra le opzioni {minItems} e {maxItems}",

--- a/front/app/translations/kl-GL.json
+++ b/front/app/translations/kl-GL.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*This answer will only be shared with project managers, and not to the public.",
   "app.components.CustomFieldsForm.otherArea": "Somewhere else",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% naammassineqarpoq",
   "app.components.CustomFieldsForm.removeAnswer": "Remove answer",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Select as many as you like",
   "app.components.CustomFieldsForm.selectBetween": "*Select between {minItems} and {maxItems} options",

--- a/front/app/translations/lb-LU.json
+++ b/front/app/translations/lb-LU.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dës Äntwert gëtt nëmme mat de Projetmanager gedeelt, an net mat der Ëffentlechkeet.",
   "app.components.CustomFieldsForm.otherArea": "Irgendwou anescht",
   "app.components.CustomFieldsForm.progressBarLabel": "Fortschrëtt",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% fäerdeg",
   "app.components.CustomFieldsForm.removeAnswer": "Äntwert ewechhuelen",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Wielt sou vill wéi Dir wëllt",
   "app.components.CustomFieldsForm.selectBetween": "*Wiel tëscht den Optiounen {minItems} an {maxItems}",

--- a/front/app/translations/lt-LT.json
+++ b/front/app/translations/lt-LT.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Šiuo atsakymu bus dalijamasi tik su projektų vadovais, o ne viešai.",
   "app.components.CustomFieldsForm.otherArea": "Kažkur kitur",
   "app.components.CustomFieldsForm.progressBarLabel": "Pažanga",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% baigta",
   "app.components.CustomFieldsForm.removeAnswer": "Pašalinti atsakymą",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Pasirinkite tiek, kiek norite",
   "app.components.CustomFieldsForm.selectBetween": "*Pasirinkite iš {minItems} ir {maxItems} parinkčių",

--- a/front/app/translations/lv-LV.json
+++ b/front/app/translations/lv-LV.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Šī atbilde tiks izpausta tikai projektu vadītājiem, bet ne sabiedrībai.",
   "app.components.CustomFieldsForm.otherArea": "Kaut kur citur",
   "app.components.CustomFieldsForm.progressBarLabel": "Progress",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% pabeigts",
   "app.components.CustomFieldsForm.removeAnswer": "Noņemt atbildi",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Izvēlieties tik daudz, cik vēlaties",
   "app.components.CustomFieldsForm.selectBetween": "*Izvēlieties starp {minItems} un {maxItems} iespējām",

--- a/front/app/translations/nb-NO.json
+++ b/front/app/translations/nb-NO.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dette svaret vil kun bli delt med prosjektledere, og ikke med offentligheten.",
   "app.components.CustomFieldsForm.otherArea": "Et annet sted",
   "app.components.CustomFieldsForm.progressBarLabel": "Fremgang",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage} % fullført",
   "app.components.CustomFieldsForm.removeAnswer": "Fjern svar",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Velg så mange du vil",
   "app.components.CustomFieldsForm.selectBetween": "*Velg mellom {minItems} og {maxItems}",

--- a/front/app/translations/nl-BE.json
+++ b/front/app/translations/nl-BE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dit antwoord wordt alleen gedeeld met projectbeheerders en niet met het publiek.",
   "app.components.CustomFieldsForm.otherArea": "Ergens anders",
   "app.components.CustomFieldsForm.progressBarLabel": "Voortgang",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% voltooid",
   "app.components.CustomFieldsForm.removeAnswer": "Antwoord verwijderen",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Selecteer er zoveel als je wilt",
   "app.components.CustomFieldsForm.selectBetween": "*Selecteer tussen {minItems} en {maxItems} opties",

--- a/front/app/translations/nl-NL.json
+++ b/front/app/translations/nl-NL.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Dit antwoord wordt alleen gedeeld met projectbeheerders en niet met het publiek.",
   "app.components.CustomFieldsForm.otherArea": "Ergens anders",
   "app.components.CustomFieldsForm.progressBarLabel": "Voortgang",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% voltooid",
   "app.components.CustomFieldsForm.removeAnswer": "Antwoord verwijderen",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Selecteer er zoveel als je wilt",
   "app.components.CustomFieldsForm.selectBetween": "*Selecteer tussen {minItems} en {maxItems} opties",

--- a/front/app/translations/pa-IN.json
+++ b/front/app/translations/pa-IN.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*ਇਹ ਜਵਾਬ ਸਿਰਫ਼ ਪ੍ਰੋਜੈਕਟ ਮੈਨੇਜਰਾਂ ਨਾਲ ਸਾਂਝਾ ਕੀਤਾ ਜਾਵੇਗਾ, ਜਨਤਾ ਨਾਲ ਨਹੀਂ।",
   "app.components.CustomFieldsForm.otherArea": "ਕਿਤੇ ਹੋਰ",
   "app.components.CustomFieldsForm.progressBarLabel": "ਤਰੱਕੀ",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% ਪੂਰਾ ਹੋਇਆ",
   "app.components.CustomFieldsForm.removeAnswer": "ਜਵਾਬ ਹਟਾਓ",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*ਜਿੰਨੇ ਮਰਜ਼ੀ ਚੁਣੋ",
   "app.components.CustomFieldsForm.selectBetween": "* {minItems} ਅਤੇ {maxItems} ਵਿਕਲਪਾਂ ਵਿੱਚੋਂ ਚੁਣੋ",

--- a/front/app/translations/pl-PL.json
+++ b/front/app/translations/pl-PL.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Ta odpowiedź zostanie udostępniona tylko kierownikom projektów, a nie publicznie.",
   "app.components.CustomFieldsForm.otherArea": "Gdzieś indziej",
   "app.components.CustomFieldsForm.progressBarLabel": "Postęp",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% ukończono",
   "app.components.CustomFieldsForm.removeAnswer": "Usuń odpowiedź",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Wybierz dowolną liczbę",
   "app.components.CustomFieldsForm.selectBetween": "*Wybierz pomiędzy opcjami {minItems} i {maxItems} .",

--- a/front/app/translations/pt-BR.json
+++ b/front/app/translations/pt-BR.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Essa resposta será compartilhada apenas com os gerentes de projeto, e não com o público.",
   "app.components.CustomFieldsForm.otherArea": "Em outro lugar",
   "app.components.CustomFieldsForm.progressBarLabel": "Progresso",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% concluído",
   "app.components.CustomFieldsForm.removeAnswer": "Remover resposta",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Selecione quantos você quiser",
   "app.components.CustomFieldsForm.selectBetween": "*Selecione entre as opções {minItems} e {maxItems}",

--- a/front/app/translations/sv-SE.json
+++ b/front/app/translations/sv-SE.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Detta svar kommer endast att delas med projektledare och inte med allmänheten.",
   "app.components.CustomFieldsForm.otherArea": "Någon annanstans",
   "app.components.CustomFieldsForm.progressBarLabel": "Framsteg",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% klart",
   "app.components.CustomFieldsForm.removeAnswer": "Ta bort svar",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*Välj så många du vill",
   "app.components.CustomFieldsForm.selectBetween": "*Välj mellan alternativen {minItems} och {maxItems}",

--- a/front/app/translations/tr-TR.json
+++ b/front/app/translations/tr-TR.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*Bu cevap sadece proje yöneticileriyle paylaşılacak, kamuoyuyla paylaşılmayacaktır.",
   "app.components.CustomFieldsForm.otherArea": "Başka bir yerde",
   "app.components.CustomFieldsForm.progressBarLabel": "İlerleme",
-  "app.components.CustomFieldsForm.progressPercentage": "% {percentage} tamamlandı",
   "app.components.CustomFieldsForm.removeAnswer": "Cevabı kaldır",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "*İstediğiniz kadar seçin",
   "app.components.CustomFieldsForm.selectBetween": "* {minItems} ve {maxItems} seçenekleri arasından seçim yapın",

--- a/front/app/translations/ur-PK.json
+++ b/front/app/translations/ur-PK.json
@@ -186,7 +186,6 @@
   "app.components.CustomFieldsForm.notPublic1": "*اس جواب کا اشتراک صرف پروجیکٹ مینیجرز کے ساتھ کیا جائے گا، عوام کے ساتھ نہیں۔",
   "app.components.CustomFieldsForm.otherArea": "کہیں اور",
   "app.components.CustomFieldsForm.progressBarLabel": "پیش رفت",
-  "app.components.CustomFieldsForm.progressPercentage": "{percentage}% مکمل",
   "app.components.CustomFieldsForm.removeAnswer": "جواب ہٹا دیں۔",
   "app.components.CustomFieldsForm.selectAsManyAsYouLike": "* جتنے چاہیں منتخب کریں۔",
   "app.components.CustomFieldsForm.selectBetween": "* {minItems} اور {maxItems} اختیارات کے درمیان منتخب کریں",


### PR DESCRIPTION
# Changelog
## Changed
- "% completed" text is removed from survey and idea form 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
