### PR TITLE
Fix local content builder layouts

### DIFF
--- a/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/runner.rb
@@ -124,6 +124,11 @@ module MultiTenancy
         MultiTenancy::Seeds::Followers.new(runner: self).run
         MultiTenancy::Seeds::Events.new(runner: self).run
         MultiTenancy::Seeds::CommunityMonitor.new(runner: self).run
+
+        # Seeded projects/folders are created straight from the models, so they miss
+        # the SideFx hooks that normally put their descriptions on the Content
+        # Builder. Provision the layouts here instead, or the Content Builder 404s.
+        ContentBuilder::DescriptionLayoutService.new.provision_all_descriptions!
       end
 
       # @return [Array[String]] default seed locales


### PR DESCRIPTION
Freshly built local env was giving 404s for content builder layouts. Root cause from claude:

What's happening. Master (from the project-page-builder work) now requires every project to have two content_builder_layouts rows: project_description and project_page. Two hooks normally create them — SideFxProjectService#after_create (per project) and SideFxTenantService#after_apply_template (whole tenant). The dev seed triggers neither.

back/engines/commercial/multi_tenancy/db/seeds/projects.rb:23 calls Project.create! straight on the model, bypassing the SideFx service, and the seed runner calls MultiTenancy::Templates::ApplyService directly rather than going through the tenant SideFx (only ApplyTenantTemplateJob does that). So a freshly seeded tenant has zero project layouts, and ContentBuilderLayoutsController#show does a find_by! → 404. That's your "cannot find" error.

# Changelog
## Technical
- Fix content builder layouts for local development
