### PR TITLE
Sentry fix: Stop reporting expected API errors to Sentry

### DIFF
--- a/front/app/utils/cl-react-query/fetcher.test.ts
+++ b/front/app/utils/cl-react-query/fetcher.test.ts
@@ -1,4 +1,10 @@
+import { reportError } from 'utils/loggingUtils';
+
 import fetcher from './fetcher';
+
+jest.mock('utils/loggingUtils', () => ({ reportError: jest.fn() }));
+
+const mockReportError = reportError as jest.Mock;
 
 const baseDataArray = {
   data: [
@@ -16,13 +22,17 @@ const baseErrorObject = { errors: [{ error: 'error' }] };
 let mockStatus = 200;
 let mockOk = true;
 let mockDataObject: any = baseDataObject;
+let mockJsonParseFails = false;
 
 global.fetch = jest.fn(() =>
   Promise.resolve({
     status: mockStatus,
     statusText: 'OK',
     ok: mockOk,
-    json: () => Promise.resolve(mockDataObject),
+    json: () =>
+      mockJsonParseFails
+        ? Promise.reject(new SyntaxError('Unexpected token < in JSON'))
+        : Promise.resolve(mockDataObject),
   } as Response)
 );
 
@@ -199,6 +209,77 @@ describe('fetcher', () => {
       }
 
       expect(thrownError).toEqual(baseErrorObject);
+    });
+  });
+
+  describe('error reporting', () => {
+    const fetchAndCatch = async () => {
+      try {
+        await fetcher({ path: '/path', action: 'get' });
+      } catch {
+        // The fetcher always throws on error; these tests are about what it reports.
+      }
+    };
+
+    beforeEach(() => {
+      mockReportError.mockClear();
+      mockJsonParseFails = false;
+      mockDataObject = baseDataObject;
+    });
+
+    it.each([401, 403, 404])(
+      'does not report a %i, which is an expected response',
+      async (status) => {
+        mockStatus = status;
+        mockOk = false;
+        mockDataObject = { message: "Couldn't find Project" };
+
+        await fetchAndCatch();
+
+        expect(mockReportError).not.toHaveBeenCalled();
+      }
+    );
+
+    it('reports an unexpected error status without a structured error body', async () => {
+      mockStatus = 500;
+      mockOk = false;
+      mockDataObject = { message: 'Internal Server Error' };
+
+      await fetchAndCatch();
+
+      expect(mockReportError).toHaveBeenCalledWith(mockDataObject);
+    });
+
+    it('does not report an error the back-end already described', async () => {
+      mockStatus = 422;
+      mockOk = false;
+      mockDataObject = { errors: { base: [{ error: 'invalid' }] } };
+
+      await fetchAndCatch();
+
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('does not report an unparseable body on a failed response', async () => {
+      mockStatus = 502;
+      mockOk = false;
+      mockJsonParseFails = true;
+
+      await fetchAndCatch();
+
+      expect(mockReportError).not.toHaveBeenCalled();
+    });
+
+    it('reports an unparseable body on a successful response', async () => {
+      mockStatus = 200;
+      mockOk = true;
+      mockJsonParseFails = true;
+
+      await fetchAndCatch();
+
+      expect(mockReportError).toHaveBeenCalledWith(
+        'Unsupported case. No valid JSON.'
+      );
     });
   });
 });

--- a/front/app/utils/cl-react-query/fetcher.ts
+++ b/front/app/utils/cl-react-query/fetcher.ts
@@ -6,10 +6,14 @@ import { API_PATH } from 'containers/App/constants';
 
 import { getJwt } from 'utils/auth/jwt';
 import { queryClient } from 'utils/cl-react-query/queryClient';
-import { handleBlockedUserError } from 'utils/errorUtils';
+import { handleBlockedUserError, isCLErrorsWrapper } from 'utils/errorUtils';
 import { reportError } from 'utils/loggingUtils';
 
 // FETCHER
+
+// Answered correctly, just not with a resource. Still thrown to the caller, but a
+// normal part of serving the web and so not worth reporting.
+const EXPECTED_ERROR_STATUSES = new Set([401, 403, 404]);
 
 type Path = `/${string}`;
 interface Get {
@@ -151,16 +155,22 @@ async function fetcher({
       return null;
     }
 
-    reportError('Unsupported case. No valid JSON.');
+    // On a failed response this adds nothing to the status code. Only an unparseable
+    // body on a successful one is a real defect.
+    if (response.ok) {
+      reportError('Unsupported case. No valid JSON.');
+    }
+
     throw new Error('Unsupported case. No valid JSON.');
   }
 
   if (!response.ok) {
     const error = data as unknown as CLErrors;
     handleBlockedUserError(response.status, error);
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    if (!error.errors) {
+    if (
+      !isCLErrorsWrapper(data) &&
+      !EXPECTED_ERROR_STATUSES.has(response.status)
+    ) {
       reportError(data);
     }
 


### PR DESCRIPTION
The fetcher reported every non-ok response without a structured error body, so back-end 404s surfaced as front-end Sentry issues titled with the raw Rails message. A 401/403/404 is a normal outcome rather than a defect, and crawlers following stale links generate them in bulk. They are still thrown to the caller, just no longer reported.

An unparseable body on a failed response likewise adds nothing to the status code, so it is only reported when the response was successful.

Example: https://sentry.hq.citizenlab.co/organizations/citizenlab/issues/83826/

# Changelog
## Technical
- Suppress front-end 401/403/404 reporting as sentry errors
