### PR TITLE
Sentry Fix: Fixed common posthog retry error

### DIFF
--- a/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
+++ b/back/engines/commercial/posthog_integration/lib/posthog_integration/post_hog/client.rb
@@ -53,13 +53,13 @@ module PosthogIntegration
 
       private
 
-      def retry_request(retries: 0)
+      def retry_request(retries: 0, &)
         response = yield
         return response if response.status.code != 429 || retries <= 0
 
-        # Retry after waiting between 30 seconds and 2 minutes
+        # Retry after 30s–2min. `&` forwards the block so the recursion can still yield.
         sleep rand(30..120)
-        retry_request(retries: retries - 1)
+        retry_request(retries: retries - 1, &)
       end
 
       def http

--- a/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
+++ b/back/engines/commercial/posthog_integration/spec/lib/posthog_integration/post_hog/client_spec.rb
@@ -87,6 +87,19 @@ describe PosthogIntegration::PostHog::Client do
       expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.to raise_error(PosthogIntegration::PostHog::Client::ApiError)
       expect(posthog).to have_received(:retry_request).twice
     end
+
+    # Regression: retry_request used to drop its block on recursion, so a real 429 retry
+    # raised LocalJumpError. Runs unstubbed here so a dropped block would resurface.
+    it 'retries the real block on 429 and then succeeds' do
+      stub_request(:get, "https://example.com/api/projects/#{project_id}/persons?distinct_id=#{user.id}")
+        .with(headers: { 'Authorization' => "Bearer #{api_key}" })
+        .to_return(
+          { status: 429 },
+          { status: 200, body: persons_response(person_id), headers: { 'Content-Type' => 'application/json' } }
+        )
+
+      expect { posthog.delete_person_by_distinct_id(user.id, retries: 3) }.not_to raise_error
+    end
   end
 
   def stub_response


### PR DESCRIPTION
Fixes a common sentry error - PostHog retry dropped its block (~2,500 events/week). RemoveUserFromPosthogJob failed with LocalJumpError: no block given every time PostHog returned a 429 rate-limit response, because the client's retry_request method recursed on retry without forwarding its block. The one-line fix forwards the block so the retry can actually re-run the request.

# Changelog
## Technical
- Fix Posthog retry sentry error