### PR TITLE
TAN-8304 Put pack permissions_custom_fields FF behavior

### DIFF
--- a/front/app/components/admin/ActionForm/DataSection/DemographicSection/index.test.tsx
+++ b/front/app/components/admin/ActionForm/DataSection/DemographicSection/index.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+
+import { IPhasePermissionData } from 'api/phase_permissions/types';
+
+import { render, screen, userEvent } from 'utils/testUtils/rtl';
+
+import DemographicSection from '.';
+
+// `permissions_custom_fields` is the paid feature that gates this whole section.
+let mockPermissionsCustomFieldsAllowed = true;
+jest.mock('hooks/useFeatureFlag', () =>
+  jest.fn(({ name }: { name: string }) =>
+    name === 'permissions_custom_fields'
+      ? mockPermissionsCustomFieldsAllowed
+      : false
+  )
+);
+
+// The section reads the permission custom fields plus three mutation hooks -
+// stub them so we can render without a backend.
+jest.mock(
+  'api/permissions_phase_custom_fields/usePermissionsPhaseCustomFields',
+  () => jest.fn(() => ({ data: { data: [] } }))
+);
+jest.mock(
+  'api/permissions_phase_custom_fields/useAddPermissionsPhaseCustomField',
+  () => jest.fn(() => ({ mutate: jest.fn(), isLoading: false }))
+);
+jest.mock(
+  'api/permissions_phase_custom_fields/useUpdatePermissionsPhaseCustomField',
+  () => jest.fn(() => ({ mutate: jest.fn() }))
+);
+jest.mock(
+  'api/permissions_phase_custom_fields/useDeletePermissionsPhaseCustomField',
+  () => jest.fn(() => ({ mutate: jest.fn() }))
+);
+
+// Orthogonal children with their own data dependencies - stub them out.
+jest.mock('./DemographicsPlacement', () => () => null);
+jest.mock('./FieldSelectionModal', () => () => null);
+jest.mock(
+  './FieldsList',
+  () => () => require('react').createElement('div', null, 'FIELDS_LIST')
+);
+
+const UPSELL_COPY = /This feature is not included in your current plan/i;
+
+const buildPermission = (
+  attributes: Partial<IPhasePermissionData['attributes']> = {}
+): IPhasePermissionData =>
+  ({
+    id: 'perm-1',
+    type: 'permission',
+    attributes: {
+      action: 'commenting_idea',
+      permitted_by: 'users',
+      user_fields_in_form_descriptor: {},
+      ...attributes,
+    },
+    relationships: {
+      permission_scope: { data: { id: 'ph-1', type: 'phase' } },
+      groups: { data: [] },
+    },
+  } as unknown as IPhasePermissionData);
+
+const renderSection = () =>
+  render(
+    <DemographicSection
+      permission={buildPermission()}
+      phaseId="ph-1"
+      permissionHasForm={false}
+      onChange={jest.fn()}
+    />
+  );
+
+beforeEach(() => {
+  mockPermissionsCustomFieldsAllowed = true;
+});
+
+describe('<DemographicSection />', () => {
+  describe('when permissions_custom_fields is allowed', () => {
+    it('renders an expandable, unlocked section', async () => {
+      renderSection();
+
+      // The section header is always shown...
+      expect(screen.getByText('Demographic questions')).toBeInTheDocument();
+      // ...and there is no lock tooltip.
+      expect(
+        screen.queryByTestId('tooltip-icon-button')
+      ).not.toBeInTheDocument();
+
+      // The controls are hidden until the row is expanded.
+      expect(screen.queryByText('FIELDS_LIST')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('Demographic questions'));
+
+      expect(screen.getByText('FIELDS_LIST')).toBeInTheDocument();
+      expect(
+        screen.getByText('Add a demographic question')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('when permissions_custom_fields is NOT allowed', () => {
+    beforeEach(() => {
+      mockPermissionsCustomFieldsAllowed = false;
+    });
+
+    it('still shows the section header', () => {
+      renderSection();
+      expect(screen.getByText('Demographic questions')).toBeInTheDocument();
+    });
+
+    it('does not render any of the section controls', () => {
+      renderSection();
+      expect(screen.queryByText('FIELDS_LIST')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Add a demographic question')
+      ).not.toBeInTheDocument();
+    });
+
+    it('cannot be expanded to reveal the controls', async () => {
+      renderSection();
+
+      await userEvent.click(screen.getByText('Demographic questions'));
+
+      expect(screen.queryByText('FIELDS_LIST')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Add a demographic question')
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows a lock tooltip explaining it is not part of the pricing plan', async () => {
+      renderSection();
+
+      const tooltip = screen.getByTestId('tooltip-icon-button');
+      await userEvent.hover(tooltip);
+
+      expect(await screen.findByText(UPSELL_COPY)).toBeInTheDocument();
+    });
+  });
+});

--- a/front/app/components/admin/ActionForm/DataSection/DemographicSection/index.tsx
+++ b/front/app/components/admin/ActionForm/DataSection/DemographicSection/index.tsx
@@ -18,6 +18,10 @@ import usePermissionsPhaseCustomFields from 'api/permissions_phase_custom_fields
 import useUpdatePermissionsPhaseCustomField from 'api/permissions_phase_custom_fields/useUpdatePermissionsPhaseCustomField';
 import { IPhasePermissionData } from 'api/phase_permissions/types';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
+import upsellMessages from 'components/UpsellTooltip/messages';
+
 import { useIntl } from 'utils/cl-intl';
 
 import { demographicsSummary } from '../../logic';
@@ -47,6 +51,12 @@ const DemographicSection = ({
   const [showSelectionModal, setShowSelectionModal] = useState(false);
   const { formatMessage } = useIntl();
 
+  // Demographic questions rely on permission custom fields, which are a paid
+  // feature. Gate the whole section behind the tenant's pricing plan.
+  const permissionsCustomFieldsAllowed = useFeatureFlag({
+    name: 'permissions_custom_fields',
+  });
+
   const { data: permissionFields } = usePermissionsPhaseCustomFields({
     phaseId,
     action,
@@ -61,6 +71,22 @@ const DemographicSection = ({
     phaseId,
     action,
   });
+
+  // Without the feature the section is shown but locked: no controls, just a
+  // lock icon and a tooltip explaining it isn't part of the pricing plan.
+  if (!permissionsCustomFieldsAllowed) {
+    return (
+      <Expander
+        icon="user-data"
+        title={formatMessage(messages.demographicQuestions)}
+        summary={null}
+        locked
+        lockedTooltip={formatMessage(upsellMessages.tooltipContent)}
+      >
+        {null}
+      </Expander>
+    );
+  }
 
   if (!permissionFields) return null;
 

--- a/front/app/components/admin/ActionForm/ui.tsx
+++ b/front/app/components/admin/ActionForm/ui.tsx
@@ -150,6 +150,10 @@ export const ModeCard = ({
  * muted one-line summary of its current value; expanded it reveals its
  * controls. This is the main tool against "the interface is too full" — every
  * optional setting hides behind one of these until the admin opens it.
+ *
+ * When `locked` is set the row is disabled: it can't be expanded, its children
+ * are never rendered, and a lock icon with a tooltip (`lockedTooltip`) explains
+ * why. Used to gate a section behind the tenant's pricing plan.
  */
 export const Expander = ({
   icon,
@@ -157,14 +161,57 @@ export const Expander = ({
   summary,
   children,
   defaultOpen = false,
+  locked = false,
+  lockedTooltip,
 }: {
   icon: IconNames;
   title: string;
   summary: ReactNode;
   children: ReactNode;
   defaultOpen?: boolean;
+  locked?: boolean;
+  lockedTooltip?: string;
 }) => {
   const [open, setOpen] = useState(defaultOpen);
+
+  if (locked) {
+    return (
+      <Box>
+        <Box w="100%" display="flex" alignItems="center" gap="10px" py="12px">
+          <Icon
+            name="chevron-right"
+            width="16px"
+            height="16px"
+            fill={colors.coolGrey300}
+          />
+          <Icon
+            name={icon}
+            width="16px"
+            height="16px"
+            fill={colors.coolGrey300}
+          />
+          <Text
+            as="span"
+            m="0"
+            fontSize="s"
+            fontWeight="semi-bold"
+            color="coolGrey500"
+          >
+            {title}
+          </Text>
+          {lockedTooltip && (
+            <IconTooltip
+              icon="lock"
+              iconSize="16px"
+              iconColor={colors.coolGrey500}
+              content={lockedTooltip}
+            />
+          )}
+          <Box flex="1 1 auto" />
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box>


### PR DESCRIPTION
# Changelog
## Fixed
- Make sure that if tenant does not have `permissions_custom_fields` enabled, they can't change demographic fields
