### PR TITLE
Sentry fix: Change unsupported params to error 400 not 500

### DIFF
--- a/back/app/controllers/application_controller.rb
+++ b/back/app/controllers/application_controller.rb
@@ -168,15 +168,28 @@ class ApplicationController < ActionController::API
     # Inspired by https://github.com/davidcelis/api-pagination/blob/master/lib/grape/pagination.rb
     url = request.url.sub(/\?.*$/, '')
     pageparams = Rack::Utils.parse_nested_query(request.query_string)
-    pageparams['page'] ||= {}
+    # `page` may arrive as a scalar (`?page=foo`); reset it before assigning below.
+    pageparams['page'] = {} unless pageparams['page'].is_a?(Hash)
     pageparams['page']['number'] = number
     "#{url}?#{pageparams.to_param}"
   end
 
   def paginate(collection)
     collection
-      .page(params.dig(:page, :number))
-      .per(params.dig(:page, :size))
+      .page(pagination_param(:number))
+      .per(pagination_param(:size))
+  end
+
+  # Reads `page[number]`/`page[size]` defensively: malformed input yields nil so Kaminari
+  # uses its defaults instead of raising (`String does not have #dig`, `to_i` on Parameters).
+  def pagination_param(key)
+    page = params[:page]
+    return nil unless page.is_a?(ActionController::Parameters)
+
+    value = page[key]
+    return nil unless value.is_a?(String) || value.is_a?(Integer)
+
+    Integer(value, exception: false)
   end
 
   def remove_image_if_requested!(resource, resource_params, image_field_name)

--- a/back/app/controllers/web_api/v1/activities_controller.rb
+++ b/back/app/controllers/web_api/v1/activities_controller.rb
@@ -16,7 +16,7 @@ class WebApi::V1::ActivitiesController < ApplicationController
     when nil
       activities
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
 
     paginated_activities = paginate activities

--- a/back/app/controllers/web_api/v1/admin_publications_controller.rb
+++ b/back/app/controllers/web_api/v1/admin_publications_controller.rb
@@ -4,6 +4,17 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
   skip_before_action :authenticate_user
   before_action :set_admin_publication, only: %i[reorder show]
 
+  # A nested query param where a scalar is expected (`?publication_statuses[x]=y`) makes
+  # ActiveRecord raise "can't cast ActionController::Parameters". That's bad input → 400,
+  # not a 500. Other TypeErrors are re-raised.
+  rescue_from TypeError do |exception|
+    raise exception unless exception.message.start_with?("can't cast ActionController::Parameters")
+
+    # Can't re-raise as ApiError here (rescue_from doesn't chain), so render its payload directly.
+    error = ApiError.new(:invalid_filter_parameter, status: 400)
+    render json: error.payload, status: error.status
+  end
+
   def index
     admin_publications = policy_scope(AdminPublication.includes(:parent))
     admin_publications = apply_projects_listed_scope(admin_publications)
@@ -17,7 +28,7 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
     when nil
       admin_publications.order('admin_publications.ordering ASC')
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
 
     @admin_publications = paginate admin_publications
@@ -46,7 +57,8 @@ class WebApi::V1::AdminPublicationsController < ApplicationController
   # Returns non-draft admin_publications for specified IDs, ordered by order of the specified IDs.
   # => [AdminPublication]
   def index_select_and_order_by_ids
-    ids = params[:ids]
+    # ids should be an explicit id array; anything else is an empty selection
+    ids = params[:ids].is_a?(Array) ? params[:ids].select { |id| id.is_a?(String) } : []
 
     visible_not_draft_admin_publications = policy_scope(AdminPublication.includes(:parent)).not_draft
     admin_publications = admin_publication_filterer.filter(visible_not_draft_admin_publications,

--- a/back/app/controllers/web_api/v1/comments_controller.rb
+++ b/back/app/controllers/web_api/v1/comments_controller.rb
@@ -29,7 +29,7 @@ class WebApi::V1::CommentsController < ApplicationController
     when nil
       root_comments.order(lft: :asc)
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
     root_comments = paginate root_comments
 

--- a/back/app/controllers/web_api/v1/events_controller.rb
+++ b/back/app/controllers/web_api/v1/events_controller.rb
@@ -159,14 +159,23 @@ class WebApi::V1::EventsController < ApplicationController
 
   def finder_params
     params.tap do |p|
-      if p.key?(:ongoing_during)
-        p[:ongoing_during] = parse_date_range(p[:ongoing_during])
-      end
+      p[:ongoing_during] = parse_date_range(p[:ongoing_during]) if p.key?(:ongoing_during)
+      # EventsFinder passes these straight into SQL, so parse them here (nil drops the
+      # filter) — otherwise a bad value reaches Postgres and 500s instead of 400ing.
+      parse_date_param!(p, :ends_before_date)
+      parse_date_param!(p, :ends_on_or_after_date)
     end
   end
 
+  def parse_date_param!(params, key)
+    return unless params.key?(key)
+
+    parsed = parse_date(params[key])
+    parsed ? params[key] = parsed : params.delete(key)
+  end
+
   def parse_date_range(date_range)
-    raise ArgumentError, 'date_range must be a String' unless date_range.is_a?(String)
+    raise ApiError.new(:invalid_date_parameter, status: 400) unless date_range.is_a?(String)
 
     date_range = date_range.reverse.chomp('[').reverse.chomp(']')
     # Ignore extra items if there are more than two. ("Be conservative in what you send,
@@ -179,12 +188,15 @@ class WebApi::V1::EventsController < ApplicationController
   end
 
   def parse_date(date_str)
-    return nil unless date_str
+    return nil unless date_str.is_a?(String)
 
     date_str = date_str.strip
     return nil if date_str.in?(['null', ''])
 
-    AppConfiguration.timezone.parse(date_str)
+    AppConfiguration.timezone.parse(date_str) || raise(ApiError.new(:invalid_date_parameter, status: 400))
+  rescue ArgumentError, RangeError
+    # Malformed input: too long (>128 chars), null byte, out-of-range, etc.
+    raise ApiError.new(:invalid_date_parameter, status: 400)
   end
 
   def default_locale

--- a/back/app/controllers/web_api/v1/global_topics_controller.rb
+++ b/back/app/controllers/web_api/v1/global_topics_controller.rb
@@ -21,7 +21,7 @@ class WebApi::V1::GlobalTopicsController < ApplicationController
       when '-projects_count'
         global_topics.order_projects_count(:asc)
       else
-        raise 'Unsupported sort method'
+        raise ApiError.new(:unsupported_sort_parameter, status: 400)
       end
 
     global_topics = paginate global_topics

--- a/back/app/controllers/web_api/v1/groups_projects_controller.rb
+++ b/back/app/controllers/web_api/v1/groups_projects_controller.rb
@@ -15,7 +15,7 @@ class WebApi::V1::GroupsProjectsController < ApplicationController
     when nil
       @groups_projects
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
 
     @groups_projects = paginate @groups_projects

--- a/back/app/controllers/web_api/v1/input_topics_controller.rb
+++ b/back/app/controllers/web_api/v1/input_topics_controller.rb
@@ -25,7 +25,7 @@ class WebApi::V1::InputTopicsController < ApplicationController
       when '-ideas_count'
         input_topics.order_ideas_count(filter_ideas, direction: :desc)
       else
-        raise 'Unsupported sort method'
+        raise ApiError.new(:unsupported_sort_parameter, status: 400)
       end
 
     input_topics = paginate input_topics

--- a/back/app/controllers/web_api/v1/internal_comments_controller.rb
+++ b/back/app/controllers/web_api/v1/internal_comments_controller.rb
@@ -119,7 +119,7 @@ class WebApi::V1::InternalCommentsController < ApplicationController
     when '-new', nil
       comments.order(created_at: :asc)
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
   end
 

--- a/back/app/controllers/web_api/v1/invites_controller.rb
+++ b/back/app/controllers/web_api/v1/invites_controller.rb
@@ -42,7 +42,7 @@ class WebApi::V1::InvitesController < ApplicationController
       when nil
         @invites
       else
-        raise 'Unsupported sort method'
+        raise ApiError.new(:unsupported_sort_parameter, status: 400)
       end
     end
 

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -342,7 +342,7 @@ class WebApi::V1::UsersController < ApplicationController
     when nil
       @users
     else
-      raise 'Unsupported sort method'
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
   end
 

--- a/back/app/services/sort_by_params_service.rb
+++ b/back/app/services/sort_by_params_service.rb
@@ -42,7 +42,7 @@ class SortByParamsService
     when 'budget' then scope.order(budget: :desc)
     when '-budget' then scope.order(budget: :asc)
     else
-      raise "Unsupported sorting parameter #{params[:sort]}"
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
@@ -52,7 +52,7 @@ class SortByParamsService
     when 'start_at' then scope.order(start_at: :desc)
     when '-start_at' then scope.order(start_at: :asc)
     else
-      raise "Unsupported sorting parameter #{params[:sort]}"
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
   end
 
@@ -61,7 +61,7 @@ class SortByParamsService
     when 'acted_at' then scope.order(acted_at: :desc)
     when '-acted_at' then scope.order(acted_at: :asc)
     else
-      raise "Unsupported sorting parameter #{params[:sort]}"
+      raise ApiError.new(:unsupported_sort_parameter, status: 400)
     end
   end
 

--- a/back/spec/acceptance/admin_publications_spec.rb
+++ b/back/spec/acceptance/admin_publications_spec.rb
@@ -57,6 +57,13 @@ resource 'AdminPublication' do
         expect(response_data.pluck(:id)).not_to include(hidden_project.admin_publication.id)
       end
 
+      example 'returns 400 when a filter param is a nested hash instead of a scalar', document: false do
+        # `?publication_statuses[x]=y` reaches `where(...)` as ActionController::Parameters,
+        # which raises "can't cast ActionController::Parameters" (previously a 500).
+        do_request(publication_statuses: { injected: 'x' })
+        expect(status).to eq(400)
+      end
+
       example 'List all top-level admin publications' do
         do_request(depth: 0)
         expect(response_data.size).to eq 7
@@ -380,6 +387,13 @@ resource 'AdminPublication' do
 
       example 'Returns empty data when no records are found', document: false do
         do_request(ids: ['not_an_admin_publication_id'])
+
+        expect(status).to eq(200)
+        expect(response_data).to be_empty
+      end
+
+      example 'Returns empty data when the ids param is missing', document: false do
+        do_request
 
         expect(status).to eq(200)
         expect(response_data).to be_empty

--- a/back/spec/acceptance/events_spec.rb
+++ b/back/spec/acceptance/events_spec.rb
@@ -100,6 +100,28 @@ resource 'Events' do
       end
     end
 
+    context 'with malformed parameters' do
+      example 'returns 400 for an unsupported sort parameter', document: false do
+        do_request(sort: "start_at; WAITFOR DELAY '00:00:07'")
+        assert_status 400
+      end
+
+      example 'returns 400 for an unparseable ends_before_date', document: false do
+        do_request(ends_before_date: 'not-a-real-date')
+        assert_status 400
+      end
+
+      example 'returns 400 for an oversized ongoing_during value', document: false do
+        do_request(ongoing_during: "[#{'9' * 180},null]")
+        assert_status 400
+      end
+
+      example 'ignores a malformed nested page parameter instead of erroring', document: false do
+        do_request(page: { number: { injected: '1' } })
+        assert_status 200
+      end
+    end
+
     context 'when the user registered to some events' do
       before { header_token_for(user) }
 

--- a/back/spec/services/sort_by_params_service_spec.rb
+++ b/back/spec/services/sort_by_params_service_spec.rb
@@ -478,6 +478,16 @@ describe SortByParamsService do
         expect(result_record_ids).to eq expected_record_ids
       end
     end
+
+    describe 'an unsupported sort parameter' do
+      let(:sort) { "start_at; WAITFOR DELAY '00:00:07'" }
+
+      it 'raises a 400 ApiError instead of a bare RuntimeError' do
+        expect { result_record_ids }.to raise_error(ApiError) do |error|
+          expect(error.status).to eq 400
+        end
+      end
+    end
   end
 
   describe 'sort_activities' do
@@ -512,6 +522,16 @@ describe SortByParamsService do
 
       it 'returns the sorted records' do
         expect(result_record_ids).to eq expected_record_ids
+      end
+    end
+
+    describe 'an unsupported sort parameter' do
+      let(:sort) { 'nonsense' }
+
+      it 'raises a 400 ApiError instead of a bare RuntimeError' do
+        expect { result_record_ids }.to raise_error(ApiError) do |error|
+          expect(error.status).to eq 400
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes a bunch of sentry issues related to malformed request parameters (~9,300 events/week). A large family of endpoints crashed with a 500 whenever a client (mostly bots/scanners, plus some genuinely malformed requests) sent junk in query parameters — an unrecognised sort value, a nested hash where a scalar filter was expected, an unparseable or oversized date, a null byte, or a malformed page parameter. 

These are client errors, not server faults, so the fix makes them correctly return 400 (or, for bad pagination, quietly fall back to defaults and return 200) instead of raising an exception that drowns real regressions in Sentry noise. 

# Changelog
## Technical
- Sentry fix: Change unsupported params to error 400 not 500
