### PR TITLE
TAN-8160 Add space display to project and folders list

### DIFF
--- a/back/app/controllers/web_api/v1/folders_controller.rb
+++ b/back/app/controllers/web_api/v1/folders_controller.rb
@@ -35,7 +35,7 @@ class WebApi::V1::FoldersController < ApplicationController
 
     project_folders = FoldersFinderAdminService.execute(project_folders, params)
     project_folders = paginate project_folders
-    project_folders = project_folders.includes(:admin_publication, :images)
+    project_folders = project_folders.includes(:admin_publication, :images, :space)
 
     moderators_per_folder = UserRoleService.new.moderators_per_folder(
       project_folders.pluck(:id)

--- a/back/app/controllers/web_api/v1/projects_controller.rb
+++ b/back/app/controllers/web_api/v1/projects_controller.rb
@@ -174,7 +174,7 @@ class WebApi::V1::ProjectsController < ApplicationController
     projects = ProjectsFinderAdminService.execute(projects, params, current_user: current_user)
 
     projects = paginate projects
-    projects = projects.includes(phases: [:report, :custom_form, { permissions: [:groups], project: :admin_publication }], admin_publication: [:parent], project_images: [], groups: [])
+    projects = projects.includes(:space, phases: [:report, :custom_form, { permissions: [:groups], project: :admin_publication }], admin_publication: [:parent], project_images: [], groups: [])
 
     moderators_per_project = UserRoleService.new.moderators_per_project(
       projects.pluck(:id)

--- a/back/app/serializers/web_api/v1/folder_mini_serializer.rb
+++ b/back/app/serializers/web_api/v1/folder_mini_serializer.rb
@@ -3,6 +3,10 @@
 class WebApi::V1::FolderMiniSerializer < WebApi::V1::BaseSerializer
   attributes :title_multiloc, :space_id
 
+  attribute :space_title_multiloc do |object|
+    object.space&.title_multiloc
+  end
+
   attribute :visible_projects_count do |object, params|
     params.dig(:visible_children_count_by_parent_id, object.admin_publication.id)
   end

--- a/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
+++ b/back/app/serializers/web_api/v1/project_mini_admin_serializer.rb
@@ -40,6 +40,10 @@ class WebApi::V1::ProjectMiniAdminSerializer < WebApi::V1::BaseSerializer
     object.folder&.title_multiloc
   end
 
+  attribute :space_title_multiloc do |object|
+    object.space&.title_multiloc
+  end
+
   has_one :folder
 
   has_one :space

--- a/back/spec/serializers/folder_mini_serializer_spec.rb
+++ b/back/spec/serializers/folder_mini_serializer_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe WebApi::V1::FolderMiniSerializer do
+  let!(:folder) { create(:project_folder) }
+  let!(:user) { create(:user) }
+
+  let(:serialized_folder) do
+    described_class
+      .new(folder, params: { current_user: user })
+      .serializable_hash
+  end
+
+  it 'serializes title_multiloc' do
+    expect(serialized_folder.dig(:data, :attributes, :title_multiloc)).to eq(folder.title_multiloc)
+  end
+
+  it 'serializes space_id and space_title_multiloc when the folder belongs to a space' do
+    space = create(:space)
+    folder.update!(space: space)
+
+    expect(serialized_folder.dig(:data, :attributes, :space_id)).to eq(space.id)
+    expect(serialized_folder.dig(:data, :attributes, :space_title_multiloc)).to eq(space.title_multiloc)
+  end
+
+  it 'serializes a nil space_title_multiloc when the folder has no space' do
+    expect(serialized_folder.dig(:data, :attributes, :space_id)).to be_nil
+    expect(serialized_folder.dig(:data, :attributes, :space_title_multiloc)).to be_nil
+  end
+end

--- a/back/spec/serializers/project_mini_admin_serializer_spec.rb
+++ b/back/spec/serializers/project_mini_admin_serializer_spec.rb
@@ -29,6 +29,19 @@ describe WebApi::V1::ProjectMiniAdminSerializer do
     expect(serialized_project.dig(:data, :attributes, :folder_title_multiloc)).to eq(folder.title_multiloc)
   end
 
+  it 'serializes space_title_multiloc when the project belongs to a space' do
+    space = create(:space)
+    folder.update!(space: space)
+    project.reload.update!(space: space)
+
+    serialized = described_class.new(project, params: { current_user: user }).serializable_hash
+    expect(serialized.dig(:data, :attributes, :space_title_multiloc)).to eq(space.title_multiloc)
+  end
+
+  it 'serializes a nil space_title_multiloc when the project has no space' do
+    expect(serialized_project.dig(:data, :attributes, :space_title_multiloc)).to be_nil
+  end
+
   it 'includes phases' do
     project2 = create(:project_with_active_ideation_phase)
     serialized_project2 = described_class

--- a/front/app/api/project_folders_mini/types.ts
+++ b/front/app/api/project_folders_mini/types.ts
@@ -25,6 +25,7 @@ export interface MiniProjectFolder {
     visible_projects_count: number;
     publication_status: PublicationStatus;
     space_id: string | null;
+    space_title_multiloc: Multiloc | null;
   };
   relationships: {
     moderators: {

--- a/front/app/api/projects_mini_admin/types.ts
+++ b/front/app/api/projects_mini_admin/types.ts
@@ -71,6 +71,7 @@ export type ProjectMiniAdminData = {
     first_phase_start_date: string | null;
     first_published_at: string | null;
     folder_title_multiloc: Multiloc | null;
+    space_title_multiloc: Multiloc | null;
     last_phase_end_date: string | null;
     listed: boolean;
     publication_status: PublicationStatus;

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.test.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+
+import {
+  Table as TableComponent,
+  Tbody,
+} from '@citizenlab/cl2-component-library';
+
+import { MiniProjectFolder } from 'api/project_folders_mini/types';
+
+import { TRole } from 'utils/permissions/roles';
+import { render, screen, userEvent } from 'utils/testUtils/rtl';
+
+import Row from './Row';
+
+let mockAuthUserRoles: TRole[] = [];
+let mockSpacesEnabled = true;
+
+jest.mock('api/me/useAuthUser', () => () => ({
+  data: {
+    data: {
+      id: 'me',
+      type: 'user',
+      attributes: {
+        first_name: 'Test',
+        last_name: 'User',
+        roles: mockAuthUserRoles,
+        highest_role: 'user',
+      },
+    },
+  },
+}));
+
+jest.mock('api/project_folder_images/useProjectFolderImage', () => () => ({
+  data: undefined,
+}));
+
+// usePermission() reads the app configuration; use the standard manual mock.
+jest.mock('api/app_configuration/useAppConfiguration');
+
+jest.mock('hooks/useFeatureFlag', () => () => mockSpacesEnabled);
+
+const mockPush = jest.fn();
+jest.mock('utils/cl-router/history', () => ({
+  push: (...args: unknown[]) => mockPush(...args),
+}));
+
+const folder: MiniProjectFolder = {
+  id: 'folder-1',
+  type: 'folder_mini',
+  attributes: {
+    title_multiloc: { en: 'Test folder' },
+    visible_projects_count: 3,
+    publication_status: 'published',
+    space_id: 'space-1',
+    space_title_multiloc: { en: 'Test space' },
+  },
+  relationships: {
+    moderators: { data: [] },
+    images: { data: [] },
+  },
+};
+
+const renderRow = () =>
+  render(
+    <TableComponent>
+      <Tbody>
+        <Row folder={folder} />
+      </Tbody>
+    </TableComponent>
+  );
+
+describe('Folders table Row — space link', () => {
+  beforeEach(() => {
+    mockAuthUserRoles = [];
+    mockSpacesEnabled = true;
+    mockPush.mockClear();
+  });
+
+  it('navigates to the space when a moderator of that space clicks it', async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'space-1' }];
+    renderRow();
+
+    await userEvent.click(screen.getByText('Test space'));
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/projects/spaces/space-1');
+  });
+
+  it('navigates to the space when an admin clicks it', async () => {
+    mockAuthUserRoles = [{ type: 'admin' }];
+    renderRow();
+
+    await userEvent.click(screen.getByText('Test space'));
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/projects/spaces/space-1');
+  });
+
+  it('falls through to the folder when a non-moderator clicks the space', async () => {
+    mockAuthUserRoles = [];
+    renderRow();
+
+    await userEvent.click(screen.getByText('Test space'));
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/projects/folders/folder-1');
+    expect(mockPush).not.toHaveBeenCalledWith('/admin/projects/spaces/space-1');
+  });
+
+  it('does not link to the space for a moderator of a different space', async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'other-space' }];
+    renderRow();
+
+    await userEvent.click(screen.getByText('Test space'));
+
+    expect(mockPush).not.toHaveBeenCalledWith('/admin/projects/spaces/space-1');
+  });
+
+  it('does not show the space when the spaces feature flag is disabled', () => {
+    mockSpacesEnabled = false;
+    renderRow();
+
+    expect(screen.queryByText('Test space')).not.toBeInTheDocument();
+  });
+});

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
@@ -5,6 +5,7 @@ import {
   Tr,
   Td,
   Text,
+  Icon,
   Spinner,
   colors,
 } from '@citizenlab/cl2-component-library';
@@ -14,6 +15,7 @@ import useProjectFolderImage from 'api/project_folder_images/useProjectFolderIma
 import { MiniProjectFolder } from 'api/project_folders_mini/types';
 import { IUserData } from 'api/users/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import FolderMoreActionsMenu from 'containers/Admin/projects/projectFolders/components/ProjectFolderRow/FolderMoreActionsMenu';
@@ -23,6 +25,7 @@ import GanttItemIconBar from 'components/UI/GanttChart/components/GanttItemIconB
 
 import { useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
+import { usePermission } from 'utils/permissions';
 
 import { PUBLICATION_STATUS_LABELS } from '../../_shared/constants';
 import ManagerBubbles from '../../_shared/ManagerBubbles';
@@ -38,6 +41,12 @@ const StyledTd = styled(Td)`
       text-decoration: underline;
     }
   }
+  .folder-table-row-space {
+    cursor: pointer;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 `;
 
 interface Props {
@@ -48,6 +57,7 @@ interface Props {
 const Row = ({ folder, moderatorsById }: Props) => {
   const localize = useLocalize();
   const { formatMessage } = useIntl();
+  const spacesEnabled = useFeatureFlag({ name: 'spaces' });
   const [isBeingDeleted, setIsBeingDeleted] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -63,7 +73,14 @@ const Row = ({ folder, moderatorsById }: Props) => {
     ? moderatorIds.map((id) => moderatorsById[id])
     : [];
 
-  const { publication_status } = folder.attributes;
+  const { publication_status, space_id, space_title_multiloc } =
+    folder.attributes;
+  const canModerateThisSpace = usePermission({
+    item: 'space',
+    action: 'moderate',
+    context: { spaceId: space_id },
+  });
+  const showSpace = spacesEnabled && !!space_title_multiloc && !!space_id;
 
   return (
     <Tr dataCy="projects-overview-folder-table-row">
@@ -87,11 +104,59 @@ const Row = ({ folder, moderatorsById }: Props) => {
             >
               {localize(folder.attributes.title_multiloc)}
             </Text>
-            <Text m="0" fontSize="xs" color="textSecondary">
-              {formatMessage(messages.numberOfProjects, {
-                numberOfProjects: folder.attributes.visible_projects_count,
-              })}
-            </Text>
+            <Box
+              display="flex"
+              alignItems="center"
+              flexWrap="wrap"
+              gap="2px 4px"
+            >
+              {showSpace && (
+                <>
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    gap="2px"
+                    flexShrink={0}
+                  >
+                    <Icon
+                      name="spaces"
+                      fill={colors.textSecondary}
+                      width="14px"
+                    />
+                    <Text
+                      m="0"
+                      fontSize="xs"
+                      color="textSecondary"
+                      className={
+                        canModerateThisSpace
+                          ? 'folder-table-row-space'
+                          : undefined
+                      }
+                      onClick={
+                        canModerateThisSpace
+                          ? (event) => {
+                              event.stopPropagation();
+                              clHistory.push(
+                                `/admin/projects/spaces/${space_id}`
+                              );
+                            }
+                          : undefined
+                      }
+                    >
+                      {localize(space_title_multiloc)}
+                    </Text>
+                  </Box>
+                  <Text m="0" fontSize="xs" color="textSecondary">
+                    ·
+                  </Text>
+                </>
+              )}
+              <Text m="0" fontSize="xs" color="textSecondary">
+                {formatMessage(messages.numberOfProjects, {
+                  numberOfProjects: folder.attributes.visible_projects_count,
+                })}
+              </Text>
+            </Box>
           </Box>
           {isBeingDeleted && (
             <Box ml="16px">

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
@@ -76,10 +76,6 @@ const Row = ({ folder, moderatorsById }: Props) => {
     context: { spaceId: space_id },
   });
   const showSpace = spacesEnabled && !!space_title_multiloc && !!space_id;
-  // `hoveringSpace` goes stale if the label unmounts or loses its handlers
-  // while hovered (React fires no onMouseLeave on unmount), so derive the live
-  // condition rather than trusting the raw state.
-  const spaceLabelHovered = hoveringSpace && showSpace && canModerateThisSpace;
 
   return (
     <Tr dataCy="projects-overview-folder-table-row">
@@ -101,9 +97,7 @@ const Row = ({ folder, moderatorsById }: Props) => {
               color="black"
               // Suspend the Td-hover underline while the space label is
               // hovered, so only the actual click target is underlined.
-              className={
-                spaceLabelHovered ? undefined : 'project-table-row-title'
-              }
+              className={hoveringSpace ? undefined : 'project-table-row-title'}
             >
               {localize(folder.attributes.title_multiloc)}
             </Text>
@@ -118,7 +112,7 @@ const Row = ({ folder, moderatorsById }: Props) => {
                   <RowLabel
                     iconName="spaces"
                     titleMultiloc={space_title_multiloc}
-                    underline={spaceLabelHovered}
+                    underline={hoveringSpace}
                     onHoverChange={
                       canModerateThisSpace ? setHoveringSpace : undefined
                     }

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
@@ -76,6 +76,10 @@ const Row = ({ folder, moderatorsById }: Props) => {
     context: { spaceId: space_id },
   });
   const showSpace = spacesEnabled && !!space_title_multiloc && !!space_id;
+  // `hoveringSpace` goes stale if the label unmounts or loses its handlers
+  // while hovered (React fires no onMouseLeave on unmount), so derive the live
+  // condition rather than trusting the raw state.
+  const spaceLabelHovered = hoveringSpace && showSpace && canModerateThisSpace;
 
   return (
     <Tr dataCy="projects-overview-folder-table-row">
@@ -97,7 +101,9 @@ const Row = ({ folder, moderatorsById }: Props) => {
               color="black"
               // Suspend the Td-hover underline while the space label is
               // hovered, so only the actual click target is underlined.
-              className={hoveringSpace ? undefined : 'project-table-row-title'}
+              className={
+                spaceLabelHovered ? undefined : 'project-table-row-title'
+              }
             >
               {localize(folder.attributes.title_multiloc)}
             </Text>
@@ -112,7 +118,7 @@ const Row = ({ folder, moderatorsById }: Props) => {
                   <RowLabel
                     iconName="spaces"
                     titleMultiloc={space_title_multiloc}
-                    underline={hoveringSpace}
+                    underline={spaceLabelHovered}
                     onHoverChange={
                       canModerateThisSpace ? setHoveringSpace : undefined
                     }

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
@@ -77,7 +77,7 @@ const Row = ({ folder, moderatorsById }: Props) => {
     folder.attributes;
   const canModerateThisSpace = usePermission({
     item: 'space',
-    action: 'moderate',
+    action: 'manage_projects_and_folders',
     context: { spaceId: space_id },
   });
   const showSpace = spacesEnabled && !!space_title_multiloc && !!space_id;

--- a/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Table/Row.tsx
@@ -5,7 +5,6 @@ import {
   Tr,
   Td,
   Text,
-  Icon,
   Spinner,
   colors,
 } from '@citizenlab/cl2-component-library';
@@ -30,6 +29,7 @@ import { usePermission } from 'utils/permissions';
 import { PUBLICATION_STATUS_LABELS } from '../../_shared/constants';
 import ManagerBubbles from '../../_shared/ManagerBubbles';
 import RowImage from '../../_shared/RowImage';
+import RowLabel from '../../_shared/RowLabel';
 import { getStatusColor } from '../../_shared/utils';
 
 import messages from './messages';
@@ -38,12 +38,6 @@ const StyledTd = styled(Td)`
   &:hover {
     cursor: pointer;
     .project-table-row-title {
-      text-decoration: underline;
-    }
-  }
-  .folder-table-row-space {
-    cursor: pointer;
-    &:hover {
       text-decoration: underline;
     }
   }
@@ -59,6 +53,7 @@ const Row = ({ folder, moderatorsById }: Props) => {
   const { formatMessage } = useIntl();
   const spacesEnabled = useFeatureFlag({ name: 'spaces' });
   const [isBeingDeleted, setIsBeingDeleted] = useState(false);
+  const [hoveringSpace, setHoveringSpace] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const { data: folderImage } = useProjectFolderImage({
@@ -100,7 +95,9 @@ const Row = ({ folder, moderatorsById }: Props) => {
               m="0"
               fontSize="s"
               color="black"
-              className="project-table-row-title"
+              // Suspend the Td-hover underline while the space label is
+              // hovered, so only the actual click target is underlined.
+              className={hoveringSpace ? undefined : 'project-table-row-title'}
             >
               {localize(folder.attributes.title_multiloc)}
             </Text>
@@ -112,40 +109,24 @@ const Row = ({ folder, moderatorsById }: Props) => {
             >
               {showSpace && (
                 <>
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    gap="2px"
-                    flexShrink={0}
-                  >
-                    <Icon
-                      name="spaces"
-                      fill={colors.textSecondary}
-                      width="14px"
-                    />
-                    <Text
-                      m="0"
-                      fontSize="xs"
-                      color="textSecondary"
-                      className={
-                        canModerateThisSpace
-                          ? 'folder-table-row-space'
-                          : undefined
-                      }
-                      onClick={
-                        canModerateThisSpace
-                          ? (event) => {
-                              event.stopPropagation();
-                              clHistory.push(
-                                `/admin/projects/spaces/${space_id}`
-                              );
-                            }
-                          : undefined
-                      }
-                    >
-                      {localize(space_title_multiloc)}
-                    </Text>
-                  </Box>
+                  <RowLabel
+                    iconName="spaces"
+                    titleMultiloc={space_title_multiloc}
+                    underline={hoveringSpace}
+                    onHoverChange={
+                      canModerateThisSpace ? setHoveringSpace : undefined
+                    }
+                    onClick={
+                      canModerateThisSpace
+                        ? (event) => {
+                            event.stopPropagation();
+                            clHistory.push(
+                              `/admin/projects/spaces/${space_id}`
+                            );
+                          }
+                        : undefined
+                    }
+                  />
                   <Text m="0" fontSize="xs" color="textSecondary">
                     ·
                   </Text>

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.test.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.test.tsx
@@ -13,6 +13,7 @@ import { render, screen, userEvent } from 'utils/testUtils/rtl';
 import Row from './Row';
 
 let mockAuthUserRoles: TRole[] = [];
+let mockSpacesEnabled = true;
 
 jest.mock('api/me/useAuthUser', () => () => ({
   data: {
@@ -33,6 +34,11 @@ jest.mock('api/project_images/useProjectImage', () => () => ({
   data: undefined,
 }));
 
+// usePermission() reads the app configuration; use the standard manual mock.
+jest.mock('api/app_configuration/useAppConfiguration');
+
+jest.mock('hooks/useFeatureFlag', () => () => mockSpacesEnabled);
+
 const project: ProjectMiniAdminData = {
   id: 'project-1',
   type: 'project_mini_admin',
@@ -42,6 +48,7 @@ const project: ProjectMiniAdminData = {
     first_phase_start_date: null,
     first_published_at: null,
     folder_title_multiloc: { en: 'Test folder' },
+    space_title_multiloc: { en: 'Test space' },
     last_phase_end_date: null,
     listed: true,
     publication_status: 'published',
@@ -74,6 +81,7 @@ const findRowLink = () =>
 describe('Projects table Row — folder link', () => {
   beforeEach(() => {
     mockAuthUserRoles = [];
+    mockSpacesEnabled = true;
   });
 
   it('does not link to the folder when the user cannot moderate it', async () => {
@@ -151,5 +159,65 @@ describe('Projects table Row — folder link', () => {
     expect(findRowLink().getAttribute('href')).not.toContain(
       'folders/folder-1'
     );
+  });
+});
+
+describe('Projects table Row — space link', () => {
+  beforeEach(() => {
+    mockAuthUserRoles = [];
+    mockSpacesEnabled = true;
+  });
+
+  it('does not link to the space when the user cannot moderate it', async () => {
+    mockAuthUserRoles = [];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test space'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/admin/projects/${project.id}`)
+    );
+    expect(findRowLink().getAttribute('href')).not.toContain('spaces/space-1');
+  });
+
+  it('links to the space when the user is a space moderator of that space', async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'space-1' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test space'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining('/admin/projects/spaces/space-1')
+    );
+  });
+
+  it('links to the space when the user is an admin', async () => {
+    mockAuthUserRoles = [{ type: 'admin' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test space'));
+
+    expect(findRowLink()).toHaveAttribute(
+      'href',
+      expect.stringContaining('/admin/projects/spaces/space-1')
+    );
+  });
+
+  it('does not link to the space for a moderator of a different space', async () => {
+    mockAuthUserRoles = [{ type: 'space_moderator', space_id: 'other-space' }];
+    renderRow();
+
+    await userEvent.hover(screen.getByText('Test space'));
+
+    expect(findRowLink().getAttribute('href')).not.toContain('spaces/space-1');
+  });
+
+  it('does not show the space when the spaces feature flag is disabled', () => {
+    mockSpacesEnabled = false;
+    renderRow();
+
+    expect(screen.queryByText('Test space')).not.toBeInTheDocument();
   });
 });

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -5,7 +5,6 @@ import {
   Tr,
   Td,
   Text,
-  Icon,
   Spinner,
   colors,
 } from '@citizenlab/cl2-component-library';
@@ -29,6 +28,7 @@ import { usePermission } from 'utils/permissions';
 
 import ManagerBubbles from '../../_shared/ManagerBubbles';
 import RowImage from '../../_shared/RowImage';
+import RowLabel from '../../_shared/RowLabel';
 
 import CurrentPhase from './CurrentPhase';
 import Visibility from './Visibility';
@@ -170,40 +170,16 @@ const Row = ({
                 gap="2px 4px"
               >
                 {showSpace && (
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    gap="2px"
-                    flexShrink={0}
-                  >
-                    <Icon
-                      name="spaces"
-                      fill={colors.textSecondary}
-                      width="14px"
-                    />
-                    <Text
-                      m="0"
-                      fontSize="xs"
-                      color="textSecondary"
-                      textDecoration={
-                        hover === 'space' && canModerateThisSpace
-                          ? 'underline'
-                          : 'none'
-                      }
-                      onMouseEnter={
-                        canModerateThisSpace
-                          ? () => setHover('space')
-                          : undefined
-                      }
-                      onMouseLeave={
-                        canModerateThisSpace
-                          ? () => setHover('project')
-                          : undefined
-                      }
-                    >
-                      {localize(space_title_multiloc)}
-                    </Text>
-                  </Box>
+                  <RowLabel
+                    iconName="spaces"
+                    titleMultiloc={space_title_multiloc}
+                    underline={hover === 'space' && canModerateThisSpace}
+                    onHoverChange={
+                      canModerateThisSpace
+                        ? (hovering) => setHover(hovering ? 'space' : 'project')
+                        : undefined
+                    }
+                  />
                 )}
                 {showSpace && folder_title_multiloc && (
                   <Text m="0" fontSize="xs" color="textSecondary">
@@ -211,40 +187,17 @@ const Row = ({
                   </Text>
                 )}
                 {folder_title_multiloc && (
-                  <Box
-                    display="flex"
-                    alignItems="center"
-                    gap="2px"
-                    flexShrink={0}
-                  >
-                    <Icon
-                      name="folder-solid"
-                      fill={colors.textSecondary}
-                      width="14px"
-                    />
-                    <Text
-                      m="0"
-                      fontSize="xs"
-                      color="textSecondary"
-                      textDecoration={
-                        hover === 'folder' && canModerateThisFolder
-                          ? 'underline'
-                          : 'none'
-                      }
-                      onMouseEnter={
-                        canModerateThisFolder
-                          ? () => setHover('folder')
-                          : undefined
-                      }
-                      onMouseLeave={
-                        canModerateThisFolder
-                          ? () => setHover('project')
-                          : undefined
-                      }
-                    >
-                      {localize(folder_title_multiloc)}
-                    </Text>
-                  </Box>
+                  <RowLabel
+                    iconName="folder-solid"
+                    titleMultiloc={folder_title_multiloc}
+                    underline={hover === 'folder' && canModerateThisFolder}
+                    onHoverChange={
+                      canModerateThisFolder
+                        ? (hovering) =>
+                            setHover(hovering ? 'folder' : 'project')
+                        : undefined
+                    }
+                  />
                 )}
               </Box>
             </Box>

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -5,15 +5,16 @@ import {
   Tr,
   Td,
   Text,
+  Icon,
   Spinner,
   colors,
 } from '@citizenlab/cl2-component-library';
 
-import useAuthUser from 'api/me/useAuthUser';
 import useProjectImage from 'api/project_images/useProjectImage';
 import { ProjectMiniAdminData } from 'api/projects_mini_admin/types';
 import { IUserData } from 'api/users/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
 import useLocalize from 'hooks/useLocalize';
 
 import ProjectMoreActionsMenu, {
@@ -24,7 +25,7 @@ import Error from 'components/UI/Error';
 
 import Link from 'utils/cl-router/Link';
 import { parseBackendDateString } from 'utils/dateUtils';
-import { userModeratesFolder } from 'utils/permissions/rules/projectFolderPermissions';
+import { usePermission } from 'utils/permissions';
 
 import ManagerBubbles from '../../_shared/ManagerBubbles';
 import RowImage from '../../_shared/RowImage';
@@ -46,7 +47,7 @@ const Row = ({
   moderatorsById,
 }: Props) => {
   const localize = useLocalize();
-  const { data: authUser } = useAuthUser();
+  const spacesEnabled = useFeatureFlag({ name: 'spaces' });
 
   const imageId = project.relationships.project_images.data[0]?.id;
   const { data: image } = useProjectImage({
@@ -57,7 +58,9 @@ const Row = ({
   const imageVersions = image?.data.attributes.versions;
   const imageUrl = imageVersions?.large ?? imageVersions?.medium;
 
-  const [hover, setHover] = useState<'none' | 'project' | 'folder'>('none');
+  const [hover, setHover] = useState<'none' | 'project' | 'folder' | 'space'>(
+    'none'
+  );
 
   const [isBeingDeleted, setIsBeingDeleted] = useState(false);
   const [isBeingCopyied, setIsBeingCopyied] = useState(false);
@@ -66,6 +69,7 @@ const Row = ({
   const {
     first_phase_start_date,
     folder_title_multiloc,
+    space_title_multiloc,
     last_phase_end_date,
     title_multiloc,
   } = project.attributes;
@@ -84,9 +88,18 @@ const Row = ({
   };
 
   const folderId = project.relationships.folder?.data?.id;
-  const folderSpaceId = project.relationships.space?.data?.id;
-  const canModerateThisFolder =
-    !!folderId && userModeratesFolder(authUser, folderId, folderSpaceId);
+  const spaceId = project.relationships.space?.data?.id;
+  const canModerateThisFolder = usePermission({
+    item: 'project_folder',
+    action: 'moderate',
+    context: { folderId, folderSpaceId: spaceId },
+  });
+  const canModerateThisSpace = usePermission({
+    item: 'space',
+    action: 'moderate',
+    context: { spaceId },
+  });
+  const showSpace = spacesEnabled && !!space_title_multiloc && !!spaceId;
 
   const handleActionLoading = (actionType: ActionType, isRunning: boolean) => {
     if (actionType === 'copying') {
@@ -99,13 +112,19 @@ const Row = ({
   const link: {
     to:
       | '/admin/projects/folders/$projectFolderId'
+      | '/admin/projects/spaces/$spaceId'
       | '/admin/projects/$projectId';
     params: Record<string, string>;
   } =
-    hover === 'folder' && canModerateThisFolder
+    hover === 'folder' && canModerateThisFolder && folderId
       ? {
           to: '/admin/projects/folders/$projectFolderId',
           params: { projectFolderId: folderId },
+        }
+      : hover === 'space' && canModerateThisSpace && spaceId
+      ? {
+          to: '/admin/projects/spaces/$spaceId',
+          params: { spaceId },
         }
       : {
           to: '/admin/projects/$projectId',
@@ -144,28 +163,90 @@ const Row = ({
               >
                 {localize(title_multiloc)}
               </Text>
-              {folder_title_multiloc && (
-                <Text
-                  m="0"
-                  fontSize="xs"
-                  color="textSecondary"
-                  textDecoration={
-                    hover === 'folder' && canModerateThisFolder
-                      ? 'underline'
-                      : 'none'
-                  }
-                  onMouseEnter={
-                    canModerateThisFolder ? () => setHover('folder') : undefined
-                  }
-                  onMouseLeave={
-                    canModerateThisFolder
-                      ? () => setHover('project')
-                      : undefined
-                  }
-                >
-                  {localize(folder_title_multiloc)}
-                </Text>
-              )}
+              <Box
+                display="flex"
+                alignItems="center"
+                flexWrap="wrap"
+                gap="2px 4px"
+              >
+                {showSpace && (
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    gap="2px"
+                    flexShrink={0}
+                  >
+                    <Icon
+                      name="spaces"
+                      fill={colors.textSecondary}
+                      width="14px"
+                    />
+                    <Text
+                      m="0"
+                      fontSize="xs"
+                      color="textSecondary"
+                      textDecoration={
+                        hover === 'space' && canModerateThisSpace
+                          ? 'underline'
+                          : 'none'
+                      }
+                      onMouseEnter={
+                        canModerateThisSpace
+                          ? () => setHover('space')
+                          : undefined
+                      }
+                      onMouseLeave={
+                        canModerateThisSpace
+                          ? () => setHover('project')
+                          : undefined
+                      }
+                    >
+                      {localize(space_title_multiloc)}
+                    </Text>
+                  </Box>
+                )}
+                {showSpace && folder_title_multiloc && (
+                  <Text m="0" fontSize="xs" color="textSecondary">
+                    ·
+                  </Text>
+                )}
+                {folder_title_multiloc && (
+                  <Box
+                    display="flex"
+                    alignItems="center"
+                    gap="2px"
+                    flexShrink={0}
+                  >
+                    <Icon
+                      name="folder-solid"
+                      fill={colors.textSecondary}
+                      width="14px"
+                    />
+                    <Text
+                      m="0"
+                      fontSize="xs"
+                      color="textSecondary"
+                      textDecoration={
+                        hover === 'folder' && canModerateThisFolder
+                          ? 'underline'
+                          : 'none'
+                      }
+                      onMouseEnter={
+                        canModerateThisFolder
+                          ? () => setHover('folder')
+                          : undefined
+                      }
+                      onMouseLeave={
+                        canModerateThisFolder
+                          ? () => setHover('project')
+                          : undefined
+                      }
+                    >
+                      {localize(folder_title_multiloc)}
+                    </Text>
+                  </Box>
+                )}
+              </Box>
             </Box>
             {(isBeingCopyied || isBeingDeleted) && (
               <Box ml="12px">

--- a/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
+++ b/front/app/containers/Admin/projects/all/Projects/Table/Row.tsx
@@ -96,7 +96,7 @@ const Row = ({
   });
   const canModerateThisSpace = usePermission({
     item: 'space',
-    action: 'moderate',
+    action: 'manage_projects_and_folders',
     context: { spaceId },
   });
   const showSpace = spacesEnabled && !!space_title_multiloc && !!spaceId;

--- a/front/app/containers/Admin/projects/all/_shared/RowLabel.test.tsx
+++ b/front/app/containers/Admin/projects/all/_shared/RowLabel.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { render, userEvent } from 'utils/testUtils/rtl';
+
+import RowLabel from './RowLabel';
+
+jest.mock(
+  'hooks/useLocalize',
+  () => () => (multiloc?: { en?: string } | null) => multiloc?.en ?? ''
+);
+
+// Regression guards: the whole label — icon included — is the interactive
+// target, not just the text.
+describe('RowLabel', () => {
+  it('fires onClick when the icon is clicked', async () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <RowLabel
+        iconName="spaces"
+        titleMultiloc={{ en: 'Label' }}
+        onClick={onClick}
+      />
+    );
+
+    const icon = container.querySelector('svg');
+    if (!icon) throw new Error('icon not found');
+
+    await userEvent.click(icon);
+
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('reports hover when the pointer enters and leaves via the icon', async () => {
+    const onHoverChange = jest.fn();
+    const { container } = render(
+      <RowLabel
+        iconName="spaces"
+        titleMultiloc={{ en: 'Label' }}
+        onHoverChange={onHoverChange}
+      />
+    );
+
+    const icon = container.querySelector('svg');
+    if (!icon) throw new Error('icon not found');
+
+    await userEvent.hover(icon);
+    expect(onHoverChange).toHaveBeenLastCalledWith(true);
+
+    await userEvent.unhover(icon);
+    expect(onHoverChange).toHaveBeenLastCalledWith(false);
+  });
+});

--- a/front/app/containers/Admin/projects/all/_shared/RowLabel.tsx
+++ b/front/app/containers/Admin/projects/all/_shared/RowLabel.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import {
+  Box,
+  Icon,
+  Text,
+  colors,
+  IconNames,
+} from '@citizenlab/cl2-component-library';
+import { Multiloc } from 'typings';
+
+import useLocalize from 'hooks/useLocalize';
+
+interface Props {
+  iconName: IconNames;
+  titleMultiloc: Multiloc | null;
+  underline?: boolean;
+  onClick?: (event: React.MouseEvent) => void;
+  onHoverChange?: (hovering: boolean) => void;
+}
+
+// Icon + title label shown under a row title (e.g. the space or folder the
+// row's item belongs to). Interactivity lives on the wrapping Box so the icon
+// and the gap are part of the click/hover target, not just the text.
+const RowLabel = ({
+  iconName,
+  titleMultiloc,
+  underline = false,
+  onClick,
+  onHoverChange,
+}: Props) => {
+  const localize = useLocalize();
+
+  return (
+    <Box
+      display="flex"
+      alignItems="center"
+      gap="2px"
+      flexShrink={0}
+      cursor={onClick || onHoverChange ? 'pointer' : undefined}
+      onClick={onClick}
+      onMouseEnter={onHoverChange ? () => onHoverChange(true) : undefined}
+      onMouseLeave={onHoverChange ? () => onHoverChange(false) : undefined}
+    >
+      <Icon name={iconName} fill={colors.textSecondary} width="14px" />
+      <Text
+        m="0"
+        fontSize="xs"
+        color="textSecondary"
+        textDecoration={underline ? 'underline' : 'none'}
+      >
+        {localize(titleMultiloc)}
+      </Text>
+    </Box>
+  );
+};
+
+export default RowLabel;

--- a/front/app/containers/Admin/spaces/EditSpace/ProjectsAndFolders/AddToSpaceModal.tsx
+++ b/front/app/containers/Admin/spaces/EditSpace/ProjectsAndFolders/AddToSpaceModal.tsx
@@ -99,9 +99,11 @@ const AddToSpaceModal = ({ spaceId, addableNodes, opened, onClose }: Props) => {
                   : messages.foldersPlaceholder
               )}
               onChange={(option) => setSelectedId(option.value ?? null)}
+              disabled={candidateOptions.length === 0}
             />
           </Box>
         </Box>
+
         <Box display="flex" justifyContent="flex-end" gap="12px">
           <Button buttonStyle="secondary-outlined" onClick={handleClose}>
             {formatMessage(messages.cancel)}

--- a/front/app/utils/permissions/rules/projectFolderPermissions.test.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.test.ts
@@ -1,7 +1,8 @@
-import { makeUser } from 'api/users/__mocks__/useUsers';
+import { makeUser, makeAdmin } from 'api/users/__mocks__/useUsers';
 
 import {
   userModeratesFolder,
+  userModeratesSpace,
   isProjectFolderModerator,
 } from './projectFolderPermissions';
 
@@ -47,5 +48,81 @@ describe('userModeratesFolder', () => {
     expect(
       userModeratesFolder(user, 'df534d5b-ec63-5adf-8713-9cc247957175')
     ).toBeFalsy();
+  });
+
+  it("returns true for a moderator of the folder's space", () => {
+    const spaceId = 'c9575fd8-2341-5f8d-b1f1-1e73a9c209b2';
+    const user = makeUser({
+      roles: [{ type: 'space_moderator', space_id: spaceId }],
+    });
+    expect(
+      userModeratesFolder(user, '793ee057-3191-53ce-a862-5f97b5c03c8b', spaceId)
+    ).toBe(true);
+  });
+
+  it('returns false for a moderator of a different space', () => {
+    const user = makeUser({
+      roles: [{ type: 'space_moderator', space_id: 'some-other-space' }],
+    });
+    expect(
+      userModeratesFolder(
+        user,
+        '793ee057-3191-53ce-a862-5f97b5c03c8b',
+        'c9575fd8-2341-5f8d-b1f1-1e73a9c209b2'
+      )
+    ).toBe(false);
+  });
+
+  // Regression guard: a missing folder id must fail closed, not fall through
+  // to the "moderates any folder" role check.
+  it('returns false when folderId is undefined, even for a moderator of some folder', () => {
+    const user = makeUser({
+      roles: [
+        {
+          type: 'project_folder_moderator',
+          project_folder_id: '793ee057-3191-53ce-a862-5f97b5c03c8b',
+        },
+      ],
+    });
+    expect(userModeratesFolder(user, undefined)).toBe(false);
+  });
+
+  it('returns false when folderId is null, even for an admin', () => {
+    expect(userModeratesFolder(makeAdmin(), null)).toBe(false);
+  });
+});
+
+describe('userModeratesSpace', () => {
+  const spaceId = 'c9575fd8-2341-5f8d-b1f1-1e73a9c209b2';
+
+  it('returns true for a moderator of that space', () => {
+    const user = makeUser({
+      roles: [{ type: 'space_moderator', space_id: spaceId }],
+    });
+    expect(userModeratesSpace(user, spaceId)).toBe(true);
+  });
+
+  it('returns false for a moderator of a different space', () => {
+    const user = makeUser({
+      roles: [{ type: 'space_moderator', space_id: 'some-other-space' }],
+    });
+    expect(userModeratesSpace(user, spaceId)).toBe(false);
+  });
+
+  it('returns true for an admin', () => {
+    expect(userModeratesSpace(makeAdmin(), spaceId)).toBe(true);
+  });
+
+  // Regression guard: a missing space id must fail closed, not fall through
+  // to the "moderates any space" role check.
+  it('returns false when spaceId is undefined, even for a space moderator', () => {
+    const user = makeUser({
+      roles: [{ type: 'space_moderator', space_id: spaceId }],
+    });
+    expect(userModeratesSpace(user, undefined)).toBe(false);
+  });
+
+  it('returns false when spaceId is null, even for an admin', () => {
+    expect(userModeratesSpace(makeAdmin(), null)).toBe(false);
   });
 });

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -12,12 +12,16 @@ import {
   isModeratorRoute,
 } from 'utils/permissions/rules/routePermissions';
 
+// Fails closed when the folder id is missing — this is always a question about
+// a specific folder. `folderSpaceId` lets moderators of the folder's space
+// moderate it too.
 export function userModeratesFolder(
   user: IUser | undefined | null,
-  projectFolderId: string,
+  projectFolderId?: string | null,
   folderSpaceId?: string | null
 ) {
   if (!user) return false;
+  if (typeof projectFolderId !== 'string') return false;
 
   return (
     isAdmin(user) ||
@@ -26,11 +30,14 @@ export function userModeratesFolder(
   );
 }
 
+// Fails closed when the space id is missing — this is always a question about
+// a specific space.
 export const userModeratesSpace = (
   user: IUser | undefined | null,
-  spaceId: string
+  spaceId?: string | null
 ) => {
   if (!user) return false;
+  if (typeof spaceId !== 'string') return false;
 
   return isAdmin(user) || isSpaceModerator(user, spaceId);
 };
@@ -103,14 +110,12 @@ definePermissionRule(
 );
 
 // Pass the folder id via `context` (e.g. `{ folderId, folderSpaceId }`) so the
-// rule can check moderation of that specific folder. `folderSpaceId` lets
-// moderators of the folder's space moderate it too.
+// rule can check moderation of that specific folder.
 definePermissionRule(
   'project_folder',
   'moderate',
-  (_folder, user, _tenant, context) => {
-    return userModeratesFolder(user, context?.folderId, context?.folderSpaceId);
-  }
+  (_folder, user, _tenant, context) =>
+    userModeratesFolder(user, context?.folderId, context?.folderSpaceId)
 );
 
 // Permission to add or remove projects from folders

--- a/front/app/utils/permissions/rules/projectFolderPermissions.ts
+++ b/front/app/utils/permissions/rules/projectFolderPermissions.ts
@@ -102,11 +102,14 @@ definePermissionRule(
   }
 );
 
+// Pass the folder id via `context` (e.g. `{ folderId, folderSpaceId }`) so the
+// rule can check moderation of that specific folder. `folderSpaceId` lets
+// moderators of the folder's space moderate it too.
 definePermissionRule(
   'project_folder',
   'moderate',
-  (folder: IProjectFolderData, user) => {
-    return userModeratesFolder(user, folder.id);
+  (_folder, user, _tenant, context) => {
+    return userModeratesFolder(user, context?.folderId, context?.folderSpaceId);
   }
 );
 

--- a/front/app/utils/permissions/rules/spacePermissions.ts
+++ b/front/app/utils/permissions/rules/spacePermissions.ts
@@ -1,13 +1,6 @@
 import { definePermissionRule } from 'utils/permissions/permissions';
 import { isAdmin, isSpaceModerator } from 'utils/permissions/roles';
 
-// Permission to moderate a space. Admins and moderators of the space are
-// allowed. Pass the space id via `context` (e.g. `{ spaceId }`) so the rule can
-// check moderation of that specific space.
-definePermissionRule('space', 'moderate', (_item, user, _tenant, context) => {
-  return isAdmin(user) || isSpaceModerator(user, context?.spaceId);
-});
-
 // Permission to add projects and folders to a space. Admins and moderators of
 // the space are allowed to manage its contents.
 definePermissionRule(

--- a/front/app/utils/permissions/rules/spacePermissions.ts
+++ b/front/app/utils/permissions/rules/spacePermissions.ts
@@ -1,6 +1,13 @@
 import { definePermissionRule } from 'utils/permissions/permissions';
 import { isAdmin, isSpaceModerator } from 'utils/permissions/roles';
 
+// Permission to moderate a space. Admins and moderators of the space are
+// allowed. Pass the space id via `context` (e.g. `{ spaceId }`) so the rule can
+// check moderation of that specific space.
+definePermissionRule('space', 'moderate', (_item, user, _tenant, context) => {
+  return isAdmin(user) || isSpaceModerator(user, context?.spaceId);
+});
+
 // Permission to add projects and folders to a space. Admins and moderators of
 // the space are allowed to manage its contents.
 definePermissionRule(

--- a/front/app/utils/permissions/rules/spacePermissions.ts
+++ b/front/app/utils/permissions/rules/spacePermissions.ts
@@ -1,13 +1,17 @@
 import { definePermissionRule } from 'utils/permissions/permissions';
 import { isAdmin, isSpaceModerator } from 'utils/permissions/roles';
+import { userModeratesSpace } from 'utils/permissions/rules/projectFolderPermissions';
 
 // Permission to add projects and folders to a space. Admins and moderators of
-// the space are allowed to manage its contents.
+// the space are allowed to manage its contents. Without a context this is a
+// general check (moderator of any space); with a context, `spaceId` must be
+// present — asking about a specific space that isn't there fails closed.
 definePermissionRule(
   'space',
   'manage_projects_and_folders',
   (_item, user, _tenant, context) => {
-    return isAdmin(user) || isSpaceModerator(user, context?.spaceId);
+    if (context) return userModeratesSpace(user, context.spaceId);
+    return isAdmin(user) || isSpaceModerator(user);
   }
 );
 


### PR DESCRIPTION
# Changelog
## Add an indication in the projects and folders list to which space (if any) the item belongs to (feature-flagged)

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
