### PR TITLE
[TAN-8275] Add CSS selectors for the new project page product tour

### DIFF
--- a/front/app/containers/Admin/projects/project/general/index.tsx
+++ b/front/app/containers/Admin/projects/project/general/index.tsx
@@ -64,7 +64,10 @@ const General = () => {
     <Box p="8px 24px 24px 24px">
       <Box background={colors.white}>
         <Box position="sticky" top="0" background={colors.white} zIndex="1">
-          <NavigationTabs position="relative">
+          <NavigationTabs
+            className="intercom-product-tour-project-general-tabs"
+            position="relative"
+          >
             {tabs.map(({ url, label, className }) => (
               <Tab
                 label={label}

--- a/front/app/containers/Admin/projects/project/newBackoffice/ProjectNavRail/NavItemRow.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/ProjectNavRail/NavItemRow.tsx
@@ -64,7 +64,12 @@ const NavItemRow = ({
   const active = pathname.includes(item.to.replace('$projectId', projectId));
 
   return (
-    <Row className={active ? 'active' : undefined} pr={trailing ? '8px' : '0'}>
+    <Row
+      className={`intercom-product-tour-project-nav-item-${item.name}${
+        active ? ' active' : ''
+      }`}
+      pr={trailing ? '8px' : '0'}
+    >
       <RowLink to={item.to} params={{ projectId }}>
         <Box flexGrow={1} minWidth="0">
           <Text

--- a/front/app/containers/Admin/projects/project/newBackoffice/ProjectNavRail/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/ProjectNavRail/index.tsx
@@ -66,6 +66,7 @@ const ProjectNavRail = ({ projectId }: Props) => {
   return (
     <Box
       as="nav"
+      className="intercom-product-tour-project-nav-rail"
       p="12px"
       flex="0 0 auto"
       display="flex"

--- a/front/app/containers/Admin/projects/project/newBackoffice/TimelinePhases/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/TimelinePhases/index.tsx
@@ -142,7 +142,11 @@ const TimelinePhases = ({ projectId }: Props) => {
   const noEndLabel = formatMessage(messages.phaseNoEndDate);
 
   return (
-    <Box p="12px" borderTop={`1px solid ${colors.grey200}`}>
+    <Box
+      className="intercom-product-tour-project-timeline"
+      p="12px"
+      borderTop={`1px solid ${colors.grey200}`}
+    >
       <Text
         m="0 0 8px 0"
         px="10px"

--- a/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
+++ b/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
@@ -226,6 +226,7 @@ export const PhaseHeader = ({ phase, tabs }: Props) => {
           </Box>
         </Box>
         <Box
+          className="intercom-product-tour-phase-tabs"
           display="flex"
           px="44px"
           boxShadow="0px 2px 4px -1px rgba(0, 0, 0, 0.06)"


### PR DESCRIPTION
# Changelog

## Technical
- Added `intercom-*` CSS classes to the new project admin page so the Intercom product tour can anchor its steps