### PR TITLE
[TAN-8368] Fix que worker crash on aiven-pg-security Postgres

### DIFF
--- a/back/config/initializers/que.rb
+++ b/back/config/initializers/que.rb
@@ -19,3 +19,10 @@ ActiveSupport.on_load(:active_job) do
     def enqueue_after_transaction_commit? = false
   end
 end
+
+# Opt-in compatibility layer that overwrites the `clean_lockers` query for PostgreSQL
+# protected by the aiven-pg-security extension (e.g. Scaleway Managed Database).
+if ENV.fetch('QUE_AIVEN_PG_SECURITY_COMPAT', false) == 'true'
+  CitizenLab::Que::AivenPgSecurityCompat.apply!
+  Rails.logger.info('[que] clean_lockers patched for aiven-pg-security (QUE_AIVEN_PG_SECURITY_COMPAT)')
+end

--- a/back/lib/citizen_lab/que/aiven_pg_security_compat.rb
+++ b/back/lib/citizen_lab/que/aiven_pg_security_compat.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module CitizenLab
+  module Que
+    # Replaces que's `clean_lockers` query for PostgreSQL protected by the
+    # aiven-pg-security extension (e.g. Scaleway Managed Database).
+    #
+    # que's default `clean_lockers` query (que/lib/que/locker.rb) crashes the
+    # worker at startup with:
+    #   ERROR: Modifying pg_authid or pg_auth_members is not allowed in elevated context
+    #
+    # It is a DELETE that references the `pg_stat_activity` view. In PostgreSQL
+    # that view is defined as a LEFT JOIN against `pg_authid` (to resolve the
+    # `usename` column), so the DELETE's query plan contains `pg_authid`. The
+    # gatekeeper forbids any modifying statement whose plan touches `pg_authid`
+    # in an "elevated context" (the managed view runs as a SECURITY DEFINER
+    # superuser).
+    #
+    # que only reads the `pid` column, so the `pg_authid` join is unnecessary.
+    # The replacement query reads from the raw `pg_stat_get_activity()` function
+    # that the view itself is built on: same rows, same pids, no `pg_authid`
+    # join.
+    module AivenPgSecurityCompat
+      CLEAN_LOCKERS_SQL = <<~SQL.squish
+        DELETE FROM public.que_lockers
+        WHERE pid = pg_backend_pid()
+           OR NOT EXISTS (
+             SELECT 1 FROM pg_stat_get_activity(NULL) s WHERE s.pid = public.que_lockers.pid
+           )
+      SQL
+
+      def self.apply!
+        ::Que::SQL[:clean_lockers] = CLEAN_LOCKERS_SQL
+      end
+    end
+  end
+end

--- a/back/spec/citizen_lab/que/aiven_pg_security_compat_spec.rb
+++ b/back/spec/citizen_lab/que/aiven_pg_security_compat_spec.rb
@@ -3,8 +3,39 @@
 require 'rails_helper'
 
 RSpec.describe CitizenLab::Que::AivenPgSecurityCompat do
-  describe 'CLEAN_LOCKERS_SQL' do
+  def normalize_sql(sql)
+    sql.gsub(/\s+/, ' ').strip
+  end
+
+  # Detects drift from que's original clean_lockers query.
+  it "patches the expected version of que's clean_lockers query" do
+    original_sql = <<~SQL.squish
+      DELETE FROM public.que_lockers
+      WHERE pid = pg_backend_pid()
+         OR NOT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid = public.que_lockers.pid)
+    SQL
+
+    message = <<~MSG
+      que's clean_lockers query changed (likely a `bundle update que`).
+      Re-check that CLEAN_LOCKERS_SQL is still an equivalent, pg_authid-free
+      rewrite of the new query.
+    MSG
+
+    expect(normalize_sql(Que::SQL[:clean_lockers]))
+      .to eq(normalize_sql(original_sql)), message
+  end
+
+  describe '.apply!' do
     let(:connection) { ActiveRecord::Base.connection }
+
+    # apply! mutates the global Que::SQL hash, so restore the stock query
+    # afterwards to keep other specs isolated.
+    around do |example|
+      original = Que::SQL[:clean_lockers]
+      example.run
+    ensure
+      Que::SQL[:clean_lockers] = original
+    end
 
     def insert_lockers(pids)
       values = pids.map { |pid| "(#{pid}, 1, '{1}', 1, 'test-host', '{default}', false)" }.join(', ')
@@ -24,11 +55,12 @@ RSpec.describe CitizenLab::Que::AivenPgSecurityCompat do
     # removes both the current connection's own locker (so a fresh one can be
     # registered) and lockers left by dead workers (pid no longer active).
     it 'removes the current connection\'s locker and lockers of dead backends' do
+      described_class.apply!
       own_pid  = connection.execute('SELECT pg_backend_pid() AS pid').first['pid']
       dead_pid = 2_147_483_647 # max int4, never a real backend pid
       insert_lockers([own_pid, dead_pid])
 
-      connection.execute(described_class::CLEAN_LOCKERS_SQL)
+      Que.execute(:clean_lockers)
 
       expect(locker_pids).to be_empty
     end

--- a/back/spec/citizen_lab/que/aiven_pg_security_compat_spec.rb
+++ b/back/spec/citizen_lab/que/aiven_pg_security_compat_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CitizenLab::Que::AivenPgSecurityCompat do
+  describe 'CLEAN_LOCKERS_SQL' do
+    let(:connection) { ActiveRecord::Base.connection }
+
+    def insert_lockers(pids)
+      values = pids.map { |pid| "(#{pid}, 1, '{1}', 1, 'test-host', '{default}', false)" }.join(', ')
+
+      connection.execute(<<~SQL.squish)
+        INSERT INTO public.que_lockers
+          (pid, worker_count, worker_priorities, ruby_pid, ruby_hostname, queues, listening)
+        VALUES #{values}
+      SQL
+    end
+
+    def locker_pids
+      connection.execute('SELECT pid FROM public.que_lockers').map { |r| r['pid'] }
+    end
+
+    # clean_lockers runs at worker startup, before the worker re-registers. It
+    # removes both the current connection's own locker (so a fresh one can be
+    # registered) and lockers left by dead workers (pid no longer active).
+    it 'removes the current connection\'s locker and lockers of dead backends' do
+      own_pid  = connection.execute('SELECT pg_backend_pid() AS pid').first['pid']
+      dead_pid = 2_147_483_647 # max int4, never a real backend pid
+      insert_lockers([own_pid, dead_pid])
+
+      connection.execute(described_class::CLEAN_LOCKERS_SQL)
+
+      expect(locker_pids).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
The que worker crashes at startup on PostgreSQL protected by the aiven-pg-security extension (e.g. Scaleway Managed Database) with: `
ERROR: Modifying pg_authid or pg_auth_members is not allowed in elevated context`.

que's clean_lockers query is a DELETE that references the pg_stat_activity view. That view LEFT JOINs pg_authid to resolve usename, so the DELETE's plan touches pg_authid — which the gatekeeper forbids for modifying statements in elevated context. que only needs the pid column, so the join is unnecessary; the replacement reads from the raw pg_stat_get_activity() function the view is built on.

Opt-in via QUE_AIVEN_PG_SECURITY_COMPAT (default off): on AWS RDS, the DB master user is allowed to run the original query.

# Changelog
## Technical
- [TAN-8368] Add a que compatibility layer for Scaleway managed Postgres

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
