### PR TITLE
Sentry Fix: New survey page returns a message when the phase is not a survey phase

### DIFF
--- a/front/app/containers/IdeasNewSurveyPage/index.test.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { IPhaseData, ParticipationMethod } from 'api/phases/types';
+import { IProjectData } from 'api/projects/types';
+
+import { render, screen } from 'utils/testUtils/rtl';
+
+import IdeasNewSurveyPage from '.';
+
+const mockTriggerAuthenticationFlow = jest.fn();
+jest.mock('containers/Authentication/events', () => ({
+  triggerAuthenticationFlow: (...args: unknown[]) =>
+    mockTriggerAuthenticationFlow(...args),
+}));
+
+jest.mock('./IdeasNewSurveyForm', () => ({
+  __esModule: true,
+  default: () => <div data-testid="surveyForm" />,
+}));
+
+jest.mock('utils/router', () => ({
+  ...jest.requireActual('utils/router'),
+  useParams: () => ({ slug: 'a-project' }),
+  useSearch: () => ({}),
+}));
+
+jest.mock('api/me/useAuthUser', () => jest.fn(() => ({ data: undefined })));
+
+const project = {
+  id: 'project-id',
+  attributes: { slug: 'a-project' },
+  relationships: { current_phase: { data: { id: 'phase-id' } } },
+} as unknown as IProjectData;
+
+jest.mock('api/projects/useProjectBySlug', () =>
+  jest.fn(() => ({
+    data: { data: project },
+    status: 'success',
+    error: null,
+  }))
+);
+
+let mockParticipationMethod: ParticipationMethod = 'native_survey';
+
+// Phases with no submission action report posting_not_supported, since no
+// Permission record exists for it (see Permission::ACTIONS in the back-end).
+const postingDescriptor = () =>
+  mockParticipationMethod === 'native_survey'
+    ? { enabled: true, disabled_reason: null }
+    : { enabled: false, disabled_reason: 'posting_not_supported' };
+
+jest.mock('api/phases/usePhase', () =>
+  jest.fn(() => ({
+    data: {
+      data: {
+        id: 'phase-id',
+        attributes: {
+          participation_method: mockParticipationMethod,
+          submission_enabled: true,
+          action_descriptors: { posting_idea: postingDescriptor() },
+        },
+      } as unknown as IPhaseData,
+    },
+    isInitialLoading: false,
+  }))
+);
+
+describe('IdeasNewSurveyPage', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the survey form for a native survey phase', () => {
+    mockParticipationMethod = 'native_survey';
+
+    render(<IdeasNewSurveyPage />);
+
+    expect(screen.getByTestId('surveyForm')).toBeInTheDocument();
+  });
+
+  // A stale link to a phase that has since become something else. Asking for a
+  // posting_idea permission on such a phase 404s, so we must not offer the
+  // authentication flow here.
+  it('shows the not-active notice for a phase that is not a survey', () => {
+    mockParticipationMethod = 'information';
+
+    render(<IdeasNewSurveyPage />);
+
+    expect(screen.queryByTestId('surveyForm')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('This survey is not currently active.')
+    ).toBeInTheDocument();
+    expect(mockTriggerAuthenticationFlow).not.toHaveBeenCalled();
+  });
+});

--- a/front/app/containers/IdeasNewSurveyPage/index.tsx
+++ b/front/app/containers/IdeasNewSurveyPage/index.tsx
@@ -49,6 +49,11 @@ const IdeasNewSurveyPage = () => {
     project?.data.relationships.current_phase?.data?.id;
   const { data: phase, isInitialLoading: phaseIsLoading } = usePhase(phaseId);
 
+  const participationMethod = phase?.data.attributes.participation_method;
+  const isSurveyPhase =
+    participationMethod === 'native_survey' ||
+    participationMethod === 'community_monitor_survey';
+
   /*
     TO DO: simplify these loading & auth checks, then if possible abstract and use the same the IdeasNewPage
   */
@@ -76,6 +81,15 @@ const IdeasNewSurveyPage = () => {
     });
 
   if (!hasEntered) {
+    // Only the survey participation methods have a survey to fill in here. A link
+    // to a phase that has since become something else (or to a project whose
+    // current phase is) would otherwise fall through to the authentication gate
+    // below, which offers a sign-in for a posting_idea permission that cannot
+    // exist on such a phase, and so dead-ends on a failed requirements fetch.
+    if (phase && !isSurveyPhase) {
+      return <SurveyNotActiveNotice project={project.data} />;
+    }
+
     if (disabledReason === 'posting_limited_max_reached' || hadIdeaIdOnMount) {
       return <SurveySubmittedNotice project={project.data} />;
     }


### PR DESCRIPTION
TBC

# Changelog
## Fixed
- New survey page returns a message instead of erroring when the phase is NOT a survey phase
