### PR TITLE
[TAN-7583] Roll back toxicity detection to Claude 3 Haiku

### DIFF
--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/bedrock.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/bedrock.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Analysis
+  module LLM
+    class Bedrock < Base
+      def initialize(**params)
+        super()
+
+        if !params.key? :region
+          raise 'No AWS region specified.'
+        end
+
+        @client = Aws::BedrockRuntime::Client.new(params)
+      end
+
+      def token_count(str)
+        # From https://docs.aws.amazon.com/bedrock/latest/userguide/model-customization-prepare.html:
+        # "Use 6 characters per token as an approximation for the number of tokens."
+        (str.size / 6.0).ceil
+      end
+
+      def accuracy
+        raise NotImplementedError
+      end
+
+      def chat(prompt, **params)
+        response = @client.converse(
+          model_id:,
+          messages: messages(prompt, params[:assistant_prefix] || ''),
+          inference_config:
+        )
+        response.output.message.content.first.text
+      end
+
+      def chat_async(prompt, **params)
+        handler = Aws::BedrockRuntime::EventStreams::ConverseStreamOutput.new
+        handler.on_content_block_delta_event do |event|
+          yield(event.delta.text)
+        end
+        @client.converse_stream(
+          model_id:,
+          messages: messages(prompt, params[:assistant_prefix] || ''),
+          inference_config:,
+          event_stream_handler: handler
+        )
+      end
+
+      protected
+
+      def model_id
+        raise NotImplementedError
+      end
+
+      private
+
+      def inference_config
+        {
+          max_tokens: 300,
+          temperature: 0.1,
+          top_p: 0.9
+        }
+      end
+
+      def messages(prompt, assistant_prefix)
+        [
+          {
+            role: 'user',
+            content: [
+              {
+                text: prompt
+              }
+            ]
+          },
+          if assistant_prefix.empty?
+            nil
+          else
+            {
+              role: 'assistant',
+              content: [
+                {
+                  text: assistant_prefix
+                }
+              ]
+            }
+          end
+        ].compact
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_3_haiku.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/claude_3_haiku.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Analysis
+  module LLM
+    class Claude3Haiku < Bedrock
+      def context_window
+        200_000
+      end
+
+      def accuracy
+        0.6
+      end
+
+      def self.family
+        'aws_anthropic'
+      end
+
+      protected
+
+      def model_id
+        'anthropic.claude-3-haiku-20240307-v1:0'
+      end
+    end
+  end
+end

--- a/back/engines/commercial/flag_inappropriate_content/app/services/flag_inappropriate_content/toxicity_detection_service.rb
+++ b/back/engines/commercial/flag_inappropriate_content/app/services/flag_inappropriate_content/toxicity_detection_service.rb
@@ -16,10 +16,8 @@ module FlagInappropriateContent
     }
 
     def initialize
-      # Some clusters (e.g. Canada) are not allowed to send data to the US or Europe.
-      return if ENV.fetch('AWS_TOXICITY_DETECTION_REGION', nil).blank?
-
-      @llm = LLMSelector.new.llm_class_for_use_case('toxicity_detection').new
+      region = ENV.fetch('AWS_TOXICITY_DETECTION_REGION', nil) # Some clusters (e.g. Canada) are not allowed to send data to the US or Europe.
+      @llm = Analysis::LLM::Claude3Haiku.new(region: region) if region
     end
 
     # @return [InappropriateContentFlag, nil] The flag if one was created, nil otherwise
@@ -72,38 +70,20 @@ module FlagInappropriateContent
       return if !@llm # Some clusters (e.g. Canada) are not allowed to send data to the US or Europe.
 
       prompt = Analysis::LLM::Prompt.new.fetch('toxicity_detection', text:, custom_guidelines:)
-      response = @llm.chat(prompt, response_schema:)
-      toxicity_label = MAP_TOXICITY_LABEL[response['category']]
-      return if !toxicity_label
-
-      { toxicity_label:, ai_reason: response['reason'] }
+      response = @llm.chat(prompt, assistant_prefix: 'My answer is (').strip
+      toxicity_label = MAP_TOXICITY_LABEL.find do |class_id, _|
+        response.starts_with? "#{class_id})"
+      end&.last
+      if toxicity_label
+        ai_reason = response[2, response.length].strip
+        { toxicity_label: toxicity_label, ai_reason: ai_reason }
+      end
     end
 
     def custom_guidelines
       return @custom_guidelines if defined? @custom_guidelines
 
       @custom_guidelines = AppConfiguration.instance.settings('flag_inappropriate_content', 'custom_guidelines').presence
-    end
-
-    def response_schema
-      categories = MAP_TOXICITY_LABEL.keys
-      categories -= ['F'] if custom_guidelines.blank?
-      {
-        type: 'object',
-        additionalProperties: false,
-        required: %w[category reason],
-        properties: {
-          category: {
-            type: 'string',
-            enum: categories,
-            description: 'The category that best describes the message'
-          },
-          reason: {
-            type: 'string',
-            description: 'A short explanation of why the chosen category applies'
-          }
-        }
-      }
     end
   end
 end

--- a/back/engines/commercial/flag_inappropriate_content/spec/services/toxicity_detection_service_spec.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/services/toxicity_detection_service_spec.rb
@@ -53,23 +53,23 @@ describe FlagInappropriateContent::ToxicityDetectionService do
   end
 
   describe 'check_toxicity' do
-    let(:llm) { instance_double(Analysis::LLM::ClaudeHaiku45) }
+    let(:llm) { instance_double(Analysis::LLM::Claude3Haiku) }
 
     before do
       SettingsService.new.activate_feature! 'moderation'
       SettingsService.new.activate_feature! 'flag_inappropriate_content'
       stub_const('ENV', ENV.to_h.merge('AWS_TOXICITY_DETECTION_REGION' => 'eu-central-1'))
-      allow(Analysis::LLM::ClaudeHaiku45).to receive(:new).and_return(llm)
+      allow(Analysis::LLM::Claude3Haiku).to receive(:new).and_return(llm)
     end
 
     it 'classifies with the default categories when no custom guidelines are configured' do
       idea = create(:idea, title_multiloc: { 'en' => 'An idea for my fellow wankers' })
 
-      expect(llm).to receive(:chat) do |prompt, response_schema:|
+      expect(llm).to receive(:chat) do |prompt, assistant_prefix:|
         expect(prompt).to include 'An idea for my fellow wankers'
         expect(prompt).not_to include '<guidelines>'
-        expect(response_schema.dig(:properties, :category, :enum)).to eq %w[A B C D E]
-        { 'category' => 'A', 'reason' => 'Contains an insult.' }
+        expect(assistant_prefix).to eq 'My answer is ('
+        'A) Contains an insult.'
       end
 
       expect(service.check_toxicity(idea, attributes: [:title_multiloc]))
@@ -82,10 +82,10 @@ describe FlagInappropriateContent::ToxicityDetectionService do
       config.save!
       comment = create(:comment, body_multiloc: { 'en' => 'Visit https://spam.example.com' })
 
-      expect(llm).to receive(:chat) do |prompt, response_schema:|
+      expect(llm).to receive(:chat) do |prompt, **|
         expect(prompt).to include 'Messages may not contain links.'
-        expect(response_schema.dig(:properties, :category, :enum)).to eq %w[A B C D E F]
-        { 'category' => 'F', 'reason' => 'The message contains a link.' }
+        expect(prompt).to include '(F) Violating the platform-specific participation guidelines'
+        'F) The message contains a link.'
       end
 
       expect(service.check_toxicity(comment))
@@ -94,7 +94,7 @@ describe FlagInappropriateContent::ToxicityDetectionService do
 
     it 'returns nil for non-toxic content' do
       comment = create(:comment, body_multiloc: { 'en' => 'What a nice idea' })
-      allow(llm).to receive(:chat).and_return({ 'category' => 'E', 'reason' => 'Not toxic.' })
+      allow(llm).to receive(:chat).and_return('E) Not toxic.')
 
       expect(service.check_toxicity(comment)).to be_nil
     end


### PR DESCRIPTION
# Changelog

## Changed

- The AI inappropriate-content detection uses the previous AI model (Claude 3 Haiku) again. The model upgrade in the 15 July release made moderation noticeably stricter, causing clean posts and comments to be flagged for review (reported by Frome and Vienna, e.g. posts that merely mention safety issues). Platform-specific moderation guidelines keep working: content violating them is still flagged with the AI's reasoning.