### PR TITLE
Sentry fix: Fix 500 when counting analytics project statuses

### DIFF
--- a/back/engines/commercial/analytics/app/models/analytics/fact_project_status.rb
+++ b/back/engines/commercial/analytics/app/models/analytics/fact_project_status.rb
@@ -12,6 +12,12 @@
 #
 module Analytics
   class FactProjectStatus < Analytics::ApplicationRecordView
+    # The view holds one row per project, so this is a natural key. Required for `count`
+    # on an eager-loaded relation: without it, `Array(arel_table[Arel.star])` splits the
+    # Arel attribute Struct into [table, *] and interpolates the table object into the
+    # SQL (activerecord 7.2 calculations.rb#calculate).
+    self.primary_key = :dimension_project_id
+
     belongs_to :dimension_date
     belongs_to :dimension_project
   end

--- a/back/engines/commercial/analytics/spec/models/analytics/fact_project_status_spec.rb
+++ b/back/engines/commercial/analytics/spec/models/analytics/fact_project_status_spec.rb
@@ -8,6 +8,26 @@ RSpec.describe Analytics::FactProjectStatus do
   it { is_expected.to belong_to(:dimension_project) }
   it { is_expected.to belong_to(:dimension_date) }
 
+  describe 'primary key' do
+    let!(:projects) { create_list(:project, 2) }
+
+    it 'is the natural key of the view, which holds one row per project' do
+      expect(described_class.primary_key).to eq('dimension_project_id')
+      expect(described_class.count).to eq(described_class.distinct.count(:dimension_project_id))
+    end
+
+    # Without a primary key this interpolates an Arel::Table into the SQL.
+    it 'counts an eager-loaded relation without a syntax error' do
+      relation = described_class
+        .includes(:dimension_project)
+        .where.not(dimension_project: { id: nil })
+
+      expect(relation).to be_eager_loading
+      expect { relation.count }.not_to raise_error
+      expect(relation.count).to eq(projects.size)
+    end
+  end
+
   shared_examples 'project can have status' do |status|
     it "the project can have the #{status} status", :aggregate_failures do
       project.update!({ admin_publication_attributes: { publication_status: status } })


### PR DESCRIPTION
Analytics::FactProjectStatus is backed by a view with no id column, so it had no primary key. Counting an eager-loaded relation then falls back to Array(arel_table[Arel.star]), and because an Arel attribute is a Struct, Array() splits it into [table, *] and interpolates the Arel::Table object into the SQL (activerecord 7.2 calculations.rb#calculate). Postgres rejects the query, so the admin dashboard 500s via QueryRunnerService#pagination.

The view holds exactly one row per project, so dimension_project_id is a natural key. Setting it makes the generated count SQL valid.

Example: https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/109736/ 

# Changelog
## Technical
- Fix error with project status in analytics views
