### PR TITLE
Fix crash requesting a phone code for users with no phone confirmation record

### DIFF
--- a/back/app/policies/request_code_policy.rb
+++ b/back/app/policies/request_code_policy.rb
@@ -11,7 +11,7 @@ class RequestCodePolicy < ApplicationPolicy
       return false
     end
 
-    return false if record.email_confirmation.code_reset_count >= max_retries - 1
+    return false if code_reset_limit_reached?(record.email_confirmation)
 
     true
   end
@@ -19,7 +19,7 @@ class RequestCodePolicy < ApplicationPolicy
   # For authenticated users changing their email
   def request_code_email_change?
     return false if user.nil?
-    return false if user.new_email_confirmation.code_reset_count >= max_retries - 1
+    return false if code_reset_limit_reached?(user.new_email_confirmation)
 
     true
   end
@@ -28,12 +28,20 @@ class RequestCodePolicy < ApplicationPolicy
   def request_code_phone_change?
     return false unless app_configuration.feature_activated?('sms')
     return false if user.nil?
-    return false if user.new_phone_confirmation.code_reset_count >= max_retries - 1
+    return false if code_reset_limit_reached?(user.new_phone_confirmation)
 
     true
   end
 
   private
+
+  # Users who predate a confirmation type have no record for it yet — the request
+  # job creates one on first use.
+  def code_reset_limit_reached?(confirmation)
+    return false if confirmation.nil?
+
+    confirmation.code_reset_count >= max_retries - 1
+  end
 
   def app_configuration
     @app_configuration ||= AppConfiguration.instance

--- a/back/spec/acceptance/request_codes_spec.rb
+++ b/back/spec/acceptance/request_codes_spec.rb
@@ -207,6 +207,15 @@ resource 'Request codes' do
       expect(response_status).to eq 401
     end
 
+    example 'It works for a user with no phone confirmation record yet' do
+      user = create(:user)
+      user.new_phone_confirmation.destroy!
+      header_token_for(user)
+      do_request(request_code: { new_phone: '+14155552671' })
+      expect(response_status).to eq 200
+      expect(user.reload.new_phone).to eq '+14155552671'
+    end
+
     example 'It does not work if the SMS feature is disabled' do
       SettingsService.new.deactivate_feature!('sms')
       user = create(:user)


### PR DESCRIPTION
- `RequestCodePolicy` read `code_reset_count` off a nil `NewPhoneConfirmation` (never backfilled for older users). Now goes through a nil-safe helper shared by all three code paths.

# Changelog
# Fixed
- Users who signed up before phone verification existed got an error instead of an SMS code when adding or changing their phone number.

