### PR TITLE
Sentry Fix: Strip empty IP in X-Forwarded for

### DIFF
--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -28,7 +28,7 @@ module Cl2Back
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks middleware])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/back/config/initializers/sanitize_forwarded_for.rb
+++ b/back/config/initializers/sanitize_forwarded_for.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require Rails.root.join('lib/middleware/sanitize_forwarded_for')
+
+# Must run before ActionDispatch::RemoteIp so malformed headers are cleaned before IP resolution.
+Rails.application.config.middleware.insert_before(
+  ActionDispatch::RemoteIp,
+  Middleware::SanitizeForwardedFor
+)

--- a/back/lib/middleware/sanitize_forwarded_for.rb
+++ b/back/lib/middleware/sanitize_forwarded_for.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Middleware
+  # Strips blank entries from forwarded-IP headers before Rails resolves the remote IP.
+  # A malformed `X-Forwarded-For` (e.g. `"1.2.3.4, "`) otherwise feeds an empty string to
+  # cloudfront-rails' `IPAddr.new`, raising IPAddr::InvalidAddressError as a 500 that runs
+  # in middleware, before any controller, so `rescue_from` can't catch it.
+  class SanitizeForwardedFor
+    FORWARDED_HEADERS = %w[HTTP_X_FORWARDED_FOR HTTP_CLIENT_IP HTTP_X_CLIENT_IP].freeze
+
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      FORWARDED_HEADERS.each { |header| sanitize!(env, header) }
+      @app.call(env)
+    end
+
+    private
+
+    def sanitize!(env, header)
+      value = env[header]
+      return unless value.is_a?(String)
+
+      cleaned = value.split(',').map(&:strip).reject(&:empty?)
+      if cleaned.empty?
+        env.delete(header)
+      else
+        env[header] = cleaned.join(', ')
+      end
+    end
+  end
+end

--- a/back/spec/middleware/sanitize_forwarded_for_spec.rb
+++ b/back/spec/middleware/sanitize_forwarded_for_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'middleware/sanitize_forwarded_for'
+
+describe Middleware::SanitizeForwardedFor do
+  subject(:middleware) { described_class.new(downstream) }
+
+  let(:downstream) { ->(_env) { [200, {}, ['ok']] } }
+
+  def env_after(headers)
+    env = Rack::MockRequest.env_for('/', headers)
+    middleware.call(env)
+    env
+  end
+
+  it 'removes blank entries from X-Forwarded-For' do
+    env = env_after('HTTP_X_FORWARDED_FOR' => '1.2.3.4, , 5.6.7.8')
+    expect(env['HTTP_X_FORWARDED_FOR']).to eq('1.2.3.4, 5.6.7.8')
+  end
+
+  it 'deletes the header when only blank entries remain' do
+    env = env_after('HTTP_X_FORWARDED_FOR' => ' , ,')
+    expect(env).not_to have_key('HTTP_X_FORWARDED_FOR')
+  end
+
+  it 'leaves a well-formed header unchanged' do
+    env = env_after('HTTP_X_FORWARDED_FOR' => '1.2.3.4, 5.6.7.8')
+    expect(env['HTTP_X_FORWARDED_FOR']).to eq('1.2.3.4, 5.6.7.8')
+  end
+
+  it 'also sanitizes Client-Ip' do
+    env = env_after('HTTP_CLIENT_IP' => ' , 9.9.9.9')
+    expect(env['HTTP_CLIENT_IP']).to eq('9.9.9.9')
+  end
+
+  it 'is a no-op when the forwarded headers are absent' do
+    expect { env_after({}) }.not_to raise_error
+  end
+end


### PR DESCRIPTION
Fixes a load of sentry events relating to blank IP address in the proxy check (~3,520 events/week). A malformed X-Forwarded-For header (an empty entry from a leading/trailing/double comma, usually spoofed or from a misconfigured proxy) left a blank IP string that the cloudfront-rails trusted-proxy middleware fed to IPAddr.new, raising IPAddr::InvalidAddressError. 

Because this happens in Rack middleware before any controller, it can't be caught by rescue_from, so the fix is a small middleware that strips blank entries from the forwarded-IP headers before Rails resolves the remote IP. 

# Changelog
## Technical
- Strip empty IPs in X-Forwarded for headers