### PR TITLE
[TAN-8135] Cancel / handle queued jobs relating to deleted records

### DIFF
--- a/back/app/models/admin_publication.rb
+++ b/back/app/models/admin_publication.rb
@@ -61,6 +61,8 @@
 #  fk_rails_...  (scheduled_by_id => users.id)
 #
 class AdminPublication < ApplicationRecord
+  include PurgesRelatedQueJobs
+
   PUBLICATION_STATUSES = %w[draft published archived]
 
   belongs_to :publication, polymorphic: true, touch: true

--- a/back/app/models/concerns/purges_related_que_jobs.rb
+++ b/back/app/models/concerns/purges_related_que_jobs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Deletes queued Que jobs referencing this record when it is destroyed, so that e.g. a
+# delayed "phase started" email is cancelled when its phase is deleted before delivery.
+#
+# A model callback (not a SideFx service) because `dependent: :destroy` cascades bypass
+# SideFx entirely — deleting a project must also purge jobs of its phases. `after_destroy`
+# (not `before_destroy`/`after_commit`) because que_jobs lives in the same database, so
+# the purge commits or rolls back atomically with the record's deletion.
+#
+# Only include in low-cardinality models (phases, projects, ...): the purge issues one
+# query per destroyed record, so a model destroyed tens of thousands at a time in a
+# cascade would need batching instead.
+module PurgesRelatedQueJobs
+  extend ActiveSupport::Concern
+
+  included do
+    after_destroy :purge_related_que_jobs
+  end
+
+  private
+
+  def purge_related_que_jobs
+    QueJobsPurgeService.new.purge_related_to(self)
+  end
+end

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -68,6 +68,7 @@ class Phase < ApplicationRecord
   include Volunteering::VolunteeringPhase
   include DocumentAnnotation::DocumentAnnotationPhase
   include Files::FileAttachable
+  include PurgesRelatedQueJobs
 
   PRESCREENING_MODES = %w[flagged_only all].freeze
   PARTICIPATION_METHODS = ParticipationMethod::Base.all_methods.map(&:method_str).freeze

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -42,6 +42,7 @@
 class Project < ApplicationRecord
   include Files::FileAttachable
   include PgSearch::Model
+  include PurgesRelatedQueJobs
 
   attribute :preview_token, :string, default: -> { generate_preview_token }
 

--- a/back/app/models/que_job.rb
+++ b/back/app/models/que_job.rb
@@ -29,9 +29,19 @@
 require 'que/active_record/model'
 
 class QueJob < Que::ActiveRecord::Model
+  # Jobs that can still be executed: pending, scheduled, or errored-and-awaiting-retry.
+  # Finished and expired jobs are invisible to Que's poll query and never run again.
+  scope :runnable, -> { where(finished_at: nil, expired_at: nil) }
+
   class << self
     def by_job_id!(job_id)
       by_args({ job_id: }).sole
+    end
+
+    # Jobs whose serialized arguments reference the given GlobalID (uses the `related_gids`
+    # array stamped by ActiveJobRelatedGidsExtension; indexed via que_jobs_args_gin_idx).
+    def all_related_to_gid(gid)
+      by_args({ related_gids: [gid] })
     end
 
     def all_by_job_ids(job_ids)

--- a/back/app/services/que_jobs_purge_service.rb
+++ b/back/app/services/que_jobs_purge_service.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Deletes queued Que jobs that reference a record being destroyed, so they never run
+# against a record that no longer exists (e.g. a "phase started" email queued with an
+# 8-hour delay for a phase that is deleted before delivery).
+#
+# Only jobs that can still run are deleted (see QueJob.runnable). A job already picked up
+# by a worker is not stopped by this — delivery-time guards cover that race (see
+# EmailCampaigns::ApplicationMailer#context_deleted?).
+class QueJobsPurgeService
+  # Job classes for which "references a destroyed record" implies the job must not run.
+  # Deliberately an allowlist: some jobs reference records only incidentally, and jobs
+  # designed to run after a record's deletion take raw ids rather than GlobalIDs.
+  PURGEABLE_JOB_CLASSES = %w[
+    ActionMailer::MailDeliveryJob
+    ProcessScheduledPublicationTransitionsJob
+  ].freeze
+
+  def purge_related_to(record)
+    QueJob.runnable
+      .all_related_to_gid(record.to_global_id.to_s)
+      .where("args #>> '{0,job_class}' IN (?)", PURGEABLE_JOB_CLASSES)
+      .delete_all
+  end
+end

--- a/back/config/initializers/active_job_related_gids.rb
+++ b/back/config/initializers/active_job_related_gids.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 # Prepended to ActiveJob::Base (not ApplicationJob) so that ActionMailer::MailDeliveryJob
-# is covered too. `to_prepare` because the module is autoloaded; prepending is idempotent
-# across reloads.
+# is covered too.
+#
+# Not `ActiveSupport.on_load(:active_job)` (what Rails/ActiveSupportOnLoad wants):
+# ActiveJob::Base is already loaded when this initializer runs, so the hook would fire
+# immediately — before the autoloader can resolve ActiveJobRelatedGidsExtension (from
+# lib/) — and boot fails with NameError. `to_prepare` runs after boot (and on each app
+# reload, where prepending again is a no-op), when autoloading is available.
 Rails.application.config.to_prepare do
+  # rubocop:disable Rails/ActiveSupportOnLoad
   ActiveJob::Base.prepend(ActiveJobRelatedGidsExtension)
+  # rubocop:enable Rails/ActiveSupportOnLoad
 end

--- a/back/config/initializers/active_job_related_gids.rb
+++ b/back/config/initializers/active_job_related_gids.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Prepended to ActiveJob::Base (not ApplicationJob) so that ActionMailer::MailDeliveryJob
+# is covered too. `to_prepare` because the module is autoloaded; prepending is idempotent
+# across reloads.
+Rails.application.config.to_prepare do
+  ActiveJob::Base.prepend(ActiveJobRelatedGidsExtension)
+end

--- a/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
+++ b/back/engines/free/email_campaigns/app/mailers/email_campaigns/application_mailer.rb
@@ -10,6 +10,11 @@ module EmailCampaigns
     end
 
     def campaign_mail
+      if context_deleted?
+        Rails.logger.info("#{self.class.name}: skipping delivery, context #{command.dig(:event_payload, :context_gid)} no longer exists")
+        return
+      end
+
       I18n.with_locale(locale.locale_sym) do
         mail(default_config, &:mjml).tap do |message|
           message.mailgun_headers = mailgun_headers if self.class.delivery_method == :mailgun
@@ -52,6 +57,21 @@ module EmailCampaigns
 
     def event
       @event ||= to_deep_struct(command&.dig(:event_payload))
+    end
+
+    # The delivery job can sit in the queue (campaign delay, transient send failures +
+    # retries) while the record the email is about — its context, e.g. a phase — is
+    # destroyed. Queued jobs are purged on destroy (see PurgesRelatedQueJobs), but a job
+    # already picked up by a worker, or enqueued concurrently with the deletion, escapes
+    # the purge; this guard covers that race. Returning early from `campaign_mail` yields
+    # a NullMail, so nothing is delivered.
+    def context_deleted?
+      gid = command&.dig(:event_payload, :context_gid)
+      return false if gid.blank?
+
+      GlobalID::Locator.locate(gid).nil?
+    rescue ActiveRecord::RecordNotFound
+      true
     end
   end
 end

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_started.rb
@@ -98,6 +98,10 @@ module EmailCampaigns
       else
         [{
           event_payload: {
+            # Plain string, deliberately not the record itself: it must survive the
+            # phase's deletion so the delivery-time guard can detect it (see
+            # ApplicationMailer#context_deleted?).
+            context_gid: notification.phase.to_global_id.to_s,
             phase_title_multiloc: notification.phase.title_multiloc,
             phase_url: Frontend::UrlService.new.model_to_url(notification.phase, locale: Locale.new(recipient.locale)),
             project_title_multiloc: notification.project.title_multiloc,

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_upcoming.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/project_phase_upcoming.rb
@@ -81,6 +81,7 @@ module EmailCampaigns
       notification = activity.item
       [{
         event_payload: {
+          context_gid: notification.phase.to_global_id.to_s,
           phase_title_multiloc: notification.phase.title_multiloc,
           phase_url: Frontend::UrlService.new.model_to_url(notification.phase, locale: Locale.new(recipient.locale)),
           project_title_multiloc: notification.project.title_multiloc,

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/campaigns/voting_phase_started.rb
@@ -93,6 +93,7 @@ module EmailCampaigns
       if notification.phase.voting?
         [{
           event_payload: {
+            context_gid: notification.phase.to_global_id.to_s,
             project_url: Frontend::UrlService.new.model_to_url(notification.phase.project, locale: Locale.new(recipient.locale)),
             project_title_multiloc: notification.phase.project.title_multiloc,
             phase_title_multiloc: notification.phase.title_multiloc,

--- a/back/engines/free/email_campaigns/spec/mailers/project_phase_started_mailer_spec.rb
+++ b/back/engines/free/email_campaigns/spec/mailers/project_phase_started_mailer_spec.rb
@@ -57,6 +57,30 @@ RSpec.describe EmailCampaigns::ProjectPhaseStartedMailer do
       expect(mail_body(mail)).to match(Frontend::UrlService.new.unfollow_url(Follower.new(followable: project, user: recipient)))
     end
 
+    context 'when the phase was deleted while the delivery was queued' do
+      let(:deleted_phase_project) { create(:project_with_phases) }
+      let(:deleted_phase) { deleted_phase_project.phases.first }
+      let(:deleted_phase_notification) do
+        create(:project_phase_started, recipient: recipient, project: deleted_phase_project, phase: deleted_phase)
+      end
+      let(:command) do
+        activity = create(:activity, item: deleted_phase_notification, action: 'created')
+        campaign.generate_commands(
+          activity: activity,
+          recipient: recipient
+        ).first.merge({ recipient: recipient })
+      end
+
+      it 'skips the delivery' do
+        command # build the command (and its payload) before the phase disappears
+        deleted_phase.destroy!
+
+        expect(mailer.campaign_mail.message).to be_a(ActionMailer::Base::NullMail)
+        expect { mailer.campaign_mail.deliver_now }
+          .not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
+
     context 'with custom text' do
       let!(:global_campaign) do
         create(

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/campaigns/project_phase_started_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe EmailCampaigns::Campaigns::ProjectPhaseStarted do
         expect(command.dig(:event_payload, :phase_title_multiloc))
           .to eq project.phases.last.title_multiloc
       end
+
+      it 'includes the phase gid as context_gid, so queued deliveries can be purged and guarded when the phase is deleted' do
+        command = campaign.generate_commands(
+          recipient: notification_activity.item.recipient,
+          activity: notification_activity
+        ).first
+
+        expect(command.dig(:event_payload, :context_gid))
+          .to eq project.phases.last.to_global_id.to_s
+      end
     end
 
     context 'phase is a voting phase' do

--- a/back/lib/active_job_related_gids_extension.rb
+++ b/back/lib/active_job_related_gids_extension.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Stamps a top-level `related_gids` array into every job's serialized data: all GlobalIDs
+# found in the job's arguments, whether GlobalID-serialized ActiveRecord objects or plain
+# `gid://` strings embedded in denormalized payloads. Que stores the serialized hash as
+# `que_jobs.args[0]`, so the gids become queryable with an indexed `@>` containment query
+# (see `QueJob.all_related_to_gid`), which is what allows queued jobs to be purged when
+# the record they reference is destroyed (see `PurgesRelatedQueJobs`).
+module ActiveJobRelatedGidsExtension
+  def serialize
+    data = super
+    gids = collect_related_gids(data['arguments']).uniq
+    gids.empty? ? data : data.merge('related_gids' => gids)
+  end
+
+  private
+
+  def collect_related_gids(value)
+    case value
+    when Hash then value.values.flat_map { |nested| collect_related_gids(nested) }
+    when Array then value.flat_map { |nested| collect_related_gids(nested) }
+    when String then value.start_with?('gid://') ? [value] : []
+    else []
+    end
+  end
+end

--- a/back/spec/factories/que_jobs.rb
+++ b/back/spec/factories/que_jobs.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
       # holds the ActiveJob wrapper for any job enqueued through ActiveJob.
       active_job_class { 'TestJob' }
       job_arguments { [] }
+      related_gids { [] }
     end
 
     priority { 100 }
@@ -21,7 +22,7 @@ FactoryBot.define do
     kwargs { {} }
 
     args do
-      [{
+      active_job_data = {
         job_id: SecureRandom.uuid,
         locale: 'en',
         priority: nil,
@@ -34,7 +35,9 @@ FactoryBot.define do
         provider_job_id: nil,
         tenant_schema_name: tenant_schema_name,
         exception_executions: {}
-      }]
+      }
+      active_job_data[:related_gids] = related_gids if related_gids.present?
+      [active_job_data]
     end
   end
 end

--- a/back/spec/lib/active_job_related_gids_extension_spec.rb
+++ b/back/spec/lib/active_job_related_gids_extension_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActiveJobRelatedGidsExtension do
+  before do
+    stub_const('RelatedGidsTestJob', Class.new(ApplicationJob) do
+      def run(*args, **kwargs); end
+    end)
+  end
+
+  describe '#serialize' do
+    let(:user) { create(:user) }
+    let(:phase) { create(:phase) }
+
+    it 'stamps the gids of ActiveRecord arguments into related_gids' do
+      data = RelatedGidsTestJob.new(user).serialize
+      expect(data['related_gids']).to eq [user.to_global_id.to_s]
+    end
+
+    it 'collects gids nested in hashes and arrays, and plain gid:// strings, without duplicates' do
+      data = RelatedGidsTestJob.new(
+        user,
+        payload: { records: [phase], context_gid: phase.to_global_id.to_s }
+      ).serialize
+
+      expect(data['related_gids']).to contain_exactly(user.to_global_id.to_s, phase.to_global_id.to_s)
+    end
+
+    it 'omits related_gids when no arguments reference records' do
+      data = RelatedGidsTestJob.new('some-string', count: 3).serialize
+      expect(data).not_to have_key('related_gids')
+    end
+  end
+
+  describe 'enqueueing through Que', :active_job_que_adapter do
+    it 'persists related_gids in the que_jobs args' do
+      user = create(:user)
+      job = RelatedGidsTestJob.perform_later(user)
+
+      que_job = QueJob.by_job_id!(job.job_id)
+      expect(que_job.args['related_gids']).to eq [user.to_global_id.to_s]
+    end
+  end
+end

--- a/back/spec/models/concerns/purges_related_que_jobs_spec.rb
+++ b/back/spec/models/concerns/purges_related_que_jobs_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe PurgesRelatedQueJobs do
+  let(:project) { create(:project_with_phases) }
+  let(:phase) { project.phases.first }
+
+  def mail_job_for(record)
+    create(
+      :que_job,
+      active_job_class: 'ActionMailer::MailDeliveryJob',
+      related_gids: [record.to_global_id.to_s]
+    )
+  end
+
+  it 'purges related jobs when a phase is destroyed' do
+    job = mail_job_for(phase)
+
+    expect { phase.destroy! }.to change { QueJob.exists?(job.id) }.to(false)
+  end
+
+  it 'purges phase-related jobs when the project cascade-destroys its phases' do
+    # The cascade bypasses SideFx services entirely, which is why the purge is a model
+    # callback: destroying a project must still cancel its phases' queued jobs.
+    phase_job = mail_job_for(phase)
+    admin_publication_job = create(
+      :que_job,
+      active_job_class: 'ProcessScheduledPublicationTransitionsJob',
+      related_gids: [project.admin_publication.to_global_id.to_s]
+    )
+
+    project.destroy!
+
+    expect(QueJob.where(id: [phase_job.id, admin_publication_job.id])).to be_empty
+  end
+
+  it 'does not purge when the destroy transaction rolls back' do
+    job = mail_job_for(phase)
+
+    ActiveRecord::Base.transaction do
+      phase.destroy!
+      raise ActiveRecord::Rollback
+    end
+
+    expect(QueJob.exists?(job.id)).to be true
+    expect(Phase.exists?(phase.id)).to be true
+  end
+
+  it 'leaves unrelated jobs alone' do
+    other_job = mail_job_for(create(:phase))
+
+    phase.destroy!
+
+    expect(QueJob.exists?(other_job.id)).to be true
+  end
+end

--- a/back/spec/models/que_job_spec.rb
+++ b/back/spec/models/que_job_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe QueJob, :active_job_que_adapter do
     end
   end
 
+  describe '.runnable' do
+    it 'includes pending, scheduled and errored jobs, but not finished or expired ones' do
+      pending_job = create(:que_job)
+      scheduled_job = create(:que_job, run_at: 1.day.from_now)
+      errored_job = create(:que_job, error_count: 3, run_at: 1.hour.from_now)
+      create(:que_job, finished_at: Time.zone.now)
+      create(:que_job, expired_at: Time.zone.now)
+
+      expect(described_class.runnable).to contain_exactly(pending_job, scheduled_job, errored_job)
+    end
+  end
+
+  describe '.all_related_to_gid' do
+    it 'retrieves the jobs whose related_gids contain the gid' do
+      gid = 'gid://cl2-back/Phase/some-uuid'
+      related_job = create(:que_job, related_gids: [gid, 'gid://cl2-back/User/other-uuid'])
+      create(:que_job, related_gids: ['gid://cl2-back/Phase/another-uuid'])
+      create(:que_job)
+
+      expect(described_class.all_related_to_gid(gid)).to contain_exactly(related_job)
+    end
+  end
+
   describe '#active?' do
     let!(:que_job) do
       id = TestJob.perform_later.job_id

--- a/back/spec/services/que_jobs_purge_service_spec.rb
+++ b/back/spec/services/que_jobs_purge_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe QueJobsPurgeService do
+  subject(:service) { described_class.new }
+
+  let(:phase) { create(:phase) }
+  let(:gid) { phase.to_global_id.to_s }
+
+  def create_job(job_class: 'ActionMailer::MailDeliveryJob', gids: [gid], **attrs)
+    create(:que_job, active_job_class: job_class, related_gids: gids, **attrs)
+  end
+
+  describe '#purge_related_to' do
+    it 'deletes runnable allowlisted jobs referencing the record' do
+      mail_job = create_job
+      transition_job = create_job(job_class: 'ProcessScheduledPublicationTransitionsJob')
+
+      service.purge_related_to(phase)
+
+      expect(QueJob.where(id: [mail_job.id, transition_job.id])).to be_empty
+    end
+
+    it 'deletes errored jobs awaiting a retry' do
+      errored_job = create_job(error_count: 3, run_at: 1.day.from_now)
+
+      expect { service.purge_related_to(phase) }
+        .to change { QueJob.exists?(errored_job.id) }.to(false)
+    end
+
+    it 'keeps jobs of classes outside the allowlist' do
+      other_job = create_job(job_class: 'LogActivityJob')
+
+      service.purge_related_to(phase)
+
+      expect(QueJob.exists?(other_job.id)).to be true
+    end
+
+    it 'keeps finished and expired jobs' do
+      finished_job = create_job(finished_at: Time.zone.now)
+      expired_job = create_job(expired_at: Time.zone.now)
+
+      service.purge_related_to(phase)
+
+      expect(QueJob.where(id: [finished_job.id, expired_job.id]).count).to eq 2
+    end
+
+    it 'keeps jobs referencing other records' do
+      other_phase = create(:phase)
+      other_job = create_job(gids: [other_phase.to_global_id.to_s])
+
+      service.purge_related_to(phase)
+
+      expect(QueJob.exists?(other_job.id)).to be true
+    end
+  end
+end


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-8135] Cancel / handle queued jobs relating to deleted records. Should greatly reduce the risk of executing jobs that have become meaningless or erroneous due to the deletion of the item they relate to (e.g. job to send 'new phase started' email for a phase that has been deleted).
