### PR TITLE
[Tan-8106] remove image in automatic email input publication if no image in input form

### DIFF
--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -20,7 +20,7 @@ module EmailCampaigns
     def preview_command(recipient, context)
       data = preview_service.preview_data(recipient)
       # check if the idea_images field is present and enabled in the custom form
-      image_field_presence = context.project.custom_form.custom_fields.find_by(code: 'idea_images_attributes')&.enabled
+      image_field_presence = context.project&.custom_form&.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled
 
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -20,7 +20,8 @@ module EmailCampaigns
     def preview_command(recipient, context)
       data = preview_service.preview_data(recipient)
       # check if the idea_images field is present and enabled in the custom form
-      image_field_presence = context.project&.custom_form&.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled
+      custom_form = context&.project&.custom_form
+      image_field_presence = custom_form.present? ? custom_form.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled : false
 
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -17,10 +17,10 @@ module EmailCampaigns
       }
     end
 
-    def preview_command(recipient, _context)
+    def preview_command(recipient, context)
       data = preview_service.preview_data(recipient)
       # check if the idea_images field is present and enabled in the custom form
-      image_field_presence = _context.project.custom_form.custom_fields.find_by(code: "idea_images_attributes")&.enabled
+      image_field_presence = context.project.custom_form.custom_fields.find_by(code: 'idea_images_attributes')&.enabled
 
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -19,6 +19,9 @@ module EmailCampaigns
 
     def preview_command(recipient, _context)
       data = preview_service.preview_data(recipient)
+      # check if the idea_images field is present and enabled in the custom form
+      image_field_presence = _context.project.custom_form.custom_fields.find_by(code: "idea_images_attributes")&.enabled
+
       {
         recipient: recipient,
         event_payload: {
@@ -28,7 +31,8 @@ module EmailCampaigns
           idea_url: data.idea.url,
           idea_images: [],
           input_term: 'idea',
-          project_title_multiloc: data.project.title_multiloc
+          project_title_multiloc: data.project.title_multiloc,
+          image_field_presence: image_field_presence
         }
       }
     end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/idea_published_mailer.rb
@@ -19,9 +19,13 @@ module EmailCampaigns
 
     def preview_command(recipient, context)
       data = preview_service.preview_data(recipient)
-      # check if the idea_images field is present and enabled in the custom form
-      custom_form = context&.project&.custom_form
-      image_field_presence = custom_form.present? ? custom_form.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled : false
+      # if context is present, check in the custom_form of the context if the idea_images field is present and enabled
+      # if no context, return true to show 'Add an image' by default
+      image_field_presence = if context.present?
+        IdeaCustomFieldsService.new(context.pmethod.custom_form).enabled_fields.any? { |f| f.code == 'idea_images_attributes' }
+      else
+        true
+      end
 
       {
         recipient: recipient,

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -92,6 +92,8 @@ module EmailCampaigns
       idea = activity.item
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
 
+      image_field_presence = idea.project.custom_form.custom_fields.find_by(code: "idea_images_attributes")&.enabled
+
       [{
         event_payload: {
           idea_id: idea.id,
@@ -105,7 +107,8 @@ module EmailCampaigns
             }
           end,
           input_term: idea.input_term,
-          project_title_multiloc: idea.project.title_multiloc
+          project_title_multiloc: idea.project.title_multiloc,
+          image_field_presence: image_field_presence
         }
       }]
     end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -92,7 +92,7 @@ module EmailCampaigns
       idea = activity.item
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
 
-      image_field_presence = idea.project.custom_form.custom_fields.find_by(code: 'idea_images_attributes')&.enabled
+      image_field_presence = idea.project&.custom_form&.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled
 
       [{
         event_payload: {

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -91,6 +91,7 @@ module EmailCampaigns
     def generate_commands(recipient:, activity:)
       idea = activity.item
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
+
       # check if the idea_images field is present and enabled in the custom form
       custom_form = idea.project&.custom_form
       image_field_presence = custom_form.present? ? custom_form.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled : false

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -93,8 +93,7 @@ module EmailCampaigns
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
 
       # check if the idea_images field is present and enabled in the custom form
-      custom_form = idea.project&.custom_form
-      image_field_presence = custom_form.present? ? custom_form.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled : false
+      image_field_presence = IdeaCustomFieldsService.new(idea.custom_form).enabled_fields.any? { |f| f.code == 'idea_images_attributes' }
 
       [{
         event_payload: {

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -91,8 +91,9 @@ module EmailCampaigns
     def generate_commands(recipient:, activity:)
       idea = activity.item
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
-
-      image_field_presence = idea.project&.custom_form&.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled
+      # check if the idea_images field is present and enabled in the custom form
+      custom_form = idea.project&.custom_form
+      image_field_presence = custom_form.present? ? custom_form.custom_fields&.find_by(code: 'idea_images_attributes')&.enabled : false
 
       [{
         event_payload: {

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/idea_published.rb
@@ -92,7 +92,7 @@ module EmailCampaigns
       idea = activity.item
       return [] if !idea.participation_method_on_creation.supports_public_visibility?
 
-      image_field_presence = idea.project.custom_form.custom_fields.find_by(code: "idea_images_attributes")&.enabled
+      image_field_presence = idea.project.custom_form.custom_fields.find_by(code: 'idea_images_attributes')&.enabled
 
       [{
         event_payload: {

--- a/back/engines/free/email_campaigns/app/views/email_campaigns/idea_published_mailer/campaign_mail.mjml
+++ b/back/engines/free/email_campaigns/app/views/email_campaigns/idea_published_mailer/campaign_mail.mjml
@@ -22,7 +22,7 @@
       </tr>
 
       <!-- (Conditional) Action item 1: Add an idea image -->
-      <% if event.idea_images.empty? %>
+      <% if event.image_field_presence && event.idea_images.empty? %>
         <tr>
           <td style="width:22px; padding-bottom:15px">
             <img style="vertical-align: middle; height: 22px;"

--- a/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
@@ -55,9 +55,23 @@ RSpec.describe EmailCampaigns::IdeaPublishedMailer do
       end
     end
 
+    it 'does not include Add an image if input form does not have image field' do
+      expect(body).not_to include("Add an image to increase visibility")
+    end
+
     it 'includes the CTA' do
       expect(body).to have_tag('a', with: { href: "http://example.org/en/ideas/#{input.slug}" }) do
         with_text(/Go to your idea/)
+      end
+    end
+
+    context 'with image field enabled in input form' do
+      let(:custom_form) { create(:custom_form, participation_context: input.project) }
+      let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+
+      it 'includes Add an image if input form has image field' do
+        expect(body).to include("Add an image")
+        expect(body).to include("to increase visibility")
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe EmailCampaigns::IdeaPublishedMailer do
     end
 
     it 'does not include Add an image if input form does not have image field' do
-      expect(body).not_to include("Add an image to increase visibility")
+      expect(body).not_to include('Add an image')
+      expect(body).not_to include('to increase visibility')
     end
 
     it 'includes the CTA' do
@@ -70,8 +71,8 @@ RSpec.describe EmailCampaigns::IdeaPublishedMailer do
       let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
 
       it 'includes Add an image if input form has image field' do
-        expect(body).to include("Add an image")
-        expect(body).to include("to increase visibility")
+        expect(body).to include('Add an image')
+        expect(body).to include('to increase visibility')
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
@@ -55,24 +55,33 @@ RSpec.describe EmailCampaigns::IdeaPublishedMailer do
       end
     end
 
-    it 'does not include Add an image if input form does not have image field' do
-      expect(body).not_to include('Add an image')
-      expect(body).not_to include('to increase visibility')
-    end
-
     it 'includes the CTA' do
       expect(body).to have_tag('a', with: { href: "http://example.org/en/ideas/#{input.slug}" }) do
         with_text(/Go to your idea/)
       end
     end
 
-    context 'with image field enabled in input form' do
-      let(:custom_form) { create(:custom_form, participation_context: input.project) }
-      let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+    context 'with custom form' do
+      let!(:custom_form) { create(:custom_form, participation_context: input.project) }
 
-      it 'includes Add an image if input form has image field' do
-        expect(body).to include('Add an image')
-        expect(body).to include('to increase visibility')
+      before { input.reload }
+
+      context 'without image field enabled in input form' do
+        # no image field created for the custom form
+        it 'does not include Add an image if input form does not have image field' do
+          expect(body).not_to include('Add an image')
+          expect(body).not_to include('to increase visibility')
+        end
+      end
+
+      context 'with image field enabled in input form' do
+        # image field is created for the custom form
+        let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+
+        it 'includes Add an image if input form has image field' do
+          expect(body).to include('Add an image')
+          expect(body).to include('to increase visibility')
+        end
       end
     end
 

--- a/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/idea_published_mailer_spec.rb
@@ -61,26 +61,67 @@ RSpec.describe EmailCampaigns::IdeaPublishedMailer do
       end
     end
 
+    # no custom_form, default fields are used, which includes the image field
+    it 'includes Add an image if input form has image field' do
+      expect(body).to include('Add an image')
+      expect(body).to include('to increase visibility')
+    end
+
     context 'with custom form' do
       let!(:custom_form) { create(:custom_form, participation_context: input.project) }
+      let!(:text_field) { create(:custom_field, resource: custom_form, input_type: 'text_multiloc', code: 'title_multiloc') }
 
       before { input.reload }
 
-      context 'without image field enabled in input form' do
-        # no image field created for the custom form
-        it 'does not include Add an image if input form does not have image field' do
+      context 'and image field enabled in input form' do
+        let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+
+        it 'includes Add an image if input form has an image field' do
+          expect(body).to include('Add an image')
+          expect(body).to include('to increase visibility')
+        end
+      end
+
+      context 'and without image field enabled in input form' do
+        it 'does not include Add an image if input form has no image field' do
           expect(body).not_to include('Add an image')
           expect(body).not_to include('to increase visibility')
         end
       end
+    end
 
-      context 'with image field enabled in input form' do
-        # image field is created for the custom form
-        let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+    context 'with proposal as an input' do
+      let!(:input) { create(:proposal, author: recipient) }
+      let!(:activity) { create(:activity, item: input, action: 'published') }
 
+      context 'and no custom form' do
+        # no custom_form, default fields are used, which includes the image field
         it 'includes Add an image if input form has image field' do
           expect(body).to include('Add an image')
           expect(body).to include('to increase visibility')
+        end
+      end
+
+      context 'and with custom form' do
+        let(:custom_form) { create(:custom_form, participation_context: input.creation_phase) }
+        let!(:text_field) { create(:custom_field, resource: custom_form, input_type: 'text_multiloc', code: 'title_multiloc') }
+
+        before { input.reload }
+
+        context 'and with image field enabled in input form' do
+          let!(:image_field) { create(:custom_field, resource: custom_form, input_type: 'image_files', code: 'idea_images_attributes') }
+
+          it 'includes Add an image if input form has an image field' do
+            expect(body).to include('Add an image')
+            expect(body).to include('to increase visibility')
+          end
+        end
+
+        context 'and without image field enabled in input form' do
+          it 'does not include Add an image if input form has no image field' do
+            expect(body).not_to include('Add an image')
+            expect(body).not_to include('to increase visibility')
+          end
         end
       end
     end


### PR DESCRIPTION
# Changelog
## Fixed
- remove "add an image" in publication of my input email if images are not allowed in input form

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
