### PR TITLE
[TAN-8287] Project page admin UI polish (sidebar, timeline, phase tabs)

### DIFF
--- a/front/app/components/admin/PostManager/components/PostTable/index.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/index.tsx
@@ -28,6 +28,12 @@ import NoPost from './NoPost';
 import Row from './Row';
 
 const Container = styled.div`
+  overflow-x: auto;
+
+  table {
+    min-width: 680px;
+  }
+
   .ui.table {
     margin-bottom: 0;
   }

--- a/front/app/components/admin/PostManager/index.tsx
+++ b/front/app/components/admin/PostManager/index.tsx
@@ -39,6 +39,7 @@ export const LeftColumn = styled.div`
 
 export const MiddleColumn = styled.div`
   flex: 1;
+  min-width: 0;
   transition: 200ms;
 `;
 

--- a/front/app/containers/Admin/index.tsx
+++ b/front/app/containers/Admin/index.tsx
@@ -61,6 +61,10 @@ export const RightColumn = styled.div`
     max-width: none;
   }
 
+  &.projectPage {
+    min-width: 0;
+  }
+
   &.noPadding {
     padding: 0;
     max-width: none;
@@ -163,8 +167,9 @@ const AdminPage = memo<Props>(({ className }) => {
       {sidebarRendered && <Sidebar />}
       <RightColumn
         className={`
-          ${fullWidth ? 'fullWidth' : ''} 
+          ${fullWidth ? 'fullWidth' : ''}
           ${noPadding ? 'noPadding' : ''}
+          ${isProjectPage ? 'projectPage' : ''}
         `}
       >
         <RouterOutlet />

--- a/front/app/containers/Admin/projects/index.tsx
+++ b/front/app/containers/Admin/projects/index.tsx
@@ -19,6 +19,7 @@ const AdminProjectsAndFolders = () => (
       display="flex"
       flexDirection="column"
       flexGrow={1}
+      minWidth="0"
     >
       <RouterOutlet />
     </Box>

--- a/front/app/containers/Admin/projects/project/newBackoffice/ProjectSidebar/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/ProjectSidebar/index.tsx
@@ -23,8 +23,8 @@ const ProjectSidebar = ({ projectId }: Props) => (
     minHeight="0"
     overflow="hidden"
   >
-    <ProjectNavRail projectId={projectId} />
     <Box flex="1 1 auto" minHeight="0" overflowY="auto">
+      <ProjectNavRail projectId={projectId} />
       <TimelinePhases projectId={projectId} />
     </Box>
   </Box>

--- a/front/app/containers/Admin/projects/project/newBackoffice/TimelinePhases/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/TimelinePhases/index.tsx
@@ -199,11 +199,6 @@ const TimelinePhases = ({ projectId }: Props) => {
                     m="0"
                     fontSize="s"
                     color={status === 'past' ? 'textSecondary' : 'textPrimary'}
-                    style={
-                      status === 'past'
-                        ? { textDecoration: 'line-through' }
-                        : undefined
-                    }
                   >
                     {localize(phase.attributes.title_multiloc)}
                   </Text>

--- a/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
+++ b/front/app/containers/Admin/projects/project/phase/PhaseHeader.tsx
@@ -41,6 +41,17 @@ const Container = styled(Box)`
   ${defaultCardStyle};
 `;
 
+// On narrow screens the tab strip scrolls sideways instead of squeezing the
+// tabs, so none of them (e.g. the last one) become unreachable.
+const TabBar = styled(Box)`
+  overflow-x: auto;
+  scrollbar-width: thin;
+
+  > * {
+    flex: 0 0 auto;
+  }
+`;
+
 export const participationMethodMessage: Record<
   ParticipationMethod,
   MessageDescriptor
@@ -225,7 +236,7 @@ export const PhaseHeader = ({ phase, tabs }: Props) => {
             )}
           </Box>
         </Box>
-        <Box
+        <TabBar
           className="intercom-product-tour-phase-tabs"
           display="flex"
           px="44px"
@@ -255,7 +266,7 @@ export const PhaseHeader = ({ phase, tabs }: Props) => {
               className={className}
             />
           ))}
-        </Box>
+        </TabBar>
       </Container>
       <TypedDeleteConfirmationModal
         opened={showDeleteModal}


### PR DESCRIPTION
# Changelog

## Changed
- The project admin sidebar now scrolls as a single column, so the navigation items at the top stay reachable as more phases are added below. Hidden behind the `parallel_participation` feature flag
- On narrow screens the project workspace now fits the available width instead of overflowing — the phase details (including the "…" actions menu) stay on screen, and the phase tab bar (Setup, Description, Input manager…) scrolls sideways instead of squeezing together.
- On narrow screens the input manager table keeps its columns at a readable width and scrolls sideways (headers and rows together) instead of squashing them.
- Past phases in the project timeline no longer show their title with a strikethrough; they stay muted but remain fully readable. Hidden behind the `parallel_participation` feature flag