### PR TITLE
TAN-8309: Fix editors signed out when opening content builder preview

### DIFF
--- a/front/app/containers/Admin/projects/project/newBackoffice/ProjectPage/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/ProjectPage/index.tsx
@@ -124,10 +124,8 @@ const ProjectPage = () => {
 
   const slug = project.data.attributes.slug;
 
-  // This frames the real front-office page, so it has no preview-specific path to
-  // recognise. The marker tells the app inside the frame not to boot tenant
-  // analytics — those would re-run third-party tags that can clear the shared auth
-  // cookie and sign the admin out. See isInContentBuilderPreview / TAN-8309.
+  // Frames the real front-office page, so it needs the marker rather than a
+  // preview path to stop trackers booting inside it. See TAN-8309.
   const previewParams = new URLSearchParams(window.location.search);
   previewParams.set(PREVIEW_FRAME_PARAM, 'true');
   const previewSrc = `/${locale}/projects/${slug}?${previewParams.toString()}`;

--- a/front/app/containers/Admin/projects/project/newBackoffice/ProjectPage/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/ProjectPage/index.tsx
@@ -14,6 +14,7 @@ import useLocale from 'hooks/useLocale';
 
 import { useIntl } from 'utils/cl-intl';
 import clHistory from 'utils/cl-router/history';
+import { PREVIEW_FRAME_PARAM } from 'utils/isInContentBuilderPreview';
 import { useParams } from 'utils/router';
 
 import messages from '../messages';
@@ -122,7 +123,14 @@ const ProjectPage = () => {
   }
 
   const slug = project.data.attributes.slug;
-  const previewSrc = `/${locale}/projects/${slug}${window.location.search}`;
+
+  // This frames the real front-office page, so it has no preview-specific path to
+  // recognise. The marker tells the app inside the frame not to boot tenant
+  // analytics — those would re-run third-party tags that can clear the shared auth
+  // cookie and sign the admin out. See isInContentBuilderPreview / TAN-8309.
+  const previewParams = new URLSearchParams(window.location.search);
+  previewParams.set(PREVIEW_FRAME_PARAM, 'true');
+  const previewSrc = `/${locale}/projects/${slug}?${previewParams.toString()}`;
 
   const openContentBuilder = () => {
     clHistory.push(

--- a/front/app/modules/commercial/google_analytics/index.ts
+++ b/front/app/modules/commercial/google_analytics/index.ts
@@ -9,6 +9,7 @@ import {
 
 import { initializeFor, shutdownFor } from 'utils/analytics';
 import { isNilOrError } from 'utils/helperUtils';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 declare module 'components/ConsentManager/destinations' {
@@ -26,6 +27,8 @@ const destinationConfig: IDestinationConfig = {
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     // Initialize
     combineLatest([
       appConfigurationStream,

--- a/front/app/modules/commercial/google_tag_manager/index.tsx
+++ b/front/app/modules/commercial/google_tag_manager/index.tsx
@@ -12,6 +12,7 @@ import {
 import { initializeFor } from 'utils/analytics';
 import { FormattedMessage } from 'utils/cl-intl';
 import { isNilOrError } from 'utils/helperUtils';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 import messages from './messages';
@@ -39,6 +40,8 @@ const destinationConfig: IDestinationConfig = {
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     combineLatest([
       appConfigurationStream,
       initializeFor('google_tag_manager'),

--- a/front/app/modules/commercial/impact_tracking/index.ts
+++ b/front/app/modules/commercial/impact_tracking/index.ts
@@ -6,6 +6,7 @@ import { pageChanges$, virtualPageViews$ } from 'utils/analytics';
 import { getJwt } from 'utils/auth/jwt';
 import fetcher from 'utils/cl-react-query/fetcher';
 import { getRoutePattern } from 'utils/getRoutePattern';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 let sessionId: string | undefined;
@@ -100,6 +101,8 @@ let userWasAuthenticated = !!getJwt();
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     pageChanges$.subscribe((e) => {
       // We remove the trailing slash from the path,
       // so that we don't track e.g. /en and /en/ as two different paths.

--- a/front/app/modules/commercial/intercom/index.ts
+++ b/front/app/modules/commercial/intercom/index.ts
@@ -18,6 +18,7 @@ import {
   tenantInfo,
 } from 'utils/analytics';
 import { isNilOrError } from 'utils/helperUtils';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import { isAdmin, isRegularUser } from 'utils/permissions/roles';
 import { getFullName } from 'utils/textUtils';
@@ -41,6 +42,8 @@ const destinationConfig: IDestinationConfig = {
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     combineLatest([
       appConfigurationStream,
       authUserStream,

--- a/front/app/modules/commercial/matomo/index.ts
+++ b/front/app/modules/commercial/matomo/index.ts
@@ -15,6 +15,7 @@ import {
   pageChanges$,
   shutdownFor,
 } from 'utils/analytics';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 import { trackEvent, trackPageChange } from './actions';
@@ -35,6 +36,8 @@ const destinationConfig: IDestinationConfig = {
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     // Subscribe to changes in app configuration, users
     // and matomo enabled state
     combineLatest([

--- a/front/app/modules/commercial/posthog_integration/index.ts
+++ b/front/app/modules/commercial/posthog_integration/index.ts
@@ -23,6 +23,7 @@ import { IUser } from 'api/users/types';
 import { events$, pageChanges$ } from 'utils/analytics';
 import eventEmitter, { IEventEmitterEvent } from 'utils/eventEmitter';
 import { isNilOrError } from 'utils/helperUtils';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import { isAdmin, isRegularUser } from 'utils/permissions/roles';
 import { getFullName } from 'utils/textUtils';
@@ -114,6 +115,7 @@ eventEmitter
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
     if (!POSTHOG_API_KEY) return;
 
     combineLatest([

--- a/front/app/modules/commercial/posthog_user_tracking/index.ts
+++ b/front/app/modules/commercial/posthog_user_tracking/index.ts
@@ -9,6 +9,7 @@ import {
 } from 'components/ConsentManager/destinations';
 
 import { initializeFor } from 'utils/analytics';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 
 import { initializePosthog } from '../posthog_integration';
@@ -30,6 +31,7 @@ const POSTHOG_API_KEY = process.env.POSTHOG_API_KEY;
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
     if (!POSTHOG_API_KEY) return;
     // Subscribe to changes in app configuration, users
     // and Posthog enabled state

--- a/front/app/modules/commercial/satismeter/index.ts
+++ b/front/app/modules/commercial/satismeter/index.ts
@@ -14,6 +14,7 @@ import {
   initializeFor,
 } from 'utils/analytics';
 import { isNilOrError } from 'utils/helperUtils';
+import { isInContentBuilderPreview } from 'utils/isInContentBuilderPreview';
 import { ModuleConfiguration } from 'utils/moduleUtils';
 import { isAdmin, isRegularUser, isSuperAdmin } from 'utils/permissions/roles';
 import { getFullName } from 'utils/textUtils';
@@ -37,6 +38,8 @@ const destinationConfig: IDestinationConfig = {
 
 const configuration: ModuleConfiguration = {
   beforeMountApplication: () => {
+    if (isInContentBuilderPreview()) return;
+
     combineLatest([
       appConfigurationStream,
       authUserStream,

--- a/front/app/utils/isInContentBuilderPreview.test.ts
+++ b/front/app/utils/isInContentBuilderPreview.test.ts
@@ -1,0 +1,52 @@
+import {
+  isContentBuilderPreviewPath,
+  isInContentBuilderPreview,
+} from './isInContentBuilderPreview';
+
+describe('isContentBuilderPreviewPath', () => {
+  it('matches content-builder preview routes', () => {
+    expect(
+      isContentBuilderPreviewPath(
+        '/en/admin/project-page-builder/projects/abc/preview'
+      )
+    ).toBe(true);
+    expect(
+      isContentBuilderPreviewPath(
+        '/en/admin/description-builder/projects/abc/preview'
+      )
+    ).toBe(true);
+    expect(
+      isContentBuilderPreviewPath(
+        '/en/admin/description-builder/folders/abc/preview'
+      )
+    ).toBe(true);
+    expect(
+      isContentBuilderPreviewPath(
+        '/en/admin/pages-menu/homepage-builder/preview'
+      )
+    ).toBe(true);
+  });
+
+  it('does not match non-preview routes', () => {
+    expect(
+      isContentBuilderPreviewPath('/en/admin/projects/abc/project-page')
+    ).toBe(false);
+    expect(isContentBuilderPreviewPath('/en/projects/my-project')).toBe(false);
+  });
+
+  it('does not match preview routes of other builders', () => {
+    expect(
+      isContentBuilderPreviewPath(
+        '/en/admin/reporting/report-builder/abc/preview'
+      )
+    ).toBe(false);
+  });
+});
+
+describe('isInContentBuilderPreview', () => {
+  // In jsdom the app runs as the top-level document (window.self === window.top),
+  // i.e. not framed, so the guard is never active regardless of the path.
+  it('returns false when not running inside an iframe', () => {
+    expect(isInContentBuilderPreview()).toBe(false);
+  });
+});

--- a/front/app/utils/isInContentBuilderPreview.test.ts
+++ b/front/app/utils/isInContentBuilderPreview.test.ts
@@ -50,9 +50,8 @@ describe('isInContentBuilderPreview', () => {
   const originalSelf = window.self;
   const originalPathname = window.location.pathname;
 
-  // jsdom has no real frames, so we fake the check the util performs.
-  // `window.top` is unforgeable and cannot be redefined; `self` can, so
-  // pointing it elsewhere is what makes `window.self !== window.top`.
+  // `window.top` is unforgeable; `self` can be redefined, so pointing it
+  // elsewhere is what makes `window.self !== window.top`.
   const setFramed = (framed: boolean) => {
     Object.defineProperty(window, 'self', {
       value: framed ? ({} as Window) : originalSelf,
@@ -90,9 +89,6 @@ describe('isInContentBuilderPreview', () => {
     expect(isInContentBuilderPreview()).toBe(false);
   });
 
-  // The new project edit page (newBackoffice/ProjectPage) frames the real
-  // front-office project page, which has no preview-specific path — it is
-  // recognised by PREVIEW_FRAME_PARAM instead. See TAN-8309.
   it('returns true inside the project page front-office preview iframe', () => {
     setPathname(`/en/projects/my-project?${PREVIEW_FRAME_PARAM}=true`);
     setFramed(true);

--- a/front/app/utils/isInContentBuilderPreview.test.ts
+++ b/front/app/utils/isInContentBuilderPreview.test.ts
@@ -1,4 +1,5 @@
 import {
+  PREVIEW_FRAME_PARAM,
   isContentBuilderPreviewPath,
   isInContentBuilderPreview,
 } from './isInContentBuilderPreview';
@@ -44,9 +45,71 @@ describe('isContentBuilderPreviewPath', () => {
 });
 
 describe('isInContentBuilderPreview', () => {
-  // In jsdom the app runs as the top-level document (window.self === window.top),
-  // i.e. not framed, so the guard is never active regardless of the path.
-  it('returns false when not running inside an iframe', () => {
+  const PREVIEW_PATH = '/en/admin/project-page-builder/projects/abc/preview';
+
+  const originalSelf = window.self;
+  const originalPathname = window.location.pathname;
+
+  // jsdom has no real frames, so we fake the check the util performs.
+  // `window.top` is unforgeable and cannot be redefined; `self` can, so
+  // pointing it elsewhere is what makes `window.self !== window.top`.
+  const setFramed = (framed: boolean) => {
+    Object.defineProperty(window, 'self', {
+      value: framed ? ({} as Window) : originalSelf,
+      configurable: true,
+      writable: true,
+    });
+  };
+
+  // replaceState changes location.pathname without triggering a jsdom navigation.
+  const setPathname = (pathname: string) =>
+    window.history.replaceState({}, '', pathname);
+
+  afterEach(() => {
+    setFramed(false);
+    setPathname(originalPathname);
+  });
+
+  it('returns true on a preview route inside an iframe', () => {
+    setPathname(PREVIEW_PATH);
+    setFramed(true);
+
+    expect(isInContentBuilderPreview()).toBe(true);
+  });
+
+  it('returns false on a preview route that is not framed', () => {
+    setPathname(PREVIEW_PATH);
+
     expect(isInContentBuilderPreview()).toBe(false);
+  });
+
+  it('returns false inside an iframe on a route that is not a preview', () => {
+    setPathname('/en/admin/projects/abc/settings');
+    setFramed(true);
+
+    expect(isInContentBuilderPreview()).toBe(false);
+  });
+
+  // The new project edit page (newBackoffice/ProjectPage) frames the real
+  // front-office project page, which has no preview-specific path — it is
+  // recognised by PREVIEW_FRAME_PARAM instead. See TAN-8309.
+  it('returns true inside the project page front-office preview iframe', () => {
+    setPathname(`/en/projects/my-project?${PREVIEW_FRAME_PARAM}=true`);
+    setFramed(true);
+
+    expect(isInContentBuilderPreview()).toBe(true);
+  });
+
+  it('returns false on a marked preview URL that is not framed', () => {
+    setPathname(`/en/projects/my-project?${PREVIEW_FRAME_PARAM}=true`);
+
+    expect(isInContentBuilderPreview()).toBe(false);
+  });
+
+  it('preserves other query params alongside the marker', () => {
+    setPathname(`/en/projects/my-project?foo=bar&${PREVIEW_FRAME_PARAM}=true`);
+    setFramed(true);
+
+    expect(isInContentBuilderPreview()).toBe(true);
   });
 });

--- a/front/app/utils/isInContentBuilderPreview.ts
+++ b/front/app/utils/isInContentBuilderPreview.ts
@@ -28,5 +28,3 @@ const isFramed = (): boolean => {
 
 export const isInContentBuilderPreview = (): boolean =>
   isContentBuilderPreviewPath(window.location.pathname) && isFramed();
-
-export default isInContentBuilderPreview;

--- a/front/app/utils/isInContentBuilderPreview.ts
+++ b/front/app/utils/isInContentBuilderPreview.ts
@@ -1,21 +1,19 @@
-// Admin editors render a live preview inside a same-origin <iframe> that boots a
-// second copy of the whole app. Re-running tenant analytics there re-runs whatever
-// those tags load — for one tenant, GTM loads a nested container that injects Civic
-// Cookie Control, whose cookie purge deletes the shared `cl2_jwt` and signs the
-// editor out. Trackers use this to skip booting inside such frames. See TAN-8309.
+// Content-builder editors (project page, project/folder description, homepage)
+// render their live preview inside a same-origin <iframe> pointing at an
+// `.../preview` admin route. That iframe boots a second copy of the whole app,
+// which would re-run tenant analytics/consent scripts (e.g. Civic Cookie Control
+// loaded via GTM). Re-running them inside the frame can wipe the shared auth
+// cookie and sign the editor out, and re-prompts for cookie consent. Trackers
+// use this to skip booting there. See TAN-8309.
 //
-// Two kinds of preview frame exist:
-//   - content-builder editors (project page, project/folder description, homepage),
-//     which frame an `.../preview` admin route;
-//   - the project edit page, which frames the real front-office project page and so
-//     has no distinguishing path — it carries PREVIEW_FRAME_PARAM instead.
+// The project edit page frames the real front-office page, so it has no
+// `.../preview` path and marks its iframe with PREVIEW_FRAME_PARAM instead.
 const CONTENT_BUILDER_PREVIEW_SEGMENTS = [
   'project-page-builder',
   'description-builder',
   'homepage-builder',
 ];
 
-/** Marks an iframe src as an in-app preview. Set by whoever renders the frame. */
 export const PREVIEW_FRAME_PARAM = 'preview_frame';
 
 export const isContentBuilderPreviewPath = (pathname: string): boolean =>
@@ -36,8 +34,7 @@ const isFramed = (): boolean => {
   }
 };
 
-// Framing is required as well as the path/param: opening either URL directly in a
-// tab is an ordinary page view that should still be tracked.
+// Framing is required too: opening either URL directly is an ordinary page view.
 export const isInContentBuilderPreview = (): boolean =>
   (isContentBuilderPreviewPath(window.location.pathname) ||
     hasPreviewFrameParam(window.location.search)) &&

--- a/front/app/utils/isInContentBuilderPreview.ts
+++ b/front/app/utils/isInContentBuilderPreview.ts
@@ -1,0 +1,32 @@
+// Content-builder editors (project page, project/folder description, homepage)
+// render their live preview inside a same-origin <iframe> pointing at an
+// `.../preview` admin route. That iframe boots a second copy of the whole app,
+// which would re-run tenant analytics/consent scripts (e.g. Civic Cookie Control
+// loaded via GTM). Re-running them inside the frame can wipe the shared auth
+// cookie and sign the editor out, and re-prompts for cookie consent. Trackers
+// use this to skip booting there. See TAN-8309.
+const CONTENT_BUILDER_PREVIEW_SEGMENTS = [
+  'project-page-builder',
+  'description-builder',
+  'homepage-builder',
+];
+
+export const isContentBuilderPreviewPath = (pathname: string): boolean =>
+  pathname.endsWith('/preview') &&
+  CONTENT_BUILDER_PREVIEW_SEGMENTS.some((segment) =>
+    pathname.includes(`/${segment}`)
+  );
+
+const isFramed = (): boolean => {
+  try {
+    return window.self !== window.top;
+  } catch {
+    // Reading window.top can throw across origins; a throw means we're framed.
+    return true;
+  }
+};
+
+export const isInContentBuilderPreview = (): boolean =>
+  isContentBuilderPreviewPath(window.location.pathname) && isFramed();
+
+export default isInContentBuilderPreview;

--- a/front/app/utils/isInContentBuilderPreview.ts
+++ b/front/app/utils/isInContentBuilderPreview.ts
@@ -1,21 +1,31 @@
-// Content-builder editors (project page, project/folder description, homepage)
-// render their live preview inside a same-origin <iframe> pointing at an
-// `.../preview` admin route. That iframe boots a second copy of the whole app,
-// which would re-run tenant analytics/consent scripts (e.g. Civic Cookie Control
-// loaded via GTM). Re-running them inside the frame can wipe the shared auth
-// cookie and sign the editor out, and re-prompts for cookie consent. Trackers
-// use this to skip booting there. See TAN-8309.
+// Admin editors render a live preview inside a same-origin <iframe> that boots a
+// second copy of the whole app. Re-running tenant analytics there re-runs whatever
+// those tags load — for one tenant, GTM loads a nested container that injects Civic
+// Cookie Control, whose cookie purge deletes the shared `cl2_jwt` and signs the
+// editor out. Trackers use this to skip booting inside such frames. See TAN-8309.
+//
+// Two kinds of preview frame exist:
+//   - content-builder editors (project page, project/folder description, homepage),
+//     which frame an `.../preview` admin route;
+//   - the project edit page, which frames the real front-office project page and so
+//     has no distinguishing path — it carries PREVIEW_FRAME_PARAM instead.
 const CONTENT_BUILDER_PREVIEW_SEGMENTS = [
   'project-page-builder',
   'description-builder',
   'homepage-builder',
 ];
 
+/** Marks an iframe src as an in-app preview. Set by whoever renders the frame. */
+export const PREVIEW_FRAME_PARAM = 'preview_frame';
+
 export const isContentBuilderPreviewPath = (pathname: string): boolean =>
   pathname.endsWith('/preview') &&
   CONTENT_BUILDER_PREVIEW_SEGMENTS.some((segment) =>
     pathname.includes(`/${segment}`)
   );
+
+export const hasPreviewFrameParam = (search: string): boolean =>
+  new URLSearchParams(search).get(PREVIEW_FRAME_PARAM) === 'true';
 
 const isFramed = (): boolean => {
   try {
@@ -26,5 +36,9 @@ const isFramed = (): boolean => {
   }
 };
 
+// Framing is required as well as the path/param: opening either URL directly in a
+// tab is an ordinary page view that should still be tracked.
 export const isInContentBuilderPreview = (): boolean =>
-  isContentBuilderPreviewPath(window.location.pathname) && isFramed();
+  (isContentBuilderPreviewPath(window.location.pathname) ||
+    hasPreviewFrameParam(window.location.search)) &&
+  isFramed();


### PR DESCRIPTION
# Changelog

## Fixed
- Admins/editors are no longer unexpectedly signed out (and re-prompted to accept cookies) when opening the live preview while editing a project description, folder description, homepage, or project page. On platforms that load a cookie-consent tool such as Civic Cookie Control via Google Tag Manager, the preview iframe used to re-run those scripts inside itself, which deleted the shared login cookie and logged the user out across the whole platform.
