### PR TITLE
Fix ordered list numbering in Quill editor

### DIFF
--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -119,7 +119,7 @@ class SanitizationService
       },
       list: {
         tags: %w[ol ul li],
-        attributes: %w[type]
+        attributes: %w[type start]
       },
       decoration: {
         tags: %w[b u i em strong],

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -49,6 +49,14 @@ describe SanitizationService do
       expect(service.sanitize(input, features)).to eq input
     end
 
+    it 'keeps the start attribute on ordered lists when list feature is enabled' do
+      # The frontend adds `start` to an ordered list that resumes after a bullet
+      # interruption so its numbering stays continuous, matching the editor.
+      input = '<ol start="2"><li>two</li><li>three</li></ol>'
+      features = [:list]
+      expect(service.sanitize(input, features)).to include('start="2"')
+    end
+
     it 'allows decoration to pass through when decoration feature is enabled' do
       input = <<~HTML
         <p>

--- a/front/app/components/UI/QuillEditor/utils.test.ts
+++ b/front/app/components/UI/QuillEditor/utils.test.ts
@@ -151,3 +151,52 @@ describe('Quill Character Count Consistency', () => {
     });
   });
 });
+
+describe('getHTML ordered-list numbering across bullet interruptions', () => {
+  // Quill stores an ordered list interrupted by bullets as one flat <ol> with a
+  // single running counter. getHTML splits it into separate <ul>/<ol> siblings,
+  // so the resumed <ol> needs `start` to keep numbering continuous like the editor.
+  const li = (type: string, text: string): string =>
+    `<li data-list="${type}">${text}</li>`;
+
+  const normalize = (flatHtml: string): string => {
+    const editor = createEditor('');
+    editor.root.innerHTML = flatHtml;
+    return getHTML(editor);
+  };
+
+  it('adds start= so a resumed ordered list continues the count', () => {
+    const flat = `<ol>${li('ordered', 'assa')}${li('bullet', 'dsdsdsd')}${li(
+      'bullet',
+      'sdsd'
+    )}${li('ordered', 'asas')}${li('ordered', 'asas')}</ol>`;
+
+    expect(normalize(flat)).toBe(
+      '<ol><li>assa</li></ol>' +
+        '<ul><li>dsdsdsd</li><li>sdsd</li></ul>' +
+        '<ol start="2"><li>asas</li><li>asas</li></ol>'
+    );
+  });
+
+  it('does not add start= to the first ordered segment', () => {
+    const flat = `<ol>${li('bullet', 'a')}${li('ordered', 'b')}</ol>`;
+
+    // The ordered run is the first ordered content, so it starts at 1 (no attr).
+    expect(normalize(flat)).toBe('<ul><li>a</li></ul><ol><li>b</li></ol>');
+  });
+
+  it('carries the count across multiple ordered/bullet alternations', () => {
+    const flat = `<ol>${li('ordered', '1')}${li('bullet', 'x')}${li(
+      'ordered',
+      '2'
+    )}${li('bullet', 'y')}${li('ordered', '3')}</ol>`;
+
+    expect(normalize(flat)).toBe(
+      '<ol><li>1</li></ol>' +
+        '<ul><li>x</li></ul>' +
+        '<ol start="2"><li>2</li></ol>' +
+        '<ul><li>y</li></ul>' +
+        '<ol start="3"><li>3</li></ol>'
+    );
+  });
+});

--- a/front/app/components/UI/QuillEditor/utils.ts
+++ b/front/app/components/UI/QuillEditor/utils.ts
@@ -164,6 +164,11 @@ const normalizeListTags = (html: string): string => {
     const fragment = document.createDocumentFragment();
     let current: HTMLUListElement | HTMLOListElement | null = null;
     let currentType = '';
+    // Running number of ordered items emitted from this original <ol>. Quill
+    // keeps one continuous counter even when bullets interrupt an ordered list;
+    // splitting into separate <ol>s would restart each at 1, so we carry the
+    // count forward with a `start` attribute to reproduce the editor's numbering.
+    let orderedCount = 0;
 
     items.forEach((li) => {
       const type = li.getAttribute('data-list') || 'ordered';
@@ -172,9 +177,13 @@ const normalizeListTags = (html: string): string => {
       if (type !== currentType) {
         currentType = type;
         current = document.createElement(type === 'bullet' ? 'ul' : 'ol');
+        if (type !== 'bullet' && orderedCount > 0) {
+          current.setAttribute('start', String(orderedCount + 1));
+        }
         fragment.appendChild(current);
       }
       current!.appendChild(li);
+      if (type !== 'bullet') orderedCount++;
     });
 
     ol.replaceWith(fragment);


### PR DESCRIPTION
# Changelog
## Fixed
- Ordering in Rich text editor when a numbered list is interrupted by bullet point list and then continued is now working correctly

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
