### PR TITLE
Sentry Fix: Permissions updated so that 404s are not triggered

### DIFF
--- a/back/app/controllers/web_api/v1/permissions_controller.rb
+++ b/back/app/controllers/web_api/v1/permissions_controller.rb
@@ -114,7 +114,14 @@ class WebApi::V1::PermissionsController < ApplicationController
   end
 
   def set_permission
-    @permission = authorize Permission.find_by!(action: permission_action, permission_scope: permission_scope)
+    permission = Permission.find_by(action: permission_action, permission_scope: permission_scope)
+    # Actions the scope's participation method doesn't support have no Permission
+    # record (see Permission::ACTIONS). Answer with a bare 404 rather than letting
+    # RecordNotFound render its message: the frontend reports 404 bodies it can't
+    # parse as errors to Sentry, and a missing permission isn't worth reporting.
+    return send_not_found if !permission
+
+    @permission = authorize permission
   end
 
   def permission_scope

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -596,6 +596,15 @@ resource 'Permissions' do
           expect(response_data[:attributes][:access_denied_explanation_multiloc]).to eq(@multiloc)
         end
       end
+
+      context 'for an action the phase does not support' do
+        let(:action) { 'taking_survey' }
+
+        example_request 'Returns 404 without a body' do
+          assert_status 404
+          expect(response_body).to be_blank
+        end
+      end
     end
   end
 end

--- a/front/app/hooks/useCustomAccessDeniedMessage.test.tsx
+++ b/front/app/hooks/useCustomAccessDeniedMessage.test.tsx
@@ -68,6 +68,15 @@ describe('useCustomAccessDeniedMessage', () => {
     }
   );
 
+  // The phase we'd ask about is the project's current one, which may be of any
+  // participation method, so the request would often 404.
+  it('does not request an explanation when the idea is not in the current phase', async () => {
+    const { result } = renderIt('idea_not_in_current_phase');
+
+    await waitFor(() => expect(result.current).toBeNull());
+    expect(requestedActions).toEqual([]);
+  });
+
   it('does not request an explanation when the user just needs to sign in', async () => {
     const { result } = renderIt('user_not_signed_in');
 

--- a/front/app/hooks/useCustomAccessDeniedMessage.tsx
+++ b/front/app/hooks/useCustomAccessDeniedMessage.tsx
@@ -8,6 +8,7 @@ import QuillEditedContent from 'components/UI/QuillEditedContent';
 import {
   isActionNotSupported,
   isFixableByAuthentication,
+  isIdeaNotInCurrentPhase,
 } from 'utils/actionDescriptors';
 
 import useLocalize from './useLocalize';
@@ -46,11 +47,14 @@ export default function useCustomAccessDeniedMessage({
   // group). Only fetch in that case — otherwise we'd issue a request (and an
   // extra re-render once it resolves) for every enabled button on the page.
   // Unsupported actions have no permission to explain, and asking for one 404s.
+  // Same for an idea outside the current phase: the phase we'd ask about isn't
+  // the one the reason came from.
   const enabled =
     !!phaseId &&
     !!disabledReason &&
     !isFixableByAuthentication(disabledReason) &&
-    !isActionNotSupported(disabledReason);
+    !isActionNotSupported(disabledReason) &&
+    !isIdeaNotInCurrentPhase(disabledReason);
 
   const { data: accessDenied } = useAccessDeniedExplanation(
     {

--- a/front/app/utils/actionDescriptors/index.ts
+++ b/front/app/utils/actionDescriptors/index.ts
@@ -37,6 +37,15 @@ export const isActionNotSupported = (disabledReason: string) => {
   return ACTION_NOT_SUPPORTED_REASONS.has(disabledReason);
 };
 
+// The reason comes from the idea's own phase, but the phase we'd ask about is the
+// project's current one. That phase can be of any participation method, so it may
+// well have no Permission for the action, and nothing to explain either way.
+export const isIdeaNotInCurrentPhase = (disabledReason: string) => {
+  return (
+    disabledReason === ('idea_not_in_current_phase' satisfies DisabledReason)
+  );
+};
+
 // Fall back messages for disabled reasons
 const globalDisabledMessages: {
   [reason in DisabledReason]?: MessageDescriptor;

--- a/front/app/utils/cl-react-query/fetcher.test.ts
+++ b/front/app/utils/cl-react-query/fetcher.test.ts
@@ -1,6 +1,9 @@
 import { queryClient } from 'utils/cl-react-query/queryClient';
+import { reportError } from 'utils/loggingUtils';
 
 import fetcher from './fetcher';
+
+jest.mock('utils/loggingUtils', () => ({ reportError: jest.fn() }));
 
 const baseDataArray = {
   data: [
@@ -96,6 +99,25 @@ describe('fetcher', () => {
       }
 
       expect(thrownError).toEqual(baseErrorObject);
+    });
+
+    it('throws without reporting when a 404 has no body', async () => {
+      const originalFetch = global.fetch;
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 404,
+          statusText: 'Not Found',
+          ok: false,
+          json: () => Promise.reject(new Error('Unexpected end of JSON input')),
+        } as unknown as Response)
+      );
+
+      await expect(fetcher({ path: '/path', action: 'get' })).rejects.toThrow(
+        'Not found'
+      );
+      expect(reportError).not.toHaveBeenCalled();
+
+      global.fetch = originalFetch;
     });
   });
   describe('POST', () => {

--- a/front/app/utils/cl-react-query/fetcher.ts
+++ b/front/app/utils/cl-react-query/fetcher.ts
@@ -151,6 +151,12 @@ async function fetcher({
       return null;
     }
 
+    // A bodyless 404 is a valid answer, not an unexpected response. Callers still
+    // get a rejection, but there's nothing here worth reporting.
+    if (response.status === 404) {
+      throw new Error('Not found');
+    }
+
     reportError('Unsupported case. No valid JSON.');
     throw new Error('Unsupported case. No valid JSON.');
   }


### PR DESCRIPTION
TBC

# Changelog
## Technical
- Sentry Fix: Permissions updated so that 404s are not triggered, and fail siliently if they are

