### PR TITLE
[TAN-8309] Report to Sentry when the auth cookie is deleted without sign-out

### DIFF
--- a/front/app/utils/auth/jwt.ts
+++ b/front/app/utils/auth/jwt.ts
@@ -5,6 +5,12 @@ import { HighestRole } from 'api/users/types';
 
 import { SECURE_COOKIE } from '../cookie';
 
+import {
+  forgetJwt,
+  rememberJwt,
+  reportUnexpectedJwtLoss,
+} from './reportJwtLoss';
+
 const COOKIE_NAME = 'cl2_jwt';
 
 export interface IDecodedJwt {
@@ -20,10 +26,15 @@ export function getJwt() {
     const jwt = Cookies.get(COOKIE_NAME);
 
     if (!jwt || jwt === 'undefined') {
+      // Before removeJwt(), which clears the record this check relies on.
+      reportUnexpectedJwtLoss();
       removeJwt();
       return null;
     }
 
+    // Seeds the record on page loads that reuse an existing session, where
+    // setJwt is never called.
+    rememberJwt(jwt);
     return jwt;
   } catch (error) {
     return null;
@@ -43,9 +54,11 @@ export function setJwt(
     attrs.expires = tokenLifetime; // If omitted, the cookie becomes a session cookie. Fore more info, check https://stackoverflow.com/a/36421888
   }
   Cookies.set(COOKIE_NAME, jwt, attrs);
+  rememberJwt(jwt);
 }
 
 export function removeJwt() {
+  forgetJwt();
   Cookies.remove(COOKIE_NAME);
 }
 

--- a/front/app/utils/auth/reportJwtLoss.test.ts
+++ b/front/app/utils/auth/reportJwtLoss.test.ts
@@ -1,0 +1,84 @@
+import { captureMessage } from '@sentry/react';
+
+import {
+  forgetJwt,
+  rememberJwt,
+  reportUnexpectedJwtLoss,
+} from './reportJwtLoss';
+
+jest.mock('@sentry/react', () => ({
+  __esModule: true,
+  captureMessage: jest.fn(),
+  // Run the callback against a scope stub so setTags/setContext are exercised.
+  withScope: jest.fn((callback) =>
+    callback({
+      setLevel: jest.fn(),
+      setTags: jest.fn(),
+      setContext: jest.fn(),
+    })
+  ),
+}));
+
+// jwt-decode is not mocked: the util must cope with real tokens, and an
+// unparseable one must not throw.
+const tokenExpiringIn = (seconds: number) => {
+  const payload = { exp: Math.floor(Date.now() / 1000) + seconds };
+  return `header.${btoa(JSON.stringify(payload))}.signature`;
+};
+
+describe('reportUnexpectedJwtLoss', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+    forgetJwt();
+  });
+
+  it('reports when a still-valid token disappears', () => {
+    rememberJwt(tokenExpiringIn(3600));
+
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports only once, since getJwt runs on every request', () => {
+    rememberJwt(tokenExpiringIn(3600));
+
+    reportUnexpectedJwtLoss();
+    reportUnexpectedJwtLoss();
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not report an expired token, which the browser drops normally', () => {
+    rememberJwt(tokenExpiringIn(-60));
+
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not report after a deliberate sign-out', () => {
+    rememberJwt(tokenExpiringIn(3600));
+    forgetJwt();
+
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not report when no token was ever seen', () => {
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on an undecodable token', () => {
+    expect(() => rememberJwt('not-a-jwt')).not.toThrow();
+
+    reportUnexpectedJwtLoss();
+
+    expect(captureMessage).not.toHaveBeenCalled();
+  });
+});

--- a/front/app/utils/auth/reportJwtLoss.ts
+++ b/front/app/utils/auth/reportJwtLoss.ts
@@ -1,0 +1,94 @@
+import { captureMessage, withScope } from '@sentry/react';
+import { jwtDecode } from 'jwt-decode';
+
+// A tenant's cookie-consent tool (typically loaded via their GTM container) can
+// enumerate document.cookie and delete everything not on its own allow-list. Our
+// auth cookie is not on those lists, so it gets deleted and the user is silently
+// signed out. That is indistinguishable from an ordinary session expiry to the
+// user, so it goes unreported. This reports it with enough context to tell the
+// two apart and to identify which script is responsible. See TAN-8309.
+
+// The exp claim of the last token we saw. Null means we have no reason to believe
+// the user was signed in, so a missing cookie is unremarkable.
+let knownExpiry: number | null = null;
+let lastSeenToken: string | null = null;
+
+export const rememberJwt = (jwt: string) => {
+  if (jwt === lastSeenToken) return;
+
+  lastSeenToken = jwt;
+  try {
+    knownExpiry = jwtDecode<{ exp: number }>(jwt).exp;
+  } catch {
+    knownExpiry = null;
+  }
+};
+
+/** Call when the token is removed on purpose, so the removal is not reported. */
+export const forgetJwt = () => {
+  knownExpiry = null;
+  lastSeenToken = null;
+};
+
+// Names only — never values, which would leak the tokens of any cookie present.
+const cookieNames = (): string[] =>
+  document.cookie
+    .split(';')
+    .map((cookie) => cookie.split('=')[0].trim())
+    .filter(Boolean);
+
+// Identifies the consent tool / tag manager that ran, which is the whole point of
+// the report: it names the culprit without us having to reproduce per tenant.
+const scriptHosts = (): string[] => {
+  const hosts = new Set<string>();
+  document.querySelectorAll<HTMLScriptElement>('script[src]').forEach((tag) => {
+    try {
+      hosts.add(new URL(tag.src, window.location.origin).hostname);
+    } catch {
+      // Ignore unparseable src attributes.
+    }
+  });
+  return [...hosts];
+};
+
+const isFramed = (): boolean => {
+  try {
+    return window.self !== window.top;
+  } catch {
+    return true;
+  }
+};
+
+/**
+ * Reports that the auth cookie vanished while we still expected it to be there.
+ * Natural expiry and deliberate sign-out are not reported.
+ */
+export const reportUnexpectedJwtLoss = () => {
+  if (knownExpiry === null) return;
+
+  const secondsUntilExpiry = knownExpiry - Math.floor(Date.now() / 1000);
+  // The token had run out; the browser dropping the cookie is expected.
+  if (secondsUntilExpiry <= 0) return;
+
+  // Clearing first makes this one report per token: getJwt runs on every API
+  // request, and a lost cookie stays lost.
+  forgetJwt();
+  const remainingCookies = cookieNames();
+
+  withScope((scope) => {
+    scope.setLevel('error');
+    scope.setTags({
+      tenant_host: window.location.hostname,
+      in_iframe: isFramed(),
+    });
+    scope.setContext('jwt_loss', {
+      path: window.location.pathname,
+      seconds_until_expiry: secondsUntilExpiry,
+      seconds_since_page_load: Math.round(performance.now() / 1000),
+      remaining_cookies: remainingCookies,
+      consent_cookie_also_gone: !remainingCookies.includes('cl2_consent'),
+      script_hosts: scriptHosts(),
+    });
+    captureMessage('Auth cookie cl2_jwt disappeared without sign-out');
+  });
+};


### PR DESCRIPTION
A tenant's cookie-consent tool, loaded via their tag manager, can delete any cookie not on its allow-list — `cl2_jwt` included. Users are silently signed out, indistinguishable from ordinary session expiry, so it goes unreported. Other platforms may be affected without us knowing.

`getJwt()` now records the token it sees and reports if it later vanishes while still valid. Deliberate sign-out and natural expiry are ignored; each token reports once.

Recorded: `tenant host`, in-iframe flag, path, remaining lifetime, time since page load, surviving cookie names, and script hostnames — enough to identify the responsible script without a per-tenant repro. No cookie values or tokens are sent.

Reporting only, no behaviour change.

# Changelog
## Technical
- [TAN-8309] Report to Sentry when the auth cookie is deleted without sign-out
