### PR TITLE
[TAN-8297] Create phone confirmation on demand instead of for every user

### DIFF
--- a/back/app/controllers/web_api/v1/request_codes_controller.rb
+++ b/back/app/controllers/web_api/v1/request_codes_controller.rb
@@ -2,6 +2,7 @@
 
 class WebApi::V1::RequestCodesController < ApplicationController
   skip_before_action :authenticate_user, only: %i[request_code_unauthenticated]
+  before_action :ensure_new_phone_confirmation, only: %i[request_code_phone_change]
 
   # This endpoint allows unauthenticated users to request a confirmation code
   # This is used in the email account creation flow and when
@@ -75,6 +76,15 @@ class WebApi::V1::RequestCodesController < ApplicationController
   end
 
   private
+
+  # SMS is opt-in per tenant, so the phone confirmation is created on demand
+  # rather than for every user (see User#create_confirmations). It has to exist
+  # before RequestCodePolicy reads its code_reset_count.
+  def ensure_new_phone_confirmation
+    return unless AppConfiguration.instance.feature_activated?('sms')
+
+    current_user.new_phone_confirmation || current_user.create_new_phone_confirmation!
+  end
 
   def request_code_unauthenticated_params
     params.require(:request_code).permit(:email)

--- a/back/app/jobs/request_new_phone_confirmation_code_job.rb
+++ b/back/app/jobs/request_new_phone_confirmation_code_job.rb
@@ -8,7 +8,7 @@ class RequestNewPhoneConfirmationCodeJob < ApplicationJob
 
     ActiveRecord::Base.transaction do
       user.update!(new_phone: new_phone)
-      confirmation = user.new_phone_confirmation || user.create_new_phone_confirmation!
+      confirmation = user.new_phone_confirmation
       confirmation.reset_code!
       campaign = EmailCampaigns::Campaigns::NewPhoneConfirmation.first_or_create!
       EmailCampaigns::DeliveryService.new.send_now_to_user(campaign, user, { code: confirmation.code })

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -546,7 +546,6 @@ class User < ApplicationRecord
   def create_confirmations
     EmailConfirmation.create!(user: self)
     NewEmailConfirmation.create!(user: self)
-    NewPhoneConfirmation.create!(user: self)
   end
 
   def remove_initiated_notifications

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -253,6 +253,7 @@ resource 'Confirmations' do
 
       before do
         header_token_for user
+        user.create_new_phone_confirmation!
         RequestNewPhoneConfirmationCodeJob.perform_now(user, new_phone: new_phone)
       end
 

--- a/back/spec/acceptance/request_codes_spec.rb
+++ b/back/spec/acceptance/request_codes_spec.rb
@@ -174,6 +174,20 @@ resource 'Request codes' do
         .with(an_instance_of(EmailCampaigns::Campaigns::NewPhoneConfirmation), user, hash_including(:code)).once
     end
 
+    example 'It works for a user without an existing new_phone_confirmation' do
+      user = create(:user)
+      expect(user.new_phone_confirmation).to be_nil
+      header_token_for(user)
+
+      do_request(request_code: { new_phone: '+1 415 555 2671' })
+
+      expect(response_status).to eq 200
+      expect(user.reload.new_phone).to eq '+14155552671'
+      expect(user.new_phone_confirmation).to be_present
+      expect(delivery_service).to have_received(:send_now_to_user)
+        .with(an_instance_of(EmailCampaigns::Campaigns::NewPhoneConfirmation), user, hash_including(:code)).once
+    end
+
     example 'It does not work if new_phone is blank' do
       user = create(:user)
       header_token_for(user)
@@ -201,7 +215,7 @@ resource 'Request codes' do
 
     example 'It does not work if the user reached code_reset_count' do
       user = create(:user)
-      user.new_phone_confirmation.update!(code_reset_count: 4)
+      user.create_new_phone_confirmation!(code_reset_count: 4)
       header_token_for(user)
       do_request(request_code: { new_phone: '+14155552671' })
       expect(response_status).to eq 401

--- a/back/spec/jobs/request_new_phone_confirmation_code_job_spec.rb
+++ b/back/spec/jobs/request_new_phone_confirmation_code_job_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe RequestNewPhoneConfirmationCodeJob do
   # is actually invoked.
   include_context 'with stubbed SMS provider'
 
+  # In the real flow the confirmation is created by the controller's
+  # ensure_new_phone_confirmation before_action; the job assumes it exists.
+  before { user.create_new_phone_confirmation! }
+
   it 'stores the number as the pending new_phone, leaving phone unset' do
     job.perform(user, new_phone: new_phone)
     expect(user.reload.new_phone).to eq new_phone

--- a/back/spec/models/new_phone_confirmation_spec.rb
+++ b/back/spec/models/new_phone_confirmation_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe NewPhoneConfirmation do
     it 'promotes new_phone to phone, stamps confirmed_at and clears the code' do
       user = create(:user)
       user.update!(new_phone: '+14155552671')
-      user.new_phone_confirmation.update!(code: '1234', code_sent_at: Time.zone.now)
+      user.create_new_phone_confirmation!(code: '1234', code_sent_at: Time.zone.now)
 
       expect(user.new_phone_confirmation.confirm!).to be true
 
@@ -20,7 +20,7 @@ RSpec.describe NewPhoneConfirmation do
 
     it 'returns false when there is no pending phone number' do
       user = create(:user)
-      expect(user.new_phone_confirmation.confirm!).to be false
+      expect(user.create_new_phone_confirmation!.confirm!).to be false
       expect(user.reload.phone).to be_nil
     end
 
@@ -28,7 +28,7 @@ RSpec.describe NewPhoneConfirmation do
       other = create(:user, new_phone: '+14155552671')
       user = create(:user, new_phone: '+14155552671')
 
-      user.new_phone_confirmation.confirm!
+      user.create_new_phone_confirmation!.confirm!
 
       expect(other.reload.new_phone).to be_nil
     end
@@ -37,7 +37,7 @@ RSpec.describe NewPhoneConfirmation do
   describe '#pending?' do
     it 'is true only when a new_phone is set' do
       user = create(:user)
-      expect(user.new_phone_confirmation.pending?).to be false
+      expect(user.create_new_phone_confirmation!.pending?).to be false
 
       user.update!(new_phone: '+14155552671')
       expect(user.new_phone_confirmation.pending?).to be true

--- a/back/spec/services/user_confirmation_service_spec.rb
+++ b/back/spec/services/user_confirmation_service_spec.rb
@@ -165,6 +165,7 @@ RSpec.describe UserConfirmationService do
     include_context 'with stubbed SMS provider'
 
     before do
+      user.create_new_phone_confirmation!
       RequestNewPhoneConfirmationCodeJob.perform_now(user, new_phone: new_phone)
     end
 


### PR DESCRIPTION
# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
