### PR TITLE
Fix allowing authenticate if empty password

### DIFF
--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -287,6 +287,8 @@ class WebApi::V1::UsersController < ApplicationController
   def update_password
     @user = current_user
     authorize @user
+    # `no_password?` users (email-only, SSO) have no current password to confirm, so they can
+    # set a first one. This is not a login: they are already authenticated as `current_user`.
     if @user.no_password? || @user.authenticate(params[:user][:current_password])
       if @user.update(password: params[:user][:password])
         reset_jwt_cookie

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -329,15 +329,15 @@ class User < ApplicationRecord
     self[:last_name].blank? && self[:first_name].blank? && !invite_pending?
   end
 
+  # Authenticating ALWAYS requires a non-blank password that matches the stored digest.
+  # A user without a password digest (email-only, SSO or invited account) can never be
+  # authenticated here, no matter what is passed in - a blank password is not a valid
+  # credential and must never grant access.
   def authenticate(unencrypted_password)
-    if no_password?
-      # Allow authentication without password - but only if confirmation is required on the user
-      unencrypted_password.empty? && confirmation_required? ? self : false
-    else
-      return false unless AppConfiguration.instance.feature_activated?('password_login') || super_admin?
+    return false if password_digest.blank? || unencrypted_password.blank?
+    return false unless AppConfiguration.instance.feature_activated?('password_login') || super_admin?
 
-      BCrypt::Password.new(password_digest).is_password?(unencrypted_password) && self
-    end
+    BCrypt::Password.new(password_digest).is_password?(unencrypted_password) && self
   end
 
   # User has no password

--- a/back/lib/auth_token/auth_token_controller.rb
+++ b/back/lib/auth_token/auth_token_controller.rb
@@ -14,6 +14,11 @@ module AuthToken
     private
 
     def authenticate
+      # A blank secret is never a valid credential. The entity is expected to reject it as
+      # well, but we refuse it here too so that no entity implementation can ever hand out a
+      # token to a request that did not supply a password/secret.
+      raise ActiveRecord::RecordNotFound if auth_params[secret_param].blank?
+
       block_because_requires_confirmation = entity.try(:confirmation_required?)
 
       return if entity.present? &&

--- a/back/spec/acceptance/user_token_spec.rb
+++ b/back/spec/acceptance/user_token_spec.rb
@@ -217,6 +217,8 @@ resource 'User Token' do
       end
     end
 
+    # Logging in without a password must NEVER work, whatever the state of the user.
+    # Do not relax these expectations: they are the last line of defence of password login.
     context 'when no password is used' do
       let(:email) { 'test@email.com' }
       let(:password) { '' }
@@ -233,6 +235,52 @@ resource 'User Token' do
         let!(:user) { create(:unconfirmed_user, email: email) }
 
         example_request '[error] no JWT token is returned' do
+          assert_status 404
+        end
+      end
+
+      context 'when user has no password and is confirmed' do
+        let!(:user) do
+          create(:unconfirmed_user, email: email).tap { |u| u.email_confirmation.confirm! }
+        end
+
+        example '[error] no JWT token is returned', document: false do
+          expect(user.reload.confirmation_required?).to be false
+
+          do_request
+          assert_status 404
+        end
+      end
+
+      context 'when user has no password and is a super admin' do
+        let(:email) { 'hello@citizenlab.co' }
+        let!(:user) do
+          create(:unconfirmed_user, email: email, roles: [{ type: 'admin' }])
+            .tap { |u| u.email_confirmation.confirm! }
+        end
+
+        example '[error] no JWT token is returned', document: false do
+          expect(user.super_admin?).to be true
+
+          do_request
+          assert_status 404
+        end
+      end
+
+      context 'when the password is omitted entirely' do
+        let!(:user) { create(:unconfirmed_user, email: email).tap { |u| u.email_confirmation.confirm! } }
+
+        example '[error] no JWT token is returned', document: false do
+          do_request(auth: { email: email })
+          assert_status 404
+        end
+      end
+
+      context 'when the password is blank whitespace' do
+        let!(:user) { create(:unconfirmed_user, email: email).tap { |u| u.email_confirmation.confirm! } }
+
+        example '[error] no JWT token is returned', document: false do
+          do_request(auth: { email: email, password: '   ' })
           assert_status 404
         end
       end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -259,27 +259,95 @@ RSpec.describe User do
     end
   end
 
-  describe 'authentication without password' do
-    it 'is allowed if the user has no password and confirmation is required' do
-      u = described_class.new(email: 'bob@citizenlab.co')
-      expect(!!u.authenticate('')).to be(true)
+  describe '#authenticate' do
+    # Authentication ALWAYS requires a non-blank password matching the stored digest.
+    # A user without a password (email-only, SSO or invited account) has no credential to log
+    # in with, and a blank password is not a credential. These specs must never be relaxed:
+    # every case below has to stay `false`, whatever the confirmation state of the user.
+    describe 'authentication without a password' do
+      # Anything that is not an actual password supplied by the requester.
+      blank_secrets = ['', ' ', "\t", nil]
+
+      it 'is NOT allowed for a user with no password who requires confirmation' do
+        user = create(:unconfirmed_user)
+        expect(user.password_digest).to be_nil
+        expect(user.confirmation_required?).to be true
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+        expect(user.authenticate('any_string')).to be(false)
+      end
+
+      it 'is NOT allowed for a user with no password who does not require confirmation' do
+        user = create(:unconfirmed_user)
+        user.email_confirmation.confirm!
+        expect(user.reload.confirmation_required?).to be false
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+        expect(user.authenticate('any_string')).to be(false)
+      end
+
+      it 'is NOT allowed for an unpersisted user with no password' do
+        user = described_class.new(email: 'bob@citizenlab.co', locale: 'en')
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+        expect(user.authenticate('any_string')).to be(false)
+      end
+
+      it 'is NOT allowed for an SSO user who never set a password' do
+        user = create(:unconfirmed_user)
+        user.identities << create(:facebook_identity, user: user)
+        user.email_confirmation.confirm!
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+      end
+
+      it 'is NOT allowed for an invited user who has not accepted their invite' do
+        user = create(:invited_user)
+        expect(user.password_digest).to be_nil
+        expect(user.invite_pending?).to be true
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+        expect(user.authenticate('any_string')).to be(false)
+      end
+
+      it 'is NOT allowed for a super admin with no password' do
+        user = create(:unconfirmed_user, email: 'hello@citizenlab.co', roles: [{ type: 'admin' }])
+        expect(user.super_admin?).to be true
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+      end
+
+      it 'is NOT allowed for a user who does have a password' do
+        user = create(:user, password: 'democracy2.0')
+
+        blank_secrets.each do |secret|
+          expect(user.authenticate(secret)).to be(false), "authenticate(#{secret.inspect}) must be false"
+        end
+      end
     end
 
-    it 'is not allowed if a password has been supplied in the request' do
-      u = described_class.new(email: 'bob@citizenlab.co')
-      expect(!!u.authenticate('any_string')).to be(false)
-    end
+    describe 'authentication with a password' do
+      let(:user) { create(:user, password: 'democracy2.0') }
 
-    it 'is not allowed if a password has been set' do
-      u = described_class.new(email: 'bob@citizenlab.co', password: 'democracy2.0')
-      expect(!!u.authenticate('')).to be(false)
-    end
+      it 'returns the user when the password matches' do
+        expect(user.authenticate('democracy2.0')).to eq user
+      end
 
-    it 'is not allowed if confirmation is not required' do
-      u = described_class.new(email: 'bob@citizenlab.co', locale: 'en')
-      u.save!
-      u.email_confirmation.confirm!
-      expect(!!u.authenticate('')).to be(false)
+      it 'returns false when the password does not match' do
+        expect(user.authenticate('democracy2.1')).to be(false)
+      end
     end
   end
 


### PR DESCRIPTION
# Changelog
## Technical
- Some weird code in `User.authenticate` was suggesting that you could log in with an empty password if you don't have a password set. In practice the code was not reachable, but it still had to be removed because it was related to old functionality that does not exist anymore and could become a risk in the future.