### PR TITLE
[TAN-8155] Extract a json_headers helper in the rack attack spec

### DIFF
--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -18,16 +18,22 @@ describe 'Rack::Attack' do
   let!(:user) { create(:user) }
   let(:token) { AuthToken::AuthToken.new(payload: user.to_token_payload).token }
 
-  it 'limits login requests from same IP to 2 in 20 seconds' do
+  # Throttles key off the IP and the JWT, so examples vary one and hold the other fixed.
+  def json_headers(token: nil, ip: nil)
     headers = { 'CONTENT_TYPE' => 'application/json' }
+    headers['Authorization'] = "Bearer #{token}" if token
+    headers['REMOTE_ADDR'] = ip if ip
+    headers
+  end
 
+  it 'limits login requests from same IP to 2 in 20 seconds' do
     # Use a different email for each request, to avoid testing limit by email
     freeze_time do
       10.times do |i|
         post(
           '/web_api/v1/user_token',
           params: '{ "auth": { "email": "INSERT", "password": "test123456" } }'.gsub('INSERT', "a#{i}@b.com"),
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(404) # Not found
@@ -35,7 +41,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a11@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -44,7 +50,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "INSERT": "a12@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(404) # Not found
     end
@@ -54,29 +60,26 @@ describe 'Rack::Attack' do
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
       10.times do |i|
-        headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => "1.2.3.#{i + 1}" }
         post(
           '/web_api/v1/user_token',
           params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-          headers: headers
+          headers: json_headers(ip: "1.2.3.#{i + 1}")
         )
       end
       expect(status).to eq(404) # Not found
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.11' }
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.11')
       )
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(20.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.12' }
       post '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.12')
       expect(status).to eq(404) # Not found
     end
   end
@@ -91,7 +94,7 @@ describe 'Rack::Attack' do
         post(
           '/web_api/v1/user_token',
           params: '{ "auth": { "INSERT": "a12@b.com", "password": "test123456" } }',
-          headers: { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => whitelisted_ip }
+          headers: json_headers(ip: whitelisted_ip)
         )
       end
       expect(status).to eq(404) # Not found
@@ -109,15 +112,13 @@ describe 'Rack::Attack' do
     }
     AppConfiguration.instance.update! settings: settings
 
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     # Use a different email for each request, to emulate multiple account creation attempts
     freeze_time do
       10.times do |i|
         post(
           '/web_api/v1/users',
           params: '{ "user": { "email": "INSERT", "locale": "en" }}'.gsub('INSERT', "a#{i + 1}@b.com"),
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(201) # Created
@@ -125,7 +126,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users',
         params: '{ "user": { "email": "a11@b.com", "locale": "en" }}',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -133,20 +134,18 @@ describe 'Rack::Attack' do
     travel_to(20.seconds.from_now) do
       post '/web_api/v1/users',
         params: '{ "user": { "email": "a12@b.com", "locale": "en" }}',
-        headers: headers
+        headers: json_headers
       expect(status).to eq(201) # Created
     end
   end
 
   it 'limits password reset requests from same IP to 10 in 20 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
       10.times do
         post(
           '/web_api/v1/users/reset_password',
           params: '{ "user": { "password": "new_password", "token": "invalid-token" } }',
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(401) # Unauthorized
@@ -154,7 +153,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users/reset_password',
         params: '{ "user": { "password": "new_password", "token": "invalid-token" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -163,14 +162,13 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users/reset_password',
         params: '{ "user": { "password": "new_password", "token": "invalid-token" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(401) # Unauthorized
     end
   end
 
   it 'limits password reset email requests from same IP to 10 in 20 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
     users = create_list(:user, 12)
 
     # Use a different email for each request, to avoid testing limit by email
@@ -179,7 +177,7 @@ describe 'Rack::Attack' do
         post(
           '/web_api/v1/users/reset_password_email',
           params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', users[i].email.to_s),
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(202) # Accepted
@@ -187,7 +185,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users/reset_password_email',
         params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', users[10].email.to_s),
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -195,7 +193,7 @@ describe 'Rack::Attack' do
     travel_to(20.seconds.from_now) do
       post '/web_api/v1/users/reset_password_email',
         params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', users[11].email.to_s),
-        headers: headers
+        headers: json_headers
       expect(status).to eq(202) # Accepted
     end
   end
@@ -203,29 +201,26 @@ describe 'Rack::Attack' do
   it 'limits password reset email requests for same email to 1 in 20 seconds' do
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.1' }
       post(
         '/web_api/v1/users/reset_password_email',
         params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', user.email.to_s),
-        headers: headers
+        headers: json_headers(ip: '1.2.3.1')
       )
       expect(status).to eq(202) # Accepted
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.2' }
       post(
         '/web_api/v1/users/reset_password_email',
         params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', user.email.to_s),
-        headers: headers
+        headers: json_headers(ip: '1.2.3.2')
       )
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(20.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.3' }
       post(
         '/web_api/v1/users/reset_password_email',
         params: '{ "user": { "email": "INSERT" } }'.gsub('INSERT', user.email.to_s),
-        headers: headers
+        headers: json_headers(ip: '1.2.3.3')
       )
       expect(status).to eq(202) # Accepted
     end
@@ -249,8 +244,6 @@ describe 'Rack::Attack' do
   end
 
   it 'limits invite acceptance requests from same IP to 10 in 20 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
       10.times do
         post(
@@ -261,7 +254,7 @@ describe 'Rack::Attack' do
                               "password": "test1234",
                               "token": "invalid-token" }
                   }',
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(401) # Unauthorized
@@ -274,7 +267,7 @@ describe 'Rack::Attack' do
                             "password": "test1234",
                             "token": "invalid-token" }
               }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -288,28 +281,26 @@ describe 'Rack::Attack' do
                             "password": "test1234",
                             "token": "invalid-token" }
                 }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(401) # Unauthorized
     end
   end
 
   it 'limits unauthenticated code requests from same IP to 10 in 5 minutes' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     # Use a different email for each request, to avoid testing limit by email
     freeze_time do
       10.times do |i|
-        post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "INSERT" } }'.gsub('INSERT', "a#{i}@b.com"), headers: headers)
+        post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "INSERT" } }'.gsub('INSERT', "a#{i}@b.com"), headers: json_headers)
       end
       expect(status).to eq(401) # Unauthorized
 
-      post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "a11@b.com" } }', headers: headers)
+      post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "a11@b.com" } }', headers: json_headers)
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.minutes.from_now) do
-      post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "a12@b.com" } }', headers: headers)
+      post('/web_api/v1/user/request_code_email', params: '{ "request_code": { "email": "a12@b.com" } }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
     end
   end
@@ -319,69 +310,61 @@ describe 'Rack::Attack' do
 
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.1' }
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(ip: '1.2.3.1'))
       expect(status).to eq(401) # Unauthorized
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.2' }
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(ip: '1.2.3.2'))
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.3' }
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(ip: '1.2.3.3'))
       expect(status).to eq(401) # Unauthorized
     end
   end
 
   it 'limits code requests for same user to 1 in 5 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}" }
-
     # No email in the body, to avoid testing limit by email
     params = '{ "request_code": { "only_if_first_time": false } }'
 
     freeze_time do
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(token: token))
       expect(status).to eq(200) # OK
 
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(token: token))
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      post('/web_api/v1/user/request_code_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_email', params: params, headers: json_headers(token: token))
       expect(status).to eq(200) # OK
     end
   end
 
   it 'limits code requests for same user when the token is passed as a query param' do
     # AuthToken reads params[:token] before the Authorization header
-    headers = { 'CONTENT_TYPE' => 'application/json' }
     params = '{ "request_code": { "only_if_first_time": false } }'
 
     freeze_time do
-      post("/web_api/v1/user/request_code_email?token=#{token}", params: params, headers: headers)
+      post("/web_api/v1/user/request_code_email?token=#{token}", params: params, headers: json_headers)
       expect(status).to eq(200) # OK
 
-      post("/web_api/v1/user/request_code_email?token=#{token}", params: params, headers: headers)
+      post("/web_api/v1/user/request_code_email?token=#{token}", params: params, headers: json_headers)
       expect(status).to eq(429) # Too many requests
     end
   end
 
   it 'limits email change code requests from same IP to 1 in 5 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
-      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
 
-      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: json_headers)
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: '{ "request_code": { "new_email": "coolemail@example.org" } }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
     end
   end
@@ -392,35 +375,30 @@ describe 'Rack::Attack' do
 
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.1' }
-      post('/web_api/v1/user/request_code_new_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: params, headers: json_headers(token: token, ip: '1.2.3.1'))
       expect(status).to eq(422) # Unprocessable entity
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.2' }
-      post('/web_api/v1/user/request_code_new_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: params, headers: json_headers(token: token, ip: '1.2.3.2'))
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.3' }
-      post('/web_api/v1/user/request_code_new_email', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_email', params: params, headers: json_headers(token: token, ip: '1.2.3.3'))
       expect(status).to eq(422) # Unprocessable entity
     end
   end
 
   it 'limits phone re-confirmation code requests from same IP to 1 in 5 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
-      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
 
-      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: json_headers)
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: '{ "request_code": {} }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
     end
   end
@@ -430,35 +408,30 @@ describe 'Rack::Attack' do
 
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.1' }
-      post('/web_api/v1/user/request_code_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.1'))
       expect(status).to eq(401) # Unauthorized
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.2' }
-      post('/web_api/v1/user/request_code_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.2'))
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.3' }
-      post('/web_api/v1/user/request_code_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.3'))
       expect(status).to eq(401) # Unauthorized
     end
   end
 
   it 'limits phone change code requests from same IP to 1 in 5 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
-      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
 
-      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: json_headers)
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: '{ "request_code": { "new_phone": "+32470123456" } }', headers: json_headers)
       expect(status).to eq(401) # Unauthorized
     end
   end
@@ -468,31 +441,26 @@ describe 'Rack::Attack' do
 
     # Use a different IP for each request, to avoid testing limit by IP
     freeze_time do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.1' }
-      post('/web_api/v1/user/request_code_new_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.1'))
       expect(status).to eq(401) # Unauthorized
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.2' }
-      post('/web_api/v1/user/request_code_new_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.2'))
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.seconds.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'Authorization' => "Bearer #{token}", 'REMOTE_ADDR' => '1.2.3.3' }
-      post('/web_api/v1/user/request_code_new_phone', params: params, headers: headers)
+      post('/web_api/v1/user/request_code_new_phone', params: params, headers: json_headers(token: token, ip: '1.2.3.3'))
       expect(status).to eq(401) # Unauthorized
     end
   end
 
   it 'limits unauthenticated confirmation requests from same IP to 5 in 20 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
       5.times do
         post(
           '/web_api/v1/user/confirm_code_email',
           params: "{ \"confirmation\": { \"email\": \"#{user.email}\", \"code\": \"1234\" } }",
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(422)
@@ -500,7 +468,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user/confirm_code_email',
         params: "{ \"confirmation\": { \"email\": \"#{user.email}\", \"code\": \"1234\" } }",
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -509,7 +477,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user/confirm_code_email',
         params: "{ \"confirmation\": { \"email\": \"#{user.email}\", \"code\": \"1234\" } }",
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(422)
     end
@@ -520,7 +488,6 @@ describe 'Rack::Attack' do
   # Remove skip statement to run in local dev environment, but do not push/merge that change to master.
 
   it 'limits login requests from same IP to 4000 in 1 day', skip: 'Too slow to include in CI' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
     start_time = Time.zone.now.midnight
 
     # Use a different email for each request, to avoid testing limit by email
@@ -532,7 +499,7 @@ describe 'Rack::Attack' do
           post(
             '/web_api/v1/user_token',
             params: '{ "auth": { "email": "INSERT", "password": "test123456" } }'.gsub('INSERT', "a#{iter}@b.com"),
-            headers: headers
+            headers: json_headers
           )
           print "Target: 4000 requests. Requests made: #{iter}\r"
           $stdout.flush
@@ -545,7 +512,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a11@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -554,7 +521,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "INSERT": "a12@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(404) # Not found
     end
@@ -567,11 +534,10 @@ describe 'Rack::Attack' do
       travel_to((i * 20).seconds.from_now) do
         10.times do |j|
           iter = (10 * i) + (j + 1)
-          headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => "1.2.3.#{iter}" }
           post(
             '/web_api/v1/user_token',
             params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-            headers: headers
+            headers: json_headers(ip: "1.2.3.#{iter}")
           )
           print "Target: 100 requests. Requests made: #{iter}\r"
           $stdout.flush
@@ -581,21 +547,19 @@ describe 'Rack::Attack' do
     expect(status).to eq(404) # Not found
 
     travel_to(200.seconds.from_now) do # 10 * 20 seconds
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.101' }
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.101')
       )
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(25.hours.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.102' }
       post(
         '/web_api/v1/user_token',
         params: '{ "auth": { "email": "a@b.com", "password": "test123456" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.102')
       )
       expect(status).to eq(404) # Not found
     end
@@ -622,17 +586,13 @@ describe 'Rack::Attack' do
 
   it 'limits authoring assistance response requests from same IP to 10 in 20 seconds' do
     token = AuthToken::AuthToken.new(payload: create(:user).to_token_payload).token
-    headers = {
-      'CONTENT_TYPE' => 'application/json',
-      'Authorization' => "Bearer #{token}"
-    }
 
     freeze_time do
       10.times do
         post(
           "/web_api/v1/ideas/#{SecureRandom.uuid}/authoring_assistance_responses",
           params: '{ "authoring_assistance_response": { "custom_free_prompt": "Is this a good idea?" } }',
-          headers: headers
+          headers: json_headers(token: token)
         )
       end
       expect(status).to eq(401) # Not found
@@ -640,7 +600,7 @@ describe 'Rack::Attack' do
       post(
         "/web_api/v1/ideas/#{SecureRandom.uuid}/authoring_assistance_responses",
         params: '{ "authoring_assistance_response": { "custom_free_prompt": "Is this a good idea?" } }',
-        headers: headers
+        headers: json_headers(token: token)
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -648,10 +608,6 @@ describe 'Rack::Attack' do
 
   it 'limits similar inputs requests from same IP to 5 in 1 second' do
     token = AuthToken::AuthToken.new(payload: create(:user).to_token_payload).token
-    headers = {
-      'CONTENT_TYPE' => 'application/json',
-      'Authorization' => "Bearer #{token}"
-    }
 
     allow_any_instance_of(CohereMultilingualEmbeddings).to receive(:embedding) do
       create(:embeddings_similarity).embedding
@@ -673,7 +629,7 @@ describe 'Rack::Attack' do
         post(
           "/web_api/v1/phases/#{phase_id}/inputs/similar",
           params: params_proc.call("Title #{i}"),
-          headers: headers
+          headers: json_headers(token: token)
         )
       end
       expect(status).to eq 200 # OK
@@ -681,21 +637,19 @@ describe 'Rack::Attack' do
       post(
         "/web_api/v1/phases/#{phase_id}/inputs/similar",
         params: params_proc.call('Final idea'),
-        headers: headers
+        headers: json_headers(token: token)
       )
       expect(status).to eq 429 # Too many requests
     end
   end
 
   it 'limits user check requests from same IP to 5 in 20 seconds' do
-    headers = { 'CONTENT_TYPE' => 'application/json' }
-
     freeze_time do
       5.times do |i|
         post(
           '/web_api/v1/users/check',
           params: "{ \"user\": { \"email\": \"user#{i}@test.com\" } }",
-          headers: headers
+          headers: json_headers
         )
       end
       expect(status).to eq(200) # ok
@@ -703,7 +657,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users/check',
         params: '{ "user": { "email": "user6@test.com" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(429) # Too many requests
     end
@@ -712,7 +666,7 @@ describe 'Rack::Attack' do
       post(
         '/web_api/v1/users/check',
         params: '{ "user": { "email": "user7@test.com" } }',
-        headers: headers
+        headers: json_headers
       )
       expect(status).to eq(200) # ok
     end
@@ -721,30 +675,27 @@ describe 'Rack::Attack' do
   it 'limits user check requests to same email to 5 in 5 minutes' do
     freeze_time do
       5.times do |i|
-        headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => "1.2.3.#{i}" }
         post(
           '/web_api/v1/users/check',
           params: '{ "user": { "email": "user@test.com" } }',
-          headers: headers
+          headers: json_headers(ip: "1.2.3.#{i}")
         )
       end
       expect(status).to eq(200) # ok
 
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.7' }
       post(
         '/web_api/v1/users/check',
         params: '{ "user": { "email": "user@test.com" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.7')
       )
       expect(status).to eq(429) # Too many requests
     end
 
     travel_to(5.minutes.from_now) do
-      headers = { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.8' }
       post(
         '/web_api/v1/users/check',
         params: '{ "user": { "email": "user@test.com" } }',
-        headers: headers
+        headers: json_headers(ip: '1.2.3.8')
       )
       expect(status).to eq(200) # ok
     end


### PR DESCRIPTION
# Description
- Replaced 41 repeated request-header hash literals in `rack_attack_spec.rb` with a `json_headers(token:, ip:)` helper. No behavior change.
