### PR TITLE
[TAN-8235] Add rake task to migrate proposals phases off the perspectives feed view

### DIFF
--- a/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
+++ b/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
@@ -67,9 +67,11 @@ namespace :single_use do
     end
     puts '=' * 80
 
-    # Deliberately not `Tenant.creation_finalized` or `safe_switch_each`: both skip deleted tenants,
-    # and a tenant stuck mid-deletion still holds phases that the new rule would reject.
-    tenants = host ? Tenant.where(host: host) : Tenant.all
+    # Deliberately not `safe_switch_each`: it also skips tenants whose creation never finalized, and
+    # those are on their way to being live, so their phases have to satisfy the new rule too.
+    # Deleted tenants are skipped, though: nothing un-deletes one, no request or job switches into
+    # one, and its schema is being dropped, so no phase of theirs is ever saved against the rule.
+    tenants = host ? Tenant.not_deleted.where(host: host) : Tenant.not_deleted
 
     tenants.each do |tenant|
       next unless ActiveRecord::Base.connection.schema_exists?(tenant.schema_name)
@@ -77,13 +79,6 @@ namespace :single_use do
       reporter.add_processed_tenant(tenant)
 
       tenant.switch do
-        # Apartment migrates `Tenant.not_deleted` only, so a tenant deleted before the
-        # 20260223103753 migration never received the column, and cannot offer the feed view.
-        unless ActiveRecord::Base.connection.column_exists?(:phases, :available_views)
-          totals[:skipped_no_column] += 1
-          next
-        end
-
         phases = Phase
           .where(participation_method: 'proposals')
           .where("presentation_mode = 'feed' OR 'feed' = ANY(available_views)")
@@ -133,7 +128,6 @@ namespace :single_use do
     puts(execute ? '📊 MIGRATION SUMMARY:' : '📊 DRY RUN SUMMARY:')
     by_host = affected.group_by { |row| row[:host] }
     puts "   #{execute ? 'Migrated' : 'Would migrate'}: #{totals[:migrated]} phase(s) across #{by_host.size} tenant(s)"
-    puts "   Skipped (schema predates the available_views column): #{totals[:skipped_no_column]}"
     puts "   Errors: #{reporter.errors.size}"
 
     if by_host.any?

--- a/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
+++ b/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
@@ -19,9 +19,11 @@
 #     presentation_mode: 'map',  available_views: ['card', 'map']   ->  untouched, no feed
 #
 # `presentation_mode` is only rewritten when it is 'feed' itself: a phase that merely offered the
-# feed alongside cards keeps opening on whichever view the admin chose. 'card' is unioned back in
-# because the model requires it independently, so a phase that had somehow lost it would otherwise
-# be written back still invalid, and reported as migrated.
+# feed alongside cards keeps opening on whichever view the admin chose. Both 'card' and the
+# retained mode are unioned back into the views, because the model requires each of them
+# independently, so a phase that had drifted out of that state would otherwise be written back
+# still invalid, and reported as migrated. The writes bypass validation, so this is the only thing
+# standing between drifted data and a silently invalid row.
 #
 # The migration is a subtraction, so re-running the task is a no-op.
 #
@@ -86,8 +88,8 @@ namespace :single_use do
         multiloc_service = MultilocService.new
 
         phases.each do |phase|
-          new_views = ((phase.available_views || []) - ['feed']) | ['card']
           new_mode = phase.presentation_mode == 'feed' ? 'card' : phase.presentation_mode
+          new_views = ((phase.available_views || []) - ['feed']) | ['card'] | [new_mode]
 
           reporter.add_change(
             { presentation_mode: phase.presentation_mode, available_views: phase.available_views },

--- a/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
+++ b/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
@@ -49,15 +49,13 @@ namespace :single_use do
     totals = Hash.new(0)
     affected = []
 
-    # There is no single past/active/future helper, so this composes the two that exist. Both read
-    # `start_at` without a nil check, hence the guard: it is nullable on an unscheduled phase.
-    now = Time.zone.now
-    timeline_service = TimelineService.new
+    # TimelineService classifies a whole project, not a phase, so this composes the phase's own two
+    # predicates. `started?` reads `start_at` without a nil check, hence the guard: it is nullable.
     phase_timing = lambda do |phase|
       next 'unscheduled' if phase.start_at.nil?
-      next 'active' if timeline_service.phase_current?(phase, now)
+      next 'future' unless phase.started?
 
-      phase.started? ? 'finished' : 'future'
+      phase.complete? ? 'finished' : 'active'
     end
 
     if execute

--- a/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
+++ b/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
@@ -30,8 +30,9 @@
 # anything from that work: the method and the view are named literally here, because this is a
 # one-off repair of a known state rather than an expression of the rule.
 #
-# The affected tenants are printed and written to the report so that Support can notify the clients
-# whose phases changed underneath them.
+# Every affected phase is printed with its project and whether it is finished, active or still to
+# come, so the scale of the change is visible at a glance and an individual phase can be traced back
+# to its project if anyone asks about it. The report carries the same rows, with full multilocs.
 #
 # Analyses without writing unless passed 'execute'; a host limits the run to one tenant:
 #
@@ -46,7 +47,18 @@ namespace :single_use do
 
     reporter = ScriptReporter.new
     totals = Hash.new(0)
-    affected_hosts = []
+    affected = []
+
+    # There is no single past/active/future helper, so this composes the two that exist. Both read
+    # `start_at` without a nil check, hence the guard: it is nullable on an unscheduled phase.
+    now = Time.zone.now
+    timeline_service = TimelineService.new
+    phase_timing = lambda do |phase|
+      next 'unscheduled' if phase.start_at.nil?
+      next 'active' if timeline_service.phase_current?(phase, now)
+
+      phase.started? ? 'finished' : 'future'
+    end
 
     if execute
       puts '🚀 MIGRATION MODE: moving proposals phases off the feed view.'
@@ -78,6 +90,8 @@ namespace :single_use do
           .where(participation_method: 'proposals')
           .where("presentation_mode = 'feed' OR 'feed' = ANY(available_views)")
 
+        multiloc_service = MultilocService.new
+
         phases.each do |phase|
           new_views = ((phase.available_views || []) - ['feed']) | ['card']
           new_mode = phase.presentation_mode == 'feed' ? 'card' : phase.presentation_mode
@@ -89,18 +103,28 @@ namespace :single_use do
               tenant: tenant.host,
               phase_id: phase.id,
               phase_title: phase.title_multiloc,
+              phase_timing: phase_timing.call(phase),
               project_id: phase.project_id,
+              project_title: phase.project.title_multiloc,
               project_slug: phase.project.slug
             }
           )
+
+          # The report carries the full multilocs; this is only what a human needs on screen.
+          affected << {
+            host: tenant.host,
+            timing: phase_timing.call(phase),
+            phase_id: phase.id,
+            phase_title: multiloc_service.t(phase.title_multiloc),
+            project_id: phase.project_id,
+            project_title: multiloc_service.t(phase.project.title_multiloc)
+          }
 
           # `update_columns` because we migrate *to* a valid state. `update!` would re-run every
           # other validation on a phase we have not audited, and could fail for a second reason.
           phase.update_columns(presentation_mode: new_mode, available_views: new_views) if execute
           totals[:migrated] += 1
         end
-
-        affected_hosts << tenant.host if phases.any?
       end
     rescue StandardError => e
       # One unreachable tenant must not abort the run.
@@ -109,13 +133,20 @@ namespace :single_use do
 
     puts "\n#{'=' * 80}"
     puts(execute ? '📊 MIGRATION SUMMARY:' : '📊 DRY RUN SUMMARY:')
-    puts "   #{execute ? 'Migrated' : 'Would migrate'}: #{totals[:migrated]} phase(s) across #{affected_hosts.size} tenant(s)"
+    by_host = affected.group_by { |row| row[:host] }
+    puts "   #{execute ? 'Migrated' : 'Would migrate'}: #{totals[:migrated]} phase(s) across #{by_host.size} tenant(s)"
     puts "   Skipped (schema predates the available_views column): #{totals[:skipped_no_column]}"
     puts "   Errors: #{reporter.errors.size}"
 
-    if affected_hosts.any?
-      puts "\n   👥 Tenants whose clients should be notified:"
-      affected_hosts.each { |affected_host| puts "      #{affected_host}" }
+    if by_host.any?
+      puts "\n   👥 Tenants with migrated phases:"
+      by_host.each do |affected_host, rows|
+        puts "\n      #{affected_host}"
+        rows.each do |row|
+          puts "         phase   #{row[:phase_id]}  #{row[:phase_title]} (#{row[:timing]})"
+          puts "         project #{row[:project_id]}  #{row[:project_title]}"
+        end
+      end
     end
 
     report_file = execute ? 'migrate_proposals_phases_off_feed_view.json' : 'migrate_proposals_phases_off_feed_view_dry_run.json'

--- a/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
+++ b/back/lib/tasks/single_use/20260721_migrate_proposals_phases_off_feed_view.rake
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+# Moves proposals phases off the feed view (called "Perspectives" in the UI), back to cards.
+#
+# A phase offers a set of views (`available_views`) and opens on one of them (`presentation_mode`).
+# The feed view was offered on every method that shows inputs publicly, with no per-method
+# restriction — not because it suited them all, but to keep the admin interface consistent.
+#
+# It does not suit proposals. A proposal has to gather likes to reach its `reacting_threshold`, and
+# the feed surfaces neither the like count nor the progress towards that threshold, so participants
+# don't realise their proposal needs votes at all. At least one client configured a proposals phase
+# this way before we noticed.
+#
+# So the option is being withdrawn for this method, and this task migrates the phases already using
+# it:
+#
+#     presentation_mode: 'feed', available_views: ['card', 'feed']  ->  'card', ['card']
+#     presentation_mode: 'card', available_views: ['card', 'feed']  ->  'card', ['card']
+#     presentation_mode: 'map',  available_views: ['card', 'map']   ->  untouched, no feed
+#
+# `presentation_mode` is only rewritten when it is 'feed' itself: a phase that merely offered the
+# feed alongside cards keeps opening on whichever view the admin chose. 'card' is unioned back in
+# because the model requires it independently, so a phase that had somehow lost it would otherwise
+# be written back still invalid, and reported as migrated.
+#
+# The migration is a subtraction, so re-running the task is a no-op.
+#
+# This ships and runs ahead of the code that hides the option and rejects it in the API, so that
+# the stricter rule only ever meets data that already satisfies it. It therefore cannot lean on
+# anything from that work: the method and the view are named literally here, because this is a
+# one-off repair of a known state rather than an expression of the rule.
+#
+# The affected tenants are printed and written to the report so that Support can notify the clients
+# whose phases changed underneath them.
+#
+# Analyses without writing unless passed 'execute'; a host limits the run to one tenant:
+#
+#     rake single_use:migrate_proposals_phases_off_feed_view                     # dry run, all tenants
+#     rake 'single_use:migrate_proposals_phases_off_feed_view[execute]'          # migrate all tenants
+#     rake 'single_use:migrate_proposals_phases_off_feed_view[execute,foo.com]'  # migrate one tenant
+namespace :single_use do
+  desc "Move proposals phases off the feed view, back to cards. Dry run unless passed 'execute'."
+  task :migrate_proposals_phases_off_feed_view, %i[execute host] => [:environment] do |_t, args|
+    execute = args[:execute] == 'execute'
+    host = args[:host]
+
+    reporter = ScriptReporter.new
+    totals = Hash.new(0)
+    affected_hosts = []
+
+    if execute
+      puts '🚀 MIGRATION MODE: moving proposals phases off the feed view.'
+      puts '⚠️  THIS WILL MODIFY THE DATABASE'
+    else
+      puts '🔍 DRY RUN MODE: analysing without writing.'
+      puts '⚠️  NO DATABASE WRITES WILL BE PERFORMED'
+    end
+    puts '=' * 80
+
+    # Deliberately not `Tenant.creation_finalized` or `safe_switch_each`: both skip deleted tenants,
+    # and a tenant stuck mid-deletion still holds phases that the new rule would reject.
+    tenants = host ? Tenant.where(host: host) : Tenant.all
+
+    tenants.each do |tenant|
+      next unless ActiveRecord::Base.connection.schema_exists?(tenant.schema_name)
+
+      reporter.add_processed_tenant(tenant)
+
+      tenant.switch do
+        # Apartment migrates `Tenant.not_deleted` only, so a tenant deleted before the
+        # 20260223103753 migration never received the column, and cannot offer the feed view.
+        unless ActiveRecord::Base.connection.column_exists?(:phases, :available_views)
+          totals[:skipped_no_column] += 1
+          next
+        end
+
+        phases = Phase
+          .where(participation_method: 'proposals')
+          .where("presentation_mode = 'feed' OR 'feed' = ANY(available_views)")
+
+        phases.each do |phase|
+          new_views = ((phase.available_views || []) - ['feed']) | ['card']
+          new_mode = phase.presentation_mode == 'feed' ? 'card' : phase.presentation_mode
+
+          reporter.add_change(
+            { presentation_mode: phase.presentation_mode, available_views: phase.available_views },
+            { presentation_mode: new_mode, available_views: new_views },
+            context: {
+              tenant: tenant.host,
+              phase_id: phase.id,
+              phase_title: phase.title_multiloc,
+              project_id: phase.project_id,
+              project_slug: phase.project.slug
+            }
+          )
+
+          # `update_columns` because we migrate *to* a valid state. `update!` would re-run every
+          # other validation on a phase we have not audited, and could fail for a second reason.
+          phase.update_columns(presentation_mode: new_mode, available_views: new_views) if execute
+          totals[:migrated] += 1
+        end
+
+        affected_hosts << tenant.host if phases.any?
+      end
+    rescue StandardError => e
+      # One unreachable tenant must not abort the run.
+      reporter.add_error("#{e.class}: #{e.message}", context: { tenant: tenant.host })
+    end
+
+    puts "\n#{'=' * 80}"
+    puts(execute ? '📊 MIGRATION SUMMARY:' : '📊 DRY RUN SUMMARY:')
+    puts "   #{execute ? 'Migrated' : 'Would migrate'}: #{totals[:migrated]} phase(s) across #{affected_hosts.size} tenant(s)"
+    puts "   Skipped (schema predates the available_views column): #{totals[:skipped_no_column]}"
+    puts "   Errors: #{reporter.errors.size}"
+
+    if affected_hosts.any?
+      puts "\n   👥 Tenants whose clients should be notified:"
+      affected_hosts.each { |affected_host| puts "      #{affected_host}" }
+    end
+
+    report_file = execute ? 'migrate_proposals_phases_off_feed_view.json' : 'migrate_proposals_phases_off_feed_view_dry_run.json'
+    reporter.report!(report_file)
+    puts "\n   📝 Per-phase report: #{report_file}"
+  end
+end

--- a/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
+  before { load_rake_tasks_if_not_loaded }
+
+  after do
+    Rake::Task['single_use:migrate_proposals_phases_off_feed_view'].reenable
+    FileUtils.rm_f(report_path)
+    FileUtils.rm_f(dry_run_report_path)
+  end
+
+  let(:report_path) { Rails.root.join('migrate_proposals_phases_off_feed_view.json') }
+  let(:dry_run_report_path) { Rails.root.join('migrate_proposals_phases_off_feed_view_dry_run.json') }
+
+  # The task writes only when passed 'execute', so most examples want it; `dry_run: true` drops it.
+  def run_task(dry_run: false, host: nil)
+    Rake::Task['single_use:migrate_proposals_phases_off_feed_view'].invoke(dry_run ? nil : 'execute', host)
+  end
+
+  # The feed view is being withdrawn for proposals, so the model will refuse to build this state
+  # once the accompanying validation lands. Write it past validation, the way the admin UI did.
+  def offer_feed!(phase, presentation_mode: 'feed', available_views: %w[card feed])
+    phase.update_column(:presentation_mode, presentation_mode)
+    phase.update_column(:available_views, available_views)
+    phase
+  end
+
+  def report
+    JSON.parse(File.read(report_path))
+  end
+
+  context 'when a proposals phase opens on the feed view' do
+    let!(:phase) { offer_feed!(create(:proposals_phase)) }
+
+    it 'moves it back to the card view' do
+      run_task
+      expect(phase.reload.presentation_mode).to eq 'card'
+      expect(phase.reload.available_views).to eq ['card']
+    end
+
+    it 'records the change in the report' do
+      run_task
+      change = report['changes'].first
+      expect(change['old_value']).to eq('presentation_mode' => 'feed', 'available_views' => %w[card feed])
+      expect(change['new_value']).to eq('presentation_mode' => 'card', 'available_views' => ['card'])
+      expect(change['context']).to include(
+        'phase_id' => phase.id,
+        'project_id' => phase.project_id,
+        'project_slug' => phase.project.slug
+      )
+    end
+
+    it 'names the tenant so that Support can notify the client' do
+      expect { run_task }.to output(/Tenants whose clients should be notified:\s+#{Regexp.escape(Tenant.current.host)}/m).to_stdout
+    end
+
+    it 'processes a tenant that is marked as deleted' do
+      Tenant.current.update_column(:deleted_at, Time.zone.now)
+      run_task
+      expect(phase.reload.presentation_mode).to eq 'card'
+    end
+  end
+
+  # The admin chose that default and it remains available, so only the feed itself is withdrawn.
+  context 'when a proposals phase offers the feed view but opens on another one' do
+    let!(:phase) { offer_feed!(create(:proposals_phase), presentation_mode: 'map', available_views: %w[card map feed]) }
+
+    it 'removes the feed view and leaves the presentation mode alone' do
+      run_task
+      expect(phase.reload.presentation_mode).to eq 'map'
+      expect(phase.reload.available_views).to match_array %w[card map]
+    end
+  end
+
+  # Subtracting the feed alone would write back a phase that still fails `must include card view`,
+  # and report it as migrated.
+  context 'when a phase using the feed view also omits the card view' do
+    let!(:phase) { offer_feed!(create(:proposals_phase), available_views: ['feed']) }
+
+    it 'restores the card view' do
+      run_task
+      expect(phase.reload.available_views).to eq ['card']
+      expect(phase.reload).to be_valid
+    end
+  end
+
+  context 'when a proposals phase does not use the feed view' do
+    let!(:phase) { create(:proposals_phase, presentation_mode: 'map', available_views: %w[card map]) }
+
+    it 'leaves it untouched and reports no change' do
+      expect { run_task }.not_to(change { phase.reload.available_views })
+      expect(report['changes']).to be_empty
+      # Without this the example would also pass if the task had errored on every tenant.
+      expect(report['errors']).to be_empty
+      expect(report['processed_tenants']).to include(Tenant.current.host)
+    end
+  end
+
+  # The feed view remains available to ideation, which is the method it was designed for.
+  context 'when an ideation phase uses the feed view' do
+    let!(:phase) { create(:idea_feed_phase) }
+
+    it 'leaves it untouched' do
+      expect { run_task }.not_to(change { phase.reload.presentation_mode })
+      expect(report['changes']).to be_empty
+    end
+  end
+
+  context 'when the task is run twice' do
+    let!(:phase) { offer_feed!(create(:proposals_phase)) }
+
+    it 'reports nothing to do on the second run' do
+      run_task
+      Rake::Task['single_use:migrate_proposals_phases_off_feed_view'].reenable
+
+      expect { run_task }.not_to(change { phase.reload.available_views })
+      expect(report['changes']).to be_empty
+    end
+  end
+
+  # Apartment migrates `Tenant.not_deleted` only, so a tenant deleted before the
+  # 20260223103753 migration has no `available_views` column and cannot offer the feed view.
+  context 'when the schema predates the available_views column' do
+    let!(:phase) { offer_feed!(create(:proposals_phase)) }
+
+    before do
+      allow(ActiveRecord::Base.connection).to receive(:column_exists?)
+        .with(:phases, :available_views).and_return(false)
+    end
+
+    it 'skips the tenant without reporting an error' do
+      expect { run_task }.not_to raise_error
+      expect(report['errors']).to be_empty
+      expect(report['changes']).to be_empty
+    end
+  end
+
+  context 'with a dry run' do
+    let!(:phase) { offer_feed!(create(:proposals_phase)) }
+
+    it 'writes nothing but still reports the change it would make' do
+      expect { run_task(dry_run: true) }.not_to(change { phase.reload.available_views })
+
+      expect(File).not_to exist(report_path)
+      dry_run_report = JSON.parse(File.read(dry_run_report_path))
+      expect(dry_run_report['changes'].first['new_value'])
+        .to eq('presentation_mode' => 'card', 'available_views' => ['card'])
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
@@ -48,13 +48,34 @@ describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
       expect(change['new_value']).to eq('presentation_mode' => 'card', 'available_views' => ['card'])
       expect(change['context']).to include(
         'phase_id' => phase.id,
+        'phase_title' => phase.title_multiloc,
+        'phase_timing' => 'active',
         'project_id' => phase.project_id,
+        'project_title' => phase.project.title_multiloc,
         'project_slug' => phase.project.slug
       )
     end
 
-    it 'names the tenant so that Support can notify the client' do
-      expect { run_task }.to output(/Tenants whose clients should be notified:\s+#{Regexp.escape(Tenant.current.host)}/m).to_stdout
+    it 'names the tenant in the summary' do
+      expect { run_task }.to output(/Tenants with migrated phases:\s+#{Regexp.escape(Tenant.current.host)}/m).to_stdout
+    end
+
+    it 'prints the phase and its project under the tenant' do
+      expect { run_task }.to output(
+        /phase\s+#{phase.id}\s+.+ \(active\)\n\s+project\s+#{phase.project_id}\s/
+      ).to_stdout
+    end
+
+    it 'reports a phase that has ended as finished' do
+      phase.update!(start_at: Time.zone.today - 30.days, end_at: Time.zone.today - 7.days)
+      run_task
+      expect(report['changes'].first.dig('context', 'phase_timing')).to eq 'finished'
+    end
+
+    it 'reports a phase that has not started as future' do
+      phase.update!(start_at: Time.zone.today + 7.days, end_at: Time.zone.today + 30.days)
+      run_task
+      expect(report['changes'].first.dig('context', 'phase_timing')).to eq 'future'
     end
 
     it 'processes a tenant that is marked as deleted' do

--- a/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
@@ -78,10 +78,13 @@ describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
       expect(report['changes'].first.dig('context', 'phase_timing')).to eq 'future'
     end
 
-    it 'processes a tenant that is marked as deleted' do
+    # A deleted tenant is on a one-way trip to destruction: nothing un-deletes one and nothing
+    # switches into one, so no phase of its is ever saved against the rule this migration prepares.
+    it 'leaves a tenant that is marked as deleted alone' do
       Tenant.current.update_column(:deleted_at, Time.zone.now)
       run_task
-      expect(phase.reload.presentation_mode).to eq 'card'
+      expect(phase.reload.presentation_mode).to eq 'feed'
+      expect(report['processed_tenants']).to be_empty
     end
   end
 
@@ -138,23 +141,6 @@ describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
       Rake::Task['single_use:migrate_proposals_phases_off_feed_view'].reenable
 
       expect { run_task }.not_to(change { phase.reload.available_views })
-      expect(report['changes']).to be_empty
-    end
-  end
-
-  # Apartment migrates `Tenant.not_deleted` only, so a tenant deleted before the
-  # 20260223103753 migration has no `available_views` column and cannot offer the feed view.
-  context 'when the schema predates the available_views column' do
-    let!(:phase) { offer_feed!(create(:proposals_phase)) }
-
-    before do
-      allow(ActiveRecord::Base.connection).to receive(:column_exists?)
-        .with(:phases, :available_views).and_return(false)
-    end
-
-    it 'skips the tenant without reporting an error' do
-      expect { run_task }.not_to raise_error
-      expect(report['errors']).to be_empty
       expect(report['changes']).to be_empty
     end
   end

--- a/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/migrate_proposals_phases_off_feed_view_task_spec.ignore.rb
@@ -39,6 +39,8 @@ describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
       run_task
       expect(phase.reload.presentation_mode).to eq 'card'
       expect(phase.reload.available_views).to eq ['card']
+      # The task writes with `update_columns`, so nothing else checks what it leaves behind.
+      expect(phase.reload).to be_valid
     end
 
     it 'records the change in the report' do
@@ -96,11 +98,24 @@ describe 'single_use:migrate_proposals_phases_off_feed_view rake task' do
       run_task
       expect(phase.reload.presentation_mode).to eq 'map'
       expect(phase.reload.available_views).to match_array %w[card map]
+      expect(phase.reload).to be_valid
     end
   end
 
-  # Subtracting the feed alone would write back a phase that still fails `must include card view`,
-  # and report it as migrated.
+  # The model requires the mode it opens on to be among the views it offers, and phases exist that
+  # drifted out of that state. Subtracting the feed alone would write one back still invalid.
+  context 'when a phase opens on a view it does not offer' do
+    let!(:phase) { offer_feed!(create(:proposals_phase), presentation_mode: 'map', available_views: %w[card feed]) }
+
+    it 'restores the missing view' do
+      run_task
+      expect(phase.reload.presentation_mode).to eq 'map'
+      expect(phase.reload.available_views).to match_array %w[card map]
+      expect(phase.reload).to be_valid
+    end
+  end
+
+  # Same again for the card view, which the model requires of every phase.
   context 'when a phase using the feed view also omits the card view' do
     let!(:phase) { offer_feed!(create(:proposals_phase), available_views: ['feed']) }
 


### PR DESCRIPTION
Adds a single-use rake task that moves Proposals phases off the Perspectives (feed) view, back to cards.  
  - `presentation_mode: 'feed'` → `'card'`; `'feed'` removed from `available_views`.
  - A phase that merely *offered* the feed keeps opening on whichever view the admin chose.
  - Dry run by default; writes only when passed `execute`. Re-running is a no-op.
  - Prints and reports every affected phase with its project and whether it's finished, active or future.
  
To be run before and after deploying the code changes in #14344.

Note that a quick check on DACH revealed 4 active tenants with proposals phases that would be changed, 5 phases total (4 of which are currently 'open'). IMO, this means we do not ned to ask for comms to customers before we run the task (or deploy the related code changes).

# Changelog
## Technical
- [TAN-8235] Add rake task to migrate proposals phases off the perspectives feed view.
