### PR TITLE
Sentry fix: Don't request an access denied explanation for unsupported actions

### DIFF
--- a/front/app/hooks/useCustomAccessDeniedMessage.test.tsx
+++ b/front/app/hooks/useCustomAccessDeniedMessage.test.tsx
@@ -1,0 +1,84 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import createQueryClientWrapper from 'utils/testUtils/queryClientWrapper';
+import { renderHook, waitFor } from 'utils/testUtils/rtl';
+
+import useCustomAccessDeniedMessage from './useCustomAccessDeniedMessage';
+
+const apiPath =
+  '*phases/:phaseId/permissions/:action/access_denied_explanation';
+
+const requestedActions: string[] = [];
+
+const server = setupServer(
+  http.get(apiPath, ({ params }) => {
+    requestedActions.push(String(params.action));
+    return HttpResponse.json({
+      data: {
+        id: 'id',
+        type: 'access_denied_explanation',
+        attributes: {
+          access_denied_explanation_multiloc: { en: '<p>Members only</p>' },
+        },
+      },
+    });
+  })
+);
+
+const renderIt = (disabledReason: string | null) =>
+  renderHook(
+    () =>
+      useCustomAccessDeniedMessage({
+        phaseId: 'phase-id',
+        action: 'commenting_idea',
+        disabledReason,
+      }),
+    { wrapper: createQueryClientWrapper() }
+  );
+
+describe('useCustomAccessDeniedMessage', () => {
+  beforeAll(() => server.listen());
+  afterEach(() => {
+    requestedActions.length = 0;
+    server.resetHandlers();
+  });
+  afterAll(() => server.close());
+
+  it('fetches an explanation when the user is denied for a reason auth cannot fix', async () => {
+    const { result } = renderIt('user_not_in_group');
+
+    await waitFor(() => expect(result.current).not.toBeNull());
+    expect(requestedActions).toEqual(['commenting_idea']);
+  });
+
+  // No Permission record exists for these, so the request would 404.
+  it.each([
+    'commenting_not_supported',
+    'posting_not_supported',
+    'reacting_not_supported',
+    'not_voting',
+  ])(
+    'does not request an explanation when the action is %s',
+    async (reason) => {
+      const { result } = renderIt(reason);
+
+      await waitFor(() => expect(result.current).toBeNull());
+      expect(requestedActions).toEqual([]);
+    }
+  );
+
+  it('does not request an explanation when the user just needs to sign in', async () => {
+    const { result } = renderIt('user_not_signed_in');
+
+    await waitFor(() => expect(result.current).toBeNull());
+    expect(requestedActions).toEqual([]);
+  });
+
+  it('does not request an explanation when the action is enabled', async () => {
+    const { result } = renderIt(null);
+
+    await waitFor(() => expect(result.current).toBeNull());
+    expect(requestedActions).toEqual([]);
+  });
+});

--- a/front/app/hooks/useCustomAccessDeniedMessage.tsx
+++ b/front/app/hooks/useCustomAccessDeniedMessage.tsx
@@ -5,7 +5,10 @@ import { IPhasePermissionAction } from 'api/phase_permissions/types';
 
 import QuillEditedContent from 'components/UI/QuillEditedContent';
 
-import { isFixableByAuthentication } from 'utils/actionDescriptors';
+import {
+  isActionNotSupported,
+  isFixableByAuthentication,
+} from 'utils/actionDescriptors';
 
 import useLocalize from './useLocalize';
 
@@ -42,8 +45,12 @@ export default function useCustomAccessDeniedMessage({
   // reason that authentication can't fix (e.g. the user isn't in the required
   // group). Only fetch in that case — otherwise we'd issue a request (and an
   // extra re-render once it resolves) for every enabled button on the page.
+  // Unsupported actions have no permission to explain, and asking for one 404s.
   const enabled =
-    !!phaseId && !!disabledReason && !isFixableByAuthentication(disabledReason);
+    !!phaseId &&
+    !!disabledReason &&
+    !isFixableByAuthentication(disabledReason) &&
+    !isActionNotSupported(disabledReason);
 
   const { data: accessDenied } = useAccessDeniedExplanation(
     {

--- a/front/app/utils/actionDescriptors/index.ts
+++ b/front/app/utils/actionDescriptors/index.ts
@@ -20,6 +20,23 @@ export const isFixableByAuthentication = (disabledReason: string) => {
   return FIXABLE_REASONS.has(disabledReason);
 };
 
+// The phase's participation method has no such action, rather than the user being
+// unable to perform it. No Permission record exists for these (Permission::ACTIONS).
+const ACTION_NOT_SUPPORTED_REASONS = new Set<string>([
+  'posting_not_supported',
+  'commenting_not_supported',
+  'reacting_not_supported',
+  'not_voting',
+  'not_survey',
+  'not_poll',
+  'not_document_annotation',
+  'not_volunteering',
+] satisfies DisabledReason[]);
+
+export const isActionNotSupported = (disabledReason: string) => {
+  return ACTION_NOT_SUPPORTED_REASONS.has(disabledReason);
+};
+
 // Fall back messages for disabled reasons
 const globalDisabledMessages: {
   [reason in DisabledReason]?: MessageDescriptor;


### PR DESCRIPTION
useCustomAccessDeniedMessage fetched an explanation whenever the disabled reason was not fixable by authentication. That conflates two things: the user being unable to perform an action, and the action not existing on the phase at all. The back end only creates a Permission record for actions the phase's participation method supports (Permission::ACTIONS), so reasons like commenting_not_supported have no permission to explain and the request 404s.

This is the common case: an ideation project that has moved on to an information phase still shows its ideas, and every idea page then asked for a commenting_idea explanation the phase cannot have.

Adds isActionNotSupported alongside isFixableByAuthentication and skips the fetch for those reasons. No user-visible change: the request 404'd, so the UI already fell back to the default message.

Example: https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/74220/

# Changelog
## Technical
- Removed needless fetching of access denied explanation for unsupported actions
