### PR TITLE
TAN-8355 Oslo auth display issue

### DIFF
--- a/back/app/services/authentication_service.rb
+++ b/back/app/services/authentication_service.rb
@@ -22,10 +22,13 @@ class AuthenticationService
   end
 
   def first_method_enabled
-    # Temporary hack: we never want to return vienna_employee,
-    # because in the places in the UI where this endpoint is used,
-    # we always want to show the `vienna_citizen` method instead.
-    active_methods(AppConfiguration.instance).reject { |method| method.name == 'vienna_employee' }.first
+    # This endpoint is only used for the access rights interface.
+    # here, we don't want to return employee-only methods.
+    # In theory we could but it requires a redesign of the interface
+    # so for now we just hide the employee-only methods. 
+    active_methods(AppConfiguration.instance)
+      .reject { |method| method.employee_only? }
+      .first
   end
 
   def logout_url(provider, user)

--- a/back/app/services/authentication_service.rb
+++ b/back/app/services/authentication_service.rb
@@ -25,9 +25,9 @@ class AuthenticationService
     # This endpoint is only used for the access rights interface.
     # here, we don't want to return employee-only methods.
     # In theory we could but it requires a redesign of the interface
-    # so for now we just hide the employee-only methods. 
+    # so for now we just hide the employee-only methods.
     active_methods(AppConfiguration.instance)
-      .reject { |method| method.employee_only? }
+      .reject(&:employee_only?)
       .first
   end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/keycloak/keycloak_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/keycloak/keycloak_omniauth.rb
@@ -16,6 +16,10 @@ module CustomIdMethods::Keycloak
       true
     end
 
+    def employee_only?
+      config[:provider] == 'idporten'
+    end
+
     def profile_to_user_attrs(auth)
       {
         first_name: format_name(auth.info.first_name),

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/vienna_saml/employee_saml_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/vienna_saml/employee_saml_omniauth.rb
@@ -15,6 +15,10 @@ module CustomIdMethods::ViennaSaml
       true
     end
 
+    def employee_only?
+      true
+    end
+
     def verification_method_type
       :omniauth
     end

--- a/back/engines/commercial/custom_id_methods/config/initializers/omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/config/initializers/omniauth.rb
@@ -8,7 +8,7 @@ FACEBOOK_SETUP_PROC = lambda do |env|
   CustomIdMethods::Facebook::FacebookOmniauth.new.omniauth_setup(AppConfiguration.instance, env)
 end
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :facebook, setup: FACEBOOK_SETUP_PROC
+  provider :facebook, setup: FACEBOOK_SETUP_PROC, name: 'facebook'
 end
 
 GOOGLE_SETUP_PROC = lambda do |env|
@@ -23,7 +23,7 @@ AZURE_AD_SETUP_PROC = lambda do |env|
   CustomIdMethods::AzureActiveDirectory::AzureActiveDirectoryOmniauth.new.omniauth_setup(AppConfiguration.instance, env)
 end
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :azure_activedirectory, setup: AZURE_AD_SETUP_PROC
+  provider :azure_activedirectory, setup: AZURE_AD_SETUP_PROC, name: 'azureactivedirectory'
 end
 
 AZURE_AD_B2C_SETUP_PROC = lambda do |env|

--- a/back/lib/id_methods/base.rb
+++ b/back/lib/id_methods/base.rb
@@ -17,6 +17,15 @@ module IdMethods
       raise NotImplementedError
     end
 
+    # True if this method is only available to employees.
+    # If true, method will be hidden in the access rights interface for
+    # platforms that have a SSO-only setup with more than 1 authentication method.
+    # In theory we could show both but requires a redesign of the whole interface,
+    # so for now we just hide the employee-only methods.
+    def employee_only?
+      false
+    end 
+
     # @param [AppConfiguration] configuration
     def omniauth_setup(_configuration, _env)
       raise 'Subclass must implement this method'

--- a/back/lib/id_methods/base.rb
+++ b/back/lib/id_methods/base.rb
@@ -24,7 +24,7 @@ module IdMethods
     # so for now we just hide the employee-only methods.
     def employee_only?
       false
-    end 
+    end
 
     # @param [AppConfiguration] configuration
     def omniauth_setup(_configuration, _env)


### PR DESCRIPTION
# Changelog
## Fixed
- Access rights interface for Oslo was showing wrong auth method name. Now it should show the right one.