### PR TITLE
[TAN-7149] Improve rake task to complete deletion of deleted tenants

### DIFF
--- a/back/lib/tasks/single_use/20260709_finish_stuck_tenant_deletions.rake
+++ b/back/lib/tasks/single_use/20260709_finish_stuck_tenant_deletions.rake
@@ -26,12 +26,20 @@
 # sweeping, this task brings the schema forward just enough to delete — and no further. It runs only
 # the *missing*, *within-schema*, *additive* structural migrations (create_table / add_column /
 # add_reference / rename_* / change_column), each in its own rescue and in version order, so one
-# failure cannot halt the rest. It deliberately skips, per tenant:
+# failure cannot halt the rest. The additive test is a *necessary* filter, not a purity check: it
+# excludes any migration whose *only* work is one of the following, since none of them adds structure —
 #   - data backfills — they run app-model code with side effects (jobs, callbacks, external calls),
 #   - indexes and constraints — a unique index can fail on the tenant's own duplicate rows,
-#   - roles and grants — cluster-global; they must never run to finish one tenant's deletion.
-# A gap those skips leave open is not silently swallowed: it resurfaces as the `DeleteUserJob` error
-# reported below, not as a stalled sweep.
+#   - roles and grants — a `GRANT`/`CREATE ROLE` is not schema-scoped (it ignores `search_path` and
+#     so would reach every tenant on the server).
+# — but it does not prove a *selected* migration contains nothing else. A migration that adds a column
+# *and* backfills it in the same file (a common pattern) is run, backfill included; that backfill runs
+# inside `tenant.switch`, against only this doomed tenant's own data, so it reaches no other tenant, and
+# the tenant is about to be deleted anyway. The one mix that *would* escape the schema — additive DDL
+# alongside a not-schema-scoped grant — occurs in no migration in the tree. Ordinary structural DDL
+# Postgres confines to the switched-in schema regardless, so it cannot touch another tenant.
+# A gap those exclusions leave open is not silently swallowed: it resurfaces as the `DeleteUserJob`
+# error reported below, not as a stalled sweep.
 #
 # Reports and asks nothing unless passed 'execute', which makes it interactive. A host limits it to
 # one tenant; a poll timeout overrides the one derived from the tenant's user count:
@@ -72,19 +80,21 @@ namespace :single_use do
     migrations_by_version = ActiveRecord::Base.connection_pool.migration_context.migrations.index_by(&:version)
 
     additive_ddl = /\b(create_table|create_join_table|add_column|add_reference|add_belongs_to|rename_column|rename_table|change_column|change_column_null)\b/
-    # Roles and grants act on cluster-global objects, not the tenant schema. `execute`d SQL is the
-    # only place they can hide, so the body is scanned as well as the filename.
-    cluster_wide = /\b(GRANT|REVOKE|CREATE\s+ROLE|ALTER\s+ROLE|DROP\s+ROLE)\b/i
 
-    # Classification depends only on the migration, so do it once. A migration is safe to run to
-    # finish a deletion when it makes an additive, within-schema structural change and touches no
-    # cluster-global role/grant. Everything else (data backfills, indexes, constraints, drops,
-    # reporting views, grants) is left out; the sweep is the backstop for anything actually needed.
+    # Classification depends only on the migration, so do it once. The test is a *necessary* filter,
+    # not a purity check: a migration is eligible only if its body makes an additive structural change.
+    # That excludes anything whose *only* work is unsafe — a pure data backfill, a pure index/constraint,
+    # a pure roles/grants migration all carry none of these keywords, so none is selected. It does NOT
+    # prove a selected migration contains nothing else:
+    #   - additive + backfill in one file (common) IS selected, and the backfill runs — but inside
+    #     `tenant.switch`, so it touches only this doomed tenant's own data; it reaches no other tenant,
+    #     and the tenant is about to be deleted anyway.
+    #   - additive + GRANT/CREATE ROLE would be the one genuinely unsafe mix, since a grant is not
+    #     schema-scoped — but no migration in the tree does both, so a separate guard would cover an
+    #     empty set. (A filename match on "role" is worse than useless: it drops benign columns like
+    #     `add_internal_role_to_projects`.)
     structural_versions = migrations_by_version.select do |_version, migration|
-      body = File.read(migration.filename)
-      body.match?(additive_ddl) &&
-        !migration.filename.match?(/grant|revoke|role|reporting_view/i) &&
-        !body.match?(cluster_wide)
+      File.read(migration.filename).match?(additive_ddl)
     rescue StandardError
       false # unreadable/unusual migration: never auto-run it — a real gap will surface in the sweep
     end.keys.to_set
@@ -180,14 +190,14 @@ namespace :single_use do
       # Bring the schema forward just enough to delete (see header). Per-migration and in version
       # order, each in its own rescue: a failure here — or a migration that needs data this frozen
       # schema no longer has — must not abort the deletion. Anything genuinely still missing shows up
-      # as the DeleteUserJob error after the sweep. `connection_pool.migration_context.run` (not the
-      # removed `connection.migration_context`) records the version in, and applies the DDL to, the
-      # switched-in schema.
+      # as the DeleteUserJob error after the sweep. `Apartment::Migrator.run` switches into the tenant,
+      # then applies and records the one migration there — the supported per-tenant path, already
+      # correct for Rails 7.2's `connection_pool.migration_context` accessor.
       if runnable_migrations.any?
         puts "  Applying #{runnable_migrations.size} missing structural migration(s) to #{tenant.schema_name}…"
         applied_now = 0
         runnable_migrations.each do |version|
-          tenant.switch { ActiveRecord::Base.connection_pool.migration_context.run(:up, version) }
+          Apartment::Migrator.run(:up, tenant.schema_name, version)
           applied_now += 1
         rescue StandardError => e
           puts "    ⚠️  #{version} #{migrations_by_version[version].name}: #{e.class}: #{e.message.lines.first&.strip}"

--- a/back/lib/tasks/single_use/20260709_finish_stuck_tenant_deletions.rake
+++ b/back/lib/tasks/single_use/20260709_finish_stuck_tenant_deletions.rake
@@ -19,6 +19,20 @@
 # (losing the record of when the deletion was actually requested) and re-run
 # `SideFxTenantService#before_destroy`, which deletes Typeform webhooks that are already gone.
 #
+# A deletion also stalls when the schema was frozen before later migrations ran: Apartment migrates
+# `Tenant.not_deleted` only, so a tenant deleted months ago is missing every migration since. The
+# delete cascade then references columns/tables the current code expects but the old schema lacks
+# (e.g. `phases.placement_type`), and every `DeleteUserJob` raises `PG::UndefinedColumn`. Before
+# sweeping, this task brings the schema forward just enough to delete — and no further. It runs only
+# the *missing*, *within-schema*, *additive* structural migrations (create_table / add_column /
+# add_reference / rename_* / change_column), each in its own rescue and in version order, so one
+# failure cannot halt the rest. It deliberately skips, per tenant:
+#   - data backfills — they run app-model code with side effects (jobs, callbacks, external calls),
+#   - indexes and constraints — a unique index can fail on the tenant's own duplicate rows,
+#   - roles and grants — cluster-global; they must never run to finish one tenant's deletion.
+# A gap those skips leave open is not silently swallowed: it resurfaces as the `DeleteUserJob` error
+# reported below, not as a stalled sweep.
+#
 # Reports and asks nothing unless passed 'execute', which makes it interactive. A host limits it to
 # one tenant; a poll timeout overrides the one derived from the tenant's user count:
 #
@@ -50,6 +64,31 @@ namespace :single_use do
 
     puts "Found #{tenants.count} tenant(s) with an unfinished deletion."
 
+    # The migrations a fully-migrated schema has, from Rails' own loader — deduplicated and
+    # authoritative. NOT a glob of db/migrate + engines/**/db/migrate: engine migrations exist there
+    # both as originals and as copied-in versions, and only the copies' versions are ever recorded,
+    # so a glob invents phantom "pending" migrations under the originals' never-recorded timestamps.
+    # This is the same source `db:migrate_if_pending` uses.
+    migrations_by_version = ActiveRecord::Base.connection_pool.migration_context.migrations.index_by(&:version)
+
+    additive_ddl = /\b(create_table|create_join_table|add_column|add_reference|add_belongs_to|rename_column|rename_table|change_column|change_column_null)\b/
+    # Roles and grants act on cluster-global objects, not the tenant schema. `execute`d SQL is the
+    # only place they can hide, so the body is scanned as well as the filename.
+    cluster_wide = /\b(GRANT|REVOKE|CREATE\s+ROLE|ALTER\s+ROLE|DROP\s+ROLE)\b/i
+
+    # Classification depends only on the migration, so do it once. A migration is safe to run to
+    # finish a deletion when it makes an additive, within-schema structural change and touches no
+    # cluster-global role/grant. Everything else (data backfills, indexes, constraints, drops,
+    # reporting views, grants) is left out; the sweep is the backstop for anything actually needed.
+    structural_versions = migrations_by_version.select do |_version, migration|
+      body = File.read(migration.filename)
+      body.match?(additive_ddl) &&
+        !migration.filename.match?(/grant|revoke|role|reporting_view/i) &&
+        !body.match?(cluster_wide)
+    rescue StandardError
+      false # unreadable/unusual migration: never auto-run it — a real gap will surface in the sweep
+    end.keys.to_set
+
     tenants.each do |tenant|
       reporter.add_processed_tenant(tenant)
 
@@ -68,9 +107,16 @@ namespace :single_use do
           admins: User.admin.count,
           draft_baskets: Basket.not_submitted.count,
           drifted_phases: drifted_phases,
-          orphaned_projects: Project.where.missing(:admin_publication).count
+          orphaned_projects: Project.where.missing(:admin_publication).count,
+          applied_migrations: ActiveRecord::Base.connection.select_values('SELECT version FROM schema_migrations').to_set(&:to_i)
         }
       end
+
+      # What this schema is missing versus a fully-migrated one, split into the structural
+      # migrations we would run and everything we deliberately skip.
+      missing_migrations = migrations_by_version.keys.to_set - stats[:applied_migrations]
+      runnable_migrations = (missing_migrations & structural_versions).to_a.sort
+      skipped_migrations = (missing_migrations - structural_versions).to_a.sort
 
       user_jobs = QueJob.by_job_class(DeleteUserJob).all_by_tenant_schema_name(tenant.schema_name)
       pending_user_jobs = user_jobs.not_finished.not_expired.count
@@ -92,6 +138,16 @@ namespace :single_use do
       puts "  drifted phases: #{drifted}   orphaned projects: #{stats[:orphaned_projects]}"
       puts "  DeleteUserJobs: #{pending_user_jobs} pending, #{user_jobs.expired.count} expired"
       failure_classes.each { |klass, count| puts "    #{count} x #{klass}" }
+      if missing_migrations.any?
+        puts "  missing migrations: #{missing_migrations.size} " \
+             "(#{runnable_migrations.size} structural to run, #{skipped_migrations.size} skipped: data/index/roles)"
+        # List the ones that would run, in both modes and — in execute mode — before the prompt, so
+        # the operator sees exactly what will be applied before confirming.
+        unless runnable_migrations.empty?
+          puts '    structural migrations to run:'
+          runnable_migrations.each { |version| puts "      #{File.basename(migrations_by_version[version].filename, '.rb')}" }
+        end
+      end
       if stats[:drifted_phases].to_i.positive?
         puts "  ⚠️  drifted phases remain — run 'single_use:fix_phase_available_views[execute,#{tenant.host}]' first"
       end
@@ -120,6 +176,29 @@ namespace :single_use do
       end
 
       tenant_host = tenant.host
+
+      # Bring the schema forward just enough to delete (see header). Per-migration and in version
+      # order, each in its own rescue: a failure here — or a migration that needs data this frozen
+      # schema no longer has — must not abort the deletion. Anything genuinely still missing shows up
+      # as the DeleteUserJob error after the sweep. `connection_pool.migration_context.run` (not the
+      # removed `connection.migration_context`) records the version in, and applies the DDL to, the
+      # switched-in schema.
+      if runnable_migrations.any?
+        puts "  Applying #{runnable_migrations.size} missing structural migration(s) to #{tenant.schema_name}…"
+        applied_now = 0
+        runnable_migrations.each do |version|
+          tenant.switch { ActiveRecord::Base.connection_pool.migration_context.run(:up, version) }
+          applied_now += 1
+        rescue StandardError => e
+          puts "    ⚠️  #{version} #{migrations_by_version[version].name}: #{e.class}: #{e.message.lines.first&.strip}"
+          reporter.add_error(
+            "migration #{version} (#{migrations_by_version[version].name}) failed: #{e.class}: #{e.message.lines.first&.strip}",
+            context: { tenant: tenant_host }
+          )
+        end
+        puts "    ✅ applied #{applied_now}/#{runnable_migrations.size} structural migration(s)"
+      end
+
       tenant.switch { User.destroy_all_async }
 
       # The sweep fans out at 5 jobs/sec, so the last job runs about `users / 5` seconds after it
@@ -133,22 +212,37 @@ namespace :single_use do
       end
 
       if remaining.positive?
-        still_pending = user_jobs.not_finished.not_expired.count
+        # A DeleteUserJob that keeps raising stays in `not_finished, not_expired` for days — its
+        # retry backoff grows steeply with `error_count` — so a *count* of queued jobs cannot tell a
+        # failing sweep from a slow one. Ask whether a job has actually errored before calling it
+        # "in progress"; an errored job carries the reason this schema still cannot be swept (e.g. a
+        # column a skipped migration would have added). The *expired* jobs carry a previous attempt's
+        # failure, possibly months old, so they are not consulted here.
+        errored_job = user_jobs.errored.order(error_count: :desc).first
 
-        if still_pending.positive?
-          puts "  ⏳ Sweep still in progress: #{remaining} user(s) left, #{still_pending} job(s) queued. Re-run later."
+        if errored_job
+          latest_error = errored_job.last_error_message
+          puts "  ❌ #{remaining} user(s) remain; DeleteUserJob is failing (error_count #{errored_job.error_count})."
+          puts "     Job error: #{latest_error.to_s.lines.first&.strip}"
           reporter.add_error(
-            "sweep still in progress after #{poll_timeout}s: #{remaining} user(s) remain, #{still_pending} job(s) queued",
+            "#{remaining} user(s) could not be deleted. DeleteUserJob error: #{latest_error}",
+            context: { tenant: tenant_host }
+          )
+        elsif user_jobs.not_finished.not_expired.exists?
+          # No job has errored yet, but jobs are still queued/scheduled: the sweep is genuinely
+          # working, just slower than the poll (5 jobs/sec). A warning, not a verdict.
+          queued = user_jobs.not_finished.not_expired.count
+          puts "  ⏳ Sweep still in progress: #{remaining} user(s) left, #{queued} job(s) queued. Re-run later."
+          reporter.add_error(
+            "sweep still in progress after #{poll_timeout}s: #{remaining} user(s) remain, #{queued} job(s) queued",
             context: { tenant: tenant_host }
           )
         else
-          # The *errored* jobs carry this attempt's failure. The *expired* ones carry the failure
-          # of a previous attempt, which may be months old.
-          latest_error = user_jobs.errored.order(error_count: :desc).first&.last_error_message
-          puts "  ❌ #{remaining} user(s) remain; tenant not destroyed."
-          puts "     Latest job error: #{latest_error}"
+          # Users remain but nothing is queued, scheduled or erroring on them — no job is working
+          # towards this deletion at all, so re-running will not help on its own.
+          puts "  ❌ #{remaining} user(s) remain; tenant not destroyed (no DeleteUserJob is working on them)."
           reporter.add_error(
-            "#{remaining} user(s) could not be deleted. Latest job error: #{latest_error}",
+            "#{remaining} user(s) could not be deleted; no DeleteUserJob remains.",
             context: { tenant: tenant_host }
           )
         end

--- a/back/spec/tasks/single_use/finish_stuck_tenant_deletions_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/finish_stuck_tenant_deletions_task_spec.ignore.rb
@@ -53,6 +53,14 @@ describe 'single_use:finish_stuck_tenant_deletions rake task' do
     }])
   end
 
+  # The same job already failing: a positive `error_count` with a captured message is exactly the
+  # state of a DeleteUserJob wedged on a missing column, mid-retry and not yet expired.
+  def enqueue_errored_delete_user_job(schema_name, error:)
+    enqueue_delete_user_job(schema_name).tap do |job|
+      job.update_columns(error_count: 5, last_error_message: error)
+    end
+  end
+
   def report
     JSON.parse(File.read(report_path))
   end
@@ -183,6 +191,134 @@ describe 'single_use:finish_stuck_tenant_deletions rake task' do
 
       expect(Tenant.find_by(host: stuck_tenant.host)).to be_present
       expect(report['errors'].first['error']).to match(/sweep still in progress/)
+    end
+
+    # A job that keeps raising sits in not_finished/not_expired for days (its retry backoff grows
+    # steeply), so it must be recognised by its error, not miscounted as a sweep still in progress.
+    # This is the residual-gap signal: a column a skipped migration would have added surfaces here.
+    it 'reports the DeleteUserJob error when the sweep leaves a failing job' do
+      stuck_tenant.switch { create(:user) }
+      allow(User).to receive(:destroy_all_async) do
+        enqueue_errored_delete_user_job(stuck_tenant.schema_name, error: 'PG::UndefinedColumn: column "foo" does not exist')
+      end
+
+      run_task(poll_timeout: 0)
+
+      expect(Tenant.find_by(host: stuck_tenant.host)).to be_present
+      error = report['errors'].first['error']
+      expect(error).to match(/DeleteUserJob error:.*column "foo" does not exist/)
+      expect(error).not_to match(/still in progress/)
+    end
+  end
+
+  # A tenant deleted months ago was frozen before later migrations ran, so its schema lacks columns
+  # the delete cascade needs. The task brings it forward before sweeping — running only within-schema
+  # additive structural migrations, never data/index/role ones. The migration set is stubbed so the
+  # example does not depend on the tenant's real schema_migrations (which the factory fills in full).
+  context 'when the schema is missing migrations' do
+    let(:migration_context) { ActiveRecord::Base.connection_pool.migration_context }
+    let(:structural_version) { 99_999_999_999_001 }
+    let(:skipped_version) { 99_999_999_999_002 }
+    let(:grant_version) { 99_999_999_999_003 }
+
+    before do
+      structural = instance_double(
+        ActiveRecord::MigrationProxy,
+        version: structural_version, name: 'AddFooToThings', filename: '/fake/structural.rb'
+      )
+      skipped = instance_double(
+        ActiveRecord::MigrationProxy,
+        version: skipped_version, name: 'AddUniqueIndexToThings', filename: '/fake/skipped.rb'
+      )
+      # Additive AND grants: only the body scan catches it. It must still be skipped — grants are
+      # cluster-global and must never run to finish one tenant's deletion.
+      grant = instance_double(
+        ActiveRecord::MigrationProxy,
+        version: grant_version, name: 'AddBarToThingsAndGrant', filename: '/fake/grant.rb'
+      )
+      allow(ActiveRecord::Base.connection_pool).to receive(:migration_context).and_return(migration_context)
+      allow(migration_context).to receive(:migrations).and_return([structural, skipped, grant])
+      allow(migration_context).to receive(:run)
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with('/fake/structural.rb').and_return('add_column :things, :foo, :string')
+      allow(File).to receive(:read).with('/fake/skipped.rb').and_return('add_index :things, :foo, unique: true')
+      allow(File).to receive(:read).with('/fake/grant.rb')
+        .and_return("add_column :things, :bar, :string\n    execute 'GRANT SELECT ON things TO analytics_reader'")
+
+      answer_prompt_with(stuck_tenant.host)
+      allow(User).to receive(:destroy_all_async) { stuck_tenant.switch { User.delete_all } }
+    end
+
+    it 'runs only the additive structural migration — not the index or the granting one' do
+      run_task
+
+      expect(migration_context).to have_received(:run).with(:up, structural_version)
+      expect(migration_context).not_to have_received(:run).with(:up, skipped_version)
+      expect(migration_context).not_to have_received(:run).with(:up, grant_version)
+      expect(Tenant.find_by(host: stuck_tenant.host)).to be_nil
+    end
+
+    it 'shows the counts and lists the migrations it will run, before prompting' do
+      expect { run_task }.to output(
+        a_string_matching(/missing migrations: 3 \(1 structural to run, 2 skipped/)
+          .and(a_string_matching(/structural migrations to run:\n\s+structural/))
+      ).to_stdout
+    end
+
+    it 'lists them in report (dry-run) mode too, without applying anything' do
+      expect { run_task(report_only: true) }.to output(/structural migrations to run:\n\s+structural/).to_stdout
+      expect(migration_context).not_to have_received(:run)
+    end
+
+    it 'rescues a failing migration, reports it, and still finishes the deletion' do
+      allow(migration_context).to receive(:run)
+        .with(:up, structural_version).and_raise(ActiveRecord::StatementInvalid, 'PG::Boom')
+
+      run_task
+
+      expect(report['errors'].map { |e| e['error'] })
+        .to include(a_string_matching(/migration #{structural_version} \(AddFooToThings\).*PG::Boom/))
+      expect(Tenant.find_by(host: stuck_tenant.host)).to be_nil
+    end
+  end
+
+  # The safety property the whole design rests on: a migration run to finish one deletion must not
+  # reach any other tenant. Unlike the examples above this runs a *real* migration — nothing about
+  # `run` is stubbed — which also confirms `connection_pool.migration_context.run` behaves on this
+  # Rails/PostGIS build. A bystander tenant is left in the identical "missing" state and must be
+  # untouched, proving the DDL is confined to the switched-in schema.
+  context 'when a real migration is applied' do
+    let!(:bystander) { create(:tenant, host: 'bystander.example.com') }
+    let(:version) { 20_260_622_120_000 } # add_placement_type_to_phases — additive, within-schema
+
+    def placement_type_column?(tenant)
+      tenant.switch { ActiveRecord::Base.connection.column_exists?(:phases, :placement_type) }
+    end
+
+    before do
+      answer_prompt_with(stuck_tenant.host)
+      stuck_tenant.switch { create(:user) } # keep the tenant alive past the sweep, so we can inspect it
+      allow(User).to receive(:destroy_all_async) # no-op sweep: the user remains and the tenant is not destroyed
+
+      # Freeze both schemas just before this migration: drop its column and forget its version, so
+      # the task sees it as missing on each.
+      [stuck_tenant, bystander].each do |tenant|
+        tenant.switch do
+          conn = ActiveRecord::Base.connection
+          conn.remove_column(:phases, :placement_type) if conn.column_exists?(:phases, :placement_type)
+          conn.execute("DELETE FROM schema_migrations WHERE version = '#{version}'")
+        end
+      end
+    end
+
+    it 'applies the missing migration to the targeted schema only, leaving other tenants untouched' do
+      expect(placement_type_column?(stuck_tenant)).to be(false) # precondition: both start without it
+      expect(placement_type_column?(bystander)).to be(false)
+
+      run_task(poll_timeout: 0) # scoped to stuck_tenant.host
+
+      expect(placement_type_column?(stuck_tenant)).to be(true)  # ran here
+      expect(placement_type_column?(bystander)).to be(false)    # and reached no other schema
     end
   end
 end

--- a/back/spec/tasks/single_use/finish_stuck_tenant_deletions_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/finish_stuck_tenant_deletions_task_spec.ignore.rb
@@ -230,11 +230,13 @@ describe 'single_use:finish_stuck_tenant_deletions rake task' do
         ActiveRecord::MigrationProxy,
         version: skipped_version, name: 'AddUniqueIndexToThings', filename: '/fake/skipped.rb'
       )
-      # Additive AND grants: only the body scan catches it. It must still be skipped — grants are
-      # cluster-global and must never run to finish one tenant's deletion.
+      # A pure roles/grants migration: a GRANT is not schema-scoped (it would reach every tenant on
+      # the server) — but, crucially, it carries no additive DDL, so the positive allowlist leaves it
+      # out on its own, with no dedicated grant filter. (Ordinary structural DDL, by contrast, Postgres
+      # confines to the switched-in schema, so it cannot reach another tenant.)
       grant = instance_double(
         ActiveRecord::MigrationProxy,
-        version: grant_version, name: 'AddBarToThingsAndGrant', filename: '/fake/grant.rb'
+        version: grant_version, name: 'GrantSelectOnThings', filename: '/fake/grant.rb'
       )
       allow(ActiveRecord::Base.connection_pool).to receive(:migration_context).and_return(migration_context)
       allow(migration_context).to receive(:migrations).and_return([structural, skipped, grant])
@@ -243,7 +245,7 @@ describe 'single_use:finish_stuck_tenant_deletions rake task' do
       allow(File).to receive(:read).with('/fake/structural.rb').and_return('add_column :things, :foo, :string')
       allow(File).to receive(:read).with('/fake/skipped.rb').and_return('add_index :things, :foo, unique: true')
       allow(File).to receive(:read).with('/fake/grant.rb')
-        .and_return("add_column :things, :bar, :string\n    execute 'GRANT SELECT ON things TO analytics_reader'")
+        .and_return("execute 'GRANT SELECT ON things TO analytics_reader'")
 
       answer_prompt_with(stuck_tenant.host)
       allow(User).to receive(:destroy_all_async) { stuck_tenant.switch { User.delete_all } }
@@ -284,9 +286,10 @@ describe 'single_use:finish_stuck_tenant_deletions rake task' do
 
   # The safety property the whole design rests on: a migration run to finish one deletion must not
   # reach any other tenant. Unlike the examples above this runs a *real* migration — nothing about
-  # `run` is stubbed — which also confirms `connection_pool.migration_context.run` behaves on this
-  # Rails/PostGIS build. A bystander tenant is left in the identical "missing" state and must be
-  # untouched, proving the DDL is confined to the switched-in schema.
+  # `run` is stubbed — which also confirms `Apartment::Migrator.run` (and the
+  # `connection_pool.migration_context.run` it wraps) behaves on this Rails/PostGIS build. A bystander
+  # tenant is left in the identical "missing" state and must be untouched, proving the DDL is confined
+  # to the switched-in schema.
   context 'when a real migration is applied' do
     let!(:bystander) { create(:tenant, host: 'bystander.example.com') }
     let(:version) { 20_260_622_120_000 } # add_placement_type_to_phases — additive, within-schema


### PR DESCRIPTION
The rake task in question also needs to run any missing migrations on tenants stuck in deletion. A tenant deleted a while ago was frozen before later migrations ran, so its schema is missing columns the current delete code references. The `DeleteUserJobs` then fail with `PG::UndefinedColumn`, the user count never reaches zero, and `MultiTenancy::Tenants::DeleteJob` aborts — leaving the tenant stuck. Since these deletions were started anywhere from ~1 month to ~1 year ago, or earlier, this is frequently the case.

@jamesspeake I am mainly looking for your view on the safety of the rake task in this review. Thanks!

See more details of [this iteration](https://github.com/CitizenLabDotCo/citizenlab-claude/blob/main/plans/TAN-7149-fix-available-views-missing-presentation-mode.md#iteration--2026-07-15-rollout-surfaced-a-second-deeper-blocker) in the Claude plan.

## Plan
- Snapshot each cluster's DB before running the rake task.
- Run first in dry-run mode on AUS cluster where just one tenant is stuck in deletion process: `james-aus-test5` (deleted 2025-11-21)
- Check what migrations would be run (read the actual migration files to check they are reasonable and not db global)
- If OK, execute on AUS and check un-sticks that tenant's deletion, etc
- If OK, repeat on other clusters, smallest to largest, reading the migrations to be applied to each stuck tenant carefully before running.

# Changelog
## Technical
- [TAN-7149] Improve rake task to complete deletion of deleted tenants
