### PR TITLE
[TAN-8390] Show useful error message to user when survey file upload over size limit

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -413,6 +413,12 @@ class WebApi::V1::IdeasController < ApplicationController
     file_uploads_exist = false
     params_for_file_upload_fields = extract_params_for_file_upload_fields custom_form, params
 
+    # Checked for every field before any is written, so an oversized file in a later
+    # field can't leave the files from earlier ones half-persisted.
+    params_for_file_upload_fields.each do |key, params_for_files_field|
+      validate_file_size! params_for_files_field, key
+    end
+
     legacy_files = FileUpload.where(idea: input)
 
     params_for_file_upload_fields.each do |key, params_for_files_field|
@@ -429,7 +435,7 @@ class WebApi::V1::IdeasController < ApplicationController
             content: params_for_files_field['content']
           })
         else
-          build_idea_file_attachment(input, params_for_files_field).tap(&:save!)
+          build_idea_file_attachment(input, params_for_files_field, field_key: key).tap(&:save!)
         end
 
         filename = idea_file.is_a?(FileUpload) ? idea_file.name : idea_file.file.name
@@ -447,7 +453,45 @@ class WebApi::V1::IdeasController < ApplicationController
       .map { |file_params| file_params.fetch(:file_by_content) }
   end
 
-  def build_idea_file_attachment(idea, file_params)
+  # `Files::FileAttachment#file` is a plain `belongs_to` with no `autosave: true`, so
+  # Rails persists the associated file with `save` (not `save!`) and ignores the result.
+  # A file that fails the uploader's size validation is therefore dropped silently, and
+  # the attachment insert then trips the `file_id` NOT NULL constraint — surfacing as a
+  # 500 the user can't act on. Reject it here instead, naming the file, before any write.
+  def validate_file_size!(file_params, field_key)
+    content = file_params['content']
+    return if content.blank?
+
+    # Read the limit off the uploader itself so this can't drift from the validation
+    # that would otherwise reject the file.
+    max_size = Files::FileUploader.new.size_range.max
+    return if base64_byte_size(content) <= max_size
+
+    raise ApiError.new(
+      :file_too_large,
+      payload: {
+        errors: {
+          field_key => [{
+            error: 'file_too_large',
+            value: file_params['name'],
+            payload: { max_size_mb: max_size / 1.megabyte }
+          }]
+        }
+      }
+    )
+  end
+
+  # Decoded size of a base64 data URI, derived from the encoded length rather than by
+  # decoding it — the encoded form of a file at the limit is already ~133 MB.
+  def base64_byte_size(content)
+    encoded = content.to_s.split(',', 2).last.to_s
+    padding = encoded.length - encoded.chomp('==').chomp('=').length
+    ((encoded.length * 3) / 4) - padding
+  end
+
+  def build_idea_file_attachment(idea, file_params, field_key: :base)
+    validate_file_size! file_params, field_key
+
     files_file = Files::File.new(
       content_by_content: {
         content: file_params['content'],

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -411,7 +411,10 @@ class WebApi::V1::IdeasController < ApplicationController
 
   def update_file_upload_fields(input, custom_form, params)
     file_uploads_exist = false
-    params_for_file_upload_fields = extract_params_for_file_upload_fields custom_form, params
+    # A file field the user cleared arrives as nil — there is nothing to validate
+    # or attach for those, and indexing into them would raise.
+    params_for_file_upload_fields =
+      (extract_params_for_file_upload_fields custom_form, params).reject { |_key, value| value.blank? }
 
     # Checked for every field before any is written, so an oversized file in a later
     # field can't leave the files from earlier ones half-persisted.

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -414,7 +414,7 @@ class WebApi::V1::IdeasController < ApplicationController
     # A file field the user cleared arrives as nil — there is nothing to validate
     # or attach for those, and indexing into them would raise.
     params_for_file_upload_fields =
-      (extract_params_for_file_upload_fields custom_form, params).reject { |_key, value| value.blank? }
+      (extract_params_for_file_upload_fields custom_form, params).compact_blank
 
     # Checked for every field before any is written, so an oversized file in a later
     # field can't leave the files from earlier ones half-persisted.

--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -411,13 +411,12 @@ class WebApi::V1::IdeasController < ApplicationController
 
   def update_file_upload_fields(input, custom_form, params)
     file_uploads_exist = false
-    # A file field the user cleared arrives as nil — there is nothing to validate
-    # or attach for those, and indexing into them would raise.
+    # A file field the user cleared arrives as null; indexing into it would raise.
     params_for_file_upload_fields =
       (extract_params_for_file_upload_fields custom_form, params).compact_blank
 
-    # Checked for every field before any is written, so an oversized file in a later
-    # field can't leave the files from earlier ones half-persisted.
+    # Validated up front so the file reported is the first one in the form, and so
+    # nothing is written before we know every file is acceptable.
     params_for_file_upload_fields.each do |key, params_for_files_field|
       validate_file_size! params_for_files_field, key
     end
@@ -456,17 +455,15 @@ class WebApi::V1::IdeasController < ApplicationController
       .map { |file_params| file_params.fetch(:file_by_content) }
   end
 
-  # `Files::FileAttachment#file` is a plain `belongs_to` with no `autosave: true`, so
-  # Rails persists the associated file with `save` (not `save!`) and ignores the result.
-  # A file that fails the uploader's size validation is therefore dropped silently, and
-  # the attachment insert then trips the `file_id` NOT NULL constraint — surfacing as a
-  # 500 the user can't act on. Reject it here instead, naming the file, before any write.
+  # `Files::FileAttachment#file` is a `belongs_to` without `autosave`, so Rails saves the
+  # file with `save` and ignores the result: one failing the uploader's size validation is
+  # dropped silently and the insert then trips the `file_id` NOT NULL constraint, giving a
+  # 500 the user can't act on. Reject it here instead, naming the file.
   def validate_file_size!(file_params, field_key)
     content = file_params['content']
     return if content.blank?
 
-    # Read the limit off the uploader itself so this can't drift from the validation
-    # that would otherwise reject the file.
+    # From the uploader, so it can't drift from the validation this mirrors.
     max_size = Files::FileUploader.new.size_range.max
     return if base64_byte_size(content) <= max_size
 
@@ -484,8 +481,8 @@ class WebApi::V1::IdeasController < ApplicationController
     )
   end
 
-  # Decoded size of a base64 data URI, derived from the encoded length rather than by
-  # decoding it — the encoded form of a file at the limit is already ~133 MB.
+  # Decoded size of a base64 data URI, from the encoded length — decoding would mean
+  # materialising ~133 MB for a file at the limit.
   def base64_byte_size(content)
     encoded = content.to_s.split(',', 2).last.to_s
     padding = encoded.length - encoded.chomp('==').chomp('=').length

--- a/back/spec/acceptance/ideas/resident_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/ideas/resident_native_survey_responses_spec.rb
@@ -151,6 +151,33 @@ resource 'Ideas' do
           )
         end
       end
+
+      context 'when a file exceeds the maximum upload size' do
+        # The limit is stubbed rather than posting a payload over the real 100 MB
+        # ceiling, which would make this spec unreasonably slow and memory-hungry.
+        before do
+          allow_any_instance_of(Files::FileUploader).to receive(:size_range).and_return((1.byte)..(100.bytes))
+        end
+
+        example_request '[error] Create a survey response with an oversized file' do
+          assert_status 422
+
+          # Both fields are oversized here, but only the first is reported, so the
+          # user is given one file to deal with at a time.
+          expect(json_response_body[:errors].keys).to eq [:custom_field_name1]
+
+          error = json_response_body.dig(:errors, :custom_field_name1, 0)
+          expect(error[:error]).to eq 'file_too_large'
+          expect(error[:value]).to eq filename1
+          expect(error[:payload]).to have_key(:max_size_mb)
+
+          # Nothing is written, so the user can swap the file out and resubmit
+          # successfully rather than being left with a half-saved response.
+          expect(project.reload.ideas).to be_empty
+          expect(Files::File.count).to eq 0
+          expect(Files::FileAttachment.count).to eq 0
+        end
+      end
     end
 
     context 'with two shapefile upload fields' do

--- a/back/spec/acceptance/ideas/resident_native_survey_responses_spec.rb
+++ b/back/spec/acceptance/ideas/resident_native_survey_responses_spec.rb
@@ -153,8 +153,7 @@ resource 'Ideas' do
       end
 
       context 'when a file exceeds the maximum upload size' do
-        # The limit is stubbed rather than posting a payload over the real 100 MB
-        # ceiling, which would make this spec unreasonably slow and memory-hungry.
+        # Stubbed rather than posting a payload over the real 100 MB ceiling.
         before do
           allow_any_instance_of(Files::FileUploader).to receive(:size_range).and_return((1.byte)..(100.bytes))
         end
@@ -162,8 +161,7 @@ resource 'Ideas' do
         example_request '[error] Create a survey response with an oversized file' do
           assert_status 422
 
-          # Both fields are oversized here, but only the first is reported, so the
-          # user is given one file to deal with at a time.
+          # Both fields are oversized; only the first is reported.
           expect(json_response_body[:errors].keys).to eq [:custom_field_name1]
 
           error = json_response_body.dig(:errors, :custom_field_name1, 0)
@@ -171,8 +169,7 @@ resource 'Ideas' do
           expect(error[:value]).to eq filename1
           expect(error[:payload]).to have_key(:max_size_mb)
 
-          # Nothing is written, so the user can swap the file out and resubmit
-          # successfully rather than being left with a half-saved response.
+          # Nothing is written, so the user can swap the file out and resubmit.
           expect(project.reload.ideas).to be_empty
           expect(Files::File.count).to eq 0
           expect(Files::FileAttachment.count).to eq 0

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
@@ -2,9 +2,17 @@ import React from 'react';
 
 import { FormProvider, useForm } from 'react-hook-form';
 
-import { render, screen, userEvent, waitFor } from 'utils/testUtils/rtl';
+import {
+  fireEvent,
+  render,
+  screen,
+  userEvent,
+  waitFor,
+} from 'utils/testUtils/rtl';
 
-import SingleFileUploadField from './SingleFileUploadField';
+import SingleFileUploadField, {
+  MAX_FILE_SIZE_MB,
+} from './SingleFileUploadField';
 
 // Anonymous survey respondents have no idea id, so no remote files are fetched.
 jest.mock('api/idea_files/useIdeaFiles', () => () => ({ data: undefined }));
@@ -16,14 +24,16 @@ const FIELD = 'my_file';
 
 let latestValues: Record<string, unknown> = {};
 
-const Wrapper = () => {
+const Wrapper = ({ withFile = true }: { withFile?: boolean }) => {
   const methods = useForm({
     defaultValues: {
-      [FIELD]: {
-        content: 'data:image/png;base64,AAAA',
-        name: 'too-big.png',
-        id: null,
-      },
+      [FIELD]: withFile
+        ? {
+            content: 'data:image/png;base64,AAAA',
+            name: 'too-big.png',
+            id: null,
+          }
+        : null,
     },
   });
 
@@ -55,6 +65,31 @@ describe('SingleFileUploadField', () => {
     await waitFor(() =>
       expect(screen.queryByText('too-big.png')).not.toBeInTheDocument()
     );
+    expect(latestValues[FIELD]).toBeFalsy();
+  });
+
+  // Anonymous respondents send nothing until the final submit, so without a
+  // client-side check an oversized file is only rejected after the whole survey
+  // has been filled in and the file uploaded. Reject it at selection instead, so
+  // it never enters form state and there is nothing to remove afterwards.
+  it('rejects an oversized file at selection without adding it to the form', async () => {
+    render(<Wrapper withFile={false} />);
+
+    const oversized = new File(['x'], 'huge.png', { type: 'image/png' });
+    Object.defineProperty(oversized, 'size', {
+      value: (MAX_FILE_SIZE_MB + 1) * 1000000,
+    });
+
+    // fireEvent rather than userEvent.upload: the input's onClick resets
+    // `value` to null, which user-event's value tracking cannot handle.
+    fireEvent.change(screen.getByTestId('fileInput'), {
+      target: { files: [oversized] },
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/are not permitted/i)).toBeInTheDocument()
+    );
+    expect(screen.queryByText('huge.png')).not.toBeInTheDocument();
     expect(latestValues[FIELD]).toBeFalsy();
   });
 });

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { render, screen, userEvent, waitFor } from 'utils/testUtils/rtl';
+
+import SingleFileUploadField from './SingleFileUploadField';
+
+// Anonymous survey respondents have no idea id, so no remote files are fetched.
+jest.mock('api/idea_files/useIdeaFiles', () => () => ({ data: undefined }));
+jest.mock('api/idea_files/useDeleteIdeaFile', () => () => ({
+  mutate: jest.fn(),
+}));
+
+const FIELD = 'my_file';
+
+let latestValues: Record<string, unknown> = {};
+
+const Wrapper = () => {
+  const methods = useForm({
+    defaultValues: {
+      [FIELD]: {
+        content: 'data:image/png;base64,AAAA',
+        name: 'too-big.png',
+        id: null,
+      },
+    },
+  });
+
+  latestValues = methods.watch();
+
+  return (
+    <FormProvider {...methods}>
+      <SingleFileUploadField name={FIELD} />
+    </FormProvider>
+  );
+};
+
+describe('SingleFileUploadField', () => {
+  // Regression test: the field previously read its value with `getValues`,
+  // which does not subscribe to form state. Clearing the field in onFileRemove
+  // updated React Hook Form but rendered nothing, so the removed file stayed on
+  // screen and only disappeared once an unrelated re-render happened — the user
+  // had to click the trash icon twice, and a file they believed was gone was
+  // still submitted.
+  it('removes the file from the UI and the form on a single click', async () => {
+    const user = userEvent.setup();
+
+    render(<Wrapper />);
+
+    expect(await screen.findByText('too-big.png')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /remove this file/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('too-big.png')).not.toBeInTheDocument()
+    );
+    expect(latestValues[FIELD]).toBeFalsy();
+  });
+});

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.test.tsx
@@ -47,12 +47,9 @@ const Wrapper = ({ withFile = true }: { withFile?: boolean }) => {
 };
 
 describe('SingleFileUploadField', () => {
-  // Regression test: the field previously read its value with `getValues`,
-  // which does not subscribe to form state. Clearing the field in onFileRemove
-  // updated React Hook Form but rendered nothing, so the removed file stayed on
-  // screen and only disappeared once an unrelated re-render happened — the user
-  // had to click the trash icon twice, and a file they believed was gone was
-  // still submitted.
+  // Regression test: reading the value with `getValues` meant removal didn't
+  // re-render (two clicks needed), and clearing it with `undefined` didn't reach
+  // the Controller, so a file the user had deleted was still submitted.
   it('removes the file from the UI and the form on a single click', async () => {
     const user = userEvent.setup();
 
@@ -68,10 +65,8 @@ describe('SingleFileUploadField', () => {
     expect(latestValues[FIELD]).toBeFalsy();
   });
 
-  // Anonymous respondents send nothing until the final submit, so without a
-  // client-side check an oversized file is only rejected after the whole survey
-  // has been filled in and the file uploaded. Reject it at selection instead, so
-  // it never enters form state and there is nothing to remove afterwards.
+  // Anonymous respondents send nothing until the final submit, so without this
+  // an oversized file is only rejected after the whole survey has been filled in.
   it('rejects an oversized file at selection without adding it to the form', async () => {
     render(<Wrapper withFile={false} />);
 

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
@@ -16,6 +16,14 @@ import SingleFileInput from 'components/UI/SingleFileUploader/FileInput';
 
 import { convertUrlToUploadFile } from 'utils/fileUtils';
 
+// Mirrors the server-side limit in Files::FileUploader#size_range. The server
+// remains authoritative — this only spares the user uploading a file that is
+// going to be rejected anyway, which matters most in the anonymous survey flow
+// where nothing is sent until the final submit. SingleFileInput compares
+// against decimal MB while the server uses binary MiB, so this rejects
+// marginally earlier than the server would; erring that way is deliberate.
+export const MAX_FILE_SIZE_MB = 100;
+
 interface Props
   extends Omit<
     FileUploaderProps,
@@ -35,6 +43,7 @@ const SingleFileUploaderField = ({
   const { mutate: deleteIdeaFile } = useDeleteIdeaFile();
   const {
     setValue,
+    setError,
     formState: { errors },
     control,
     trigger,
@@ -131,7 +140,13 @@ const SingleFileUploaderField = ({
               file={field.value}
             />
           ) : (
-            <SingleFileInput onAdd={onFileAdd} id={name} {...field} />
+            <SingleFileInput
+              onAdd={onFileAdd}
+              id={name}
+              {...field}
+              maxSizeMb={MAX_FILE_SIZE_MB}
+              onError={(message) => setError(name, { type: 'manual', message })}
+            />
           )
         }
       />

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
@@ -16,12 +16,9 @@ import SingleFileInput from 'components/UI/SingleFileUploader/FileInput';
 
 import { convertUrlToUploadFile } from 'utils/fileUtils';
 
-// Mirrors the server-side limit in Files::FileUploader#size_range. The server
-// remains authoritative — this only spares the user uploading a file that is
-// going to be rejected anyway, which matters most in the anonymous survey flow
-// where nothing is sent until the final submit. SingleFileInput compares
-// against decimal MB while the server uses binary MiB, so this rejects
-// marginally earlier than the server would; erring that way is deliberate.
+// Mirrors Files::FileUploader#size_range, which stays authoritative. Compared
+// against decimal MB here but binary MiB server-side, so this rejects marginally
+// earlier — the safe direction.
 export const MAX_FILE_SIZE_MB = 100;
 
 interface Props
@@ -49,9 +46,8 @@ const SingleFileUploaderField = ({
     trigger,
   } = useFormContext();
 
-  // Subscribed rather than read via getValues: getValues doesn't re-render, so
-  // clearing the field in onFileRemove left the removed file on screen until an
-  // unrelated state change happened to re-render (hence needing a second click).
+  // useWatch, not getValues: getValues doesn't subscribe, so removing a file
+  // didn't re-render and the trash icon needed two clicks.
   const file = useWatch({ control, name });
 
   useEffect(() => {
@@ -97,9 +93,8 @@ const SingleFileUploaderField = ({
         ideaId,
       });
     }
-    // Cleared with null rather than undefined: React Hook Form does not
-    // propagate an undefined value to a mounted Controller, so the removed file
-    // stayed on screen and in the submitted payload.
+    // null, not undefined: React Hook Form doesn't propagate undefined to the
+    // Controller, leaving the removed file on screen and in the payload.
     setValue(name, null, { shouldDirty: true });
     trigger(name);
   };
@@ -120,13 +115,6 @@ const SingleFileUploaderField = ({
 
   return (
     <Box data-cy="e2e-idea-file-upload" width="100%">
-      {/*
-        The Controller stays mounted whether or not a file is selected. It used
-        to be rendered only when the field was empty, so removing a file
-        re-mounted it — and registering a field whose value is undefined makes
-        React Hook Form re-apply its defaultValue, silently restoring the file
-        the user had just deleted.
-      */}
       <Controller
         name={name}
         control={control}

--- a/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleFileUploadField.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 import { get } from 'lodash-es';
-import { Controller, useFormContext } from 'react-hook-form';
+import { Controller, useFormContext, useWatch } from 'react-hook-form';
 import { UploadFile } from 'typings';
 
 import { IIdeaFileData } from 'api/idea_files/types';
@@ -38,10 +38,12 @@ const SingleFileUploaderField = ({
     formState: { errors },
     control,
     trigger,
-    getValues,
   } = useFormContext();
 
-  const file = getValues(name);
+  // Subscribed rather than read via getValues: getValues doesn't re-render, so
+  // clearing the field in onFileRemove left the removed file on screen until an
+  // unrelated state change happened to re-render (hence needing a second click).
+  const file = useWatch({ control, name });
 
   useEffect(() => {
     let isMounted = true;
@@ -80,13 +82,16 @@ const SingleFileUploaderField = ({
   const errorMessage = get(errors, name)?.message as string | undefined;
 
   const onFileRemove = () => {
-    if (file.id && ideaId) {
+    if (file?.id && ideaId) {
       deleteIdeaFile({
         fileId: file.id,
         ideaId,
       });
     }
-    setValue(name, undefined, { shouldDirty: true });
+    // Cleared with null rather than undefined: React Hook Form does not
+    // propagate an undefined value to a mounted Controller, so the removed file
+    // stayed on screen and in the submitted payload.
+    setValue(name, null, { shouldDirty: true });
     trigger(name);
   };
 
@@ -106,31 +111,36 @@ const SingleFileUploaderField = ({
 
   return (
     <Box data-cy="e2e-idea-file-upload" width="100%">
-      {!file && (
-        <Controller
-          name={name}
-          control={control}
-          render={({ field: { ref: _ref, ...field } }) => {
-            return <SingleFileInput onAdd={onFileAdd} id={name} {...field} />;
-          }}
-        />
-      )}
+      {/*
+        The Controller stays mounted whether or not a file is selected. It used
+        to be rendered only when the field was empty, so removing a file
+        re-mounted it — and registering a field whose value is undefined makes
+        React Hook Form re-apply its defaultValue, silently restoring the file
+        the user had just deleted.
+      */}
+      <Controller
+        name={name}
+        control={control}
+        render={({ field: { ref: _ref, ...field } }) =>
+          field.value ? (
+            <FileDisplay
+              key={field.value.name}
+              onDeleteClick={() => {
+                onFileRemove();
+              }}
+              file={field.value}
+            />
+          ) : (
+            <SingleFileInput onAdd={onFileAdd} id={name} {...field} />
+          )
+        }
+      />
       {errorMessage && (
         <Error
           marginTop="8px"
           marginBottom="8px"
           text={errorMessage}
           scrollIntoView={scrollErrorIntoView}
-        />
-      )}
-
-      {file && (
-        <FileDisplay
-          key={file.name}
-          onDeleteClick={() => {
-            onFileRemove();
-          }}
-          file={file}
         />
       )}
     </Box>

--- a/front/app/components/UI/Error/messages.ts
+++ b/front/app/components/UI/Error/messages.ts
@@ -437,4 +437,9 @@ export default defineMessages({
     defaultMessage:
       'This phone number is already taken. Please try another one.',
   },
+  file_too_large: {
+    id: 'app.errors.file_too_large',
+    defaultMessage:
+      '"{value}" is too large. The maximum file size is {max_size_mb} MB. Please remove it and upload a smaller file.',
+  },
 });

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -2584,6 +2584,7 @@
   "app.errors.emails_duplicate": "One or more duplicate values for the email address {value} were found in the following row(s): {rows}",
   "app.errors.extension_whitelist_error": "The format of the file you tried to upload is not supported.",
   "app.errors.file_extension_whitelist_error": "The format of the file you tried to upload is not supported.",
+  "app.errors.file_too_large": "\"{value}\" is too large. The maximum file size is {max_size_mb} MB. Please remove it and upload a smaller file.",
   "app.errors.first_name_blank": "This cannot be empty",
   "app.errors.generics.blank": "This cannot be empty.",
   "app.errors.generics.invalid": "This doesn't look like a valid value",


### PR DESCRIPTION
Uploading a file over the 100 MB limit to a survey file-upload question returned a 500: the uploader's size validation failed silently, leaving `file_id` null and tripping a NOT NULL constraint, which the front end could only render as the generic "There was a problem on our end" message.

The backend now rejects oversized files with a 422 naming the offending file before anything is written, and the survey file field clears on a single click — previously it didn't re-render on removal and cleared with`undefined`, which React Hook Form ignores, so a deleted file was still submitted.

Oversized files are now also refused at selection, so anonymous respondents find out immediately rather than after filling in the whole survey.

FE field error should now catch oversize files:
<img width="747" height="538" alt="Screenshot 2026-08-04 at 17 02 50" src="https://github.com/user-attachments/assets/92c28595-e83f-41fd-98f1-027b057973d3" />

If oversize file ever makes it to the BE, then error on submit is more useful:
<img width="747" height="1311" alt="Screenshot 2026-08-04 at 16 23 00" src="https://github.com/user-attachments/assets/588c060f-1daf-441b-bf6d-3afcb4bd82e7" />


# Changelog
## Fixed
- [TAN-8390] Show useful error message to user when survey file upload over size limit + enable removal of file to upload on first click of trash icon.

