### PR TITLE
[No-ticket] bump mcp 0.16 → 0.25 (GHSA-h669-8m4g-r2hc + 4 others)

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -619,6 +619,7 @@ GEM
     gyoku (1.4.0)
       builder (>= 2.1.2)
       rexml (~> 3.0)
+    hana (1.3.7)
     hashdiff (1.1.0)
     hashery (2.1.2)
     hashie (5.0.0)
@@ -676,6 +677,11 @@ GEM
       faraday-follow_redirects
     json-schema (4.3.0)
       addressable (>= 2.8)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jsonapi-renderer (0.2.2)
     jsonapi-serializer (2.2.0)
       activesupport (>= 4.2)
@@ -731,8 +737,8 @@ GEM
       rest-client (>= 2.0.2)
     marcel (1.0.4)
     matrix (0.4.2)
-    mcp (0.16.0)
-      json-schema (>= 4.1)
+    mcp (0.25.0)
+      json_schemer (>= 2.4)
     method_source (1.1.0)
     mime-types (3.7.0)
       logger
@@ -1148,6 +1154,7 @@ GEM
     simplecov-rcov (0.3.7)
       simplecov (>= 0.4.1)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     singleton (0.3.0)
     snaky_hash (2.0.5)
       hashie (>= 0.1.0, < 6)

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -20,7 +20,14 @@ module McpServer
       transport = MCP::Server::Transports::StreamableHTTPTransport.new(
         server,
         stateless: true,
-        enable_json_response: true
+        enable_json_response: true,
+        # mcp >= 0.23 validates the request Host header for DNS-rebinding protection,
+        # defaulting to loopback hosts only. Allow this tenant's canonical host so
+        # requests to the hosted endpoint aren't rejected. In production the endpoint
+        # is served at https://#{host} (see AppConfiguration#base_uri), so this matches
+        # the incoming Host. NOTE: does not cover proxy/LB rewrites, custom-domain
+        # aliases, or browser clients (Origin).
+        allowed_hosts: [AppConfiguration.instance.host]
       )
 
       status, headers, body = transport.handle_request(request)

--- a/back/engines/commercial/mcp_server/spec/requests/mcp_endpoint_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/requests/mcp_endpoint_spec.rb
@@ -6,7 +6,7 @@ require 'rails_helper'
 # mcp >= 0.23 DNS-rebinding Host validation and our allowed_hosts config.
 # The test tenant host is 'example.org' (non-loopback), so these specs exercise
 # the real hosted-host allow path, which a localhost dev run cannot.
-describe 'MCP endpoint (POST /mcp)' do
+describe McpServer::McpController do
   let(:user) { create(:super_admin) }
 
   let(:oauth_app) do

--- a/back/engines/commercial/mcp_server/spec/requests/mcp_endpoint_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/requests/mcp_endpoint_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Covers the transport wiring in McpController#create — in particular the
+# mcp >= 0.23 DNS-rebinding Host validation and our allowed_hosts config.
+# The test tenant host is 'example.org' (non-loopback), so these specs exercise
+# the real hosted-host allow path, which a localhost dev run cannot.
+describe 'MCP endpoint (POST /mcp)' do
+  let(:user) { create(:super_admin) }
+
+  let(:oauth_app) do
+    Doorkeeper::Application.create!(
+      name: 'Test MCP Client', redirect_uri: 'https://client.example.com/cb', confidential: false
+    )
+  end
+
+  let(:token) do
+    Doorkeeper::AccessToken.create!(
+      resource_owner_id: user.id, application: oauth_app, scopes: 'mcp:access', expires_in: 7200
+    )
+  end
+
+  let(:headers) do
+    {
+      # Doorkeeper is configured with hash_token_secrets, so the raw secret is only
+      # available via plaintext_token on the freshly-built record (token.token is hashed).
+      'Authorization' => "Bearer #{token.plaintext_token}",
+      'CONTENT_TYPE' => 'application/json',
+      'ACCEPT' => 'application/json, text/event-stream'
+    }
+  end
+
+  let(:initialize_body) do
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-06-18',
+        capabilities: {},
+        clientInfo: { name: 'rspec', version: '1.0' }
+      }
+    }.to_json
+  end
+
+  before { SettingsService.new.activate_feature!('mcp_server') }
+
+  context 'when the request Host matches the tenant host' do
+    it 'passes DNS-rebinding validation and handles the request' do
+      host! 'example.org' # == AppConfiguration.instance.host
+
+      post '/mcp', params: initialize_body, headers: headers
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include('result')
+    end
+  end
+
+  context 'when the request Host is not an allowed host' do
+    it 'is rejected by DNS-rebinding protection before reaching the tools' do
+      host! 'attacker.example.net'
+
+      post '/mcp', params: initialize_body, headers: headers
+
+      expect(response).to have_http_status(:forbidden)
+    end
+  end
+end


### PR DESCRIPTION
Solving `mcp` part of recent [back-bundle-audit failures](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/344182/workflows/3288d464-7e99-43b1-99d3-31c9355f737a/jobs/783762).

Please review. Heavily Claude driven. On the surface, what Claude advises makes sense to me, but I am very unfamiliar with the related code & functionality. Even if it looks OK, it's probably good for you to be aware of the changes introduced.

Big Q: Might this break anything important on production? (e.g. I am unsure if `mcp` is currently active on any active tenant)

I left Claude's rather verbose comments in place, as they help explain the changes, etc.

Bump `mcp` 0.16 → 0.25 (security) + configure Host allowlist

## Gemfile.lock
Bumps `mcp` from 0.16.0 to 0.25.0, resolving 5 `back-bundle-audit` advisories (transport-layer DoS + DNS-rebinding: GHSA-h669-8m4g-r2hc, -52jp-gj8w-j6xh, -7683-3w9x-ch42, -5p9g-j988-pcwv, -rjr6-rcgv-9m7m). Conservative bump — no other app gems moved. mcp swapped its JSON-Schema lib (`json-schema → json_schemer`), pulling in `json_schemer`, `hana`, `simpleidn` (all MIT, auto-approved by license_finder).

## mcp_controller.rb
  
As of 0.23, `StreamableHTTPTransport` validates the request Host header for DNS-rebinding protection, defaulting to loopback hosts only. Without config, `/mcp` would reject every non-localhost request — i.e. break on all hosted tenants. Added `allowed_hosts: [AppConfiguration.instance.host]`, which matches the incoming Host in production (`base_uri` serves the endpoint at `https://#{host}`) and works in dev (`localhost`).
  
## Tests
  
The transport/controller was previously un-specced. Added `mcp_endpoint_spec.rb` covering `POST /mcp: an allowed host` (the tenant host) reaches the tools, a foreign host is rejected (403). Verified meaningful by mutation — removing allowed_hosts fails the allowed-host case.
  
 🔍 For review (deployment specifics Claude is guessing at)
  
- Is the incoming Host on /mcp actually `AppConfiguration.instance.host`, or does a proxy/LB rewrite it?
- Any tenants reaching /mcp via a custom domain / alias (would be rejected — only the canonical host is allowed)?
- Any browser-based MCP clients? If so they'll send an Origin that also needs allowlisting (`allowed_origins`, currently unset).

# Changelog
## Technical
- [No-ticket] bump mcp 0.16 → 0.25 (GHSA-h669-8m4g-r2hc + 4 others)
