### PR TITLE
Tan 8350 take survey button visibility

### DIFF
--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
@@ -231,7 +231,7 @@ const ProjectActionButtons = memo<Props>(
       (participationMethod === 'ideation' ||
         participationMethod === 'proposals');
     const showTakeNativeSurveyButton =
-      showBoxCTAs &&
+      publication_status !== 'archived' &&
       !currentPhaseHidden &&
       !hasCurrentPhaseEnded &&
       participationMethod === 'native_survey';

--- a/front/cypress/e2e/project_description_builder/components/about_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/about_component.cy.ts
@@ -1,4 +1,5 @@
 import { randomString } from '../../../support/commands';
+import moment = require('moment');
 
 describe('Project description builder About component', () => {
   let projectId = '';
@@ -63,5 +64,56 @@ describe('Project description builder About component', () => {
 
     cy.visit(`/projects/${projectSlug}`);
     cy.get('#e2e-about-box').should('not.exist');
+  });
+
+  it('displays Take the Survey button on mobile view with native survey phase', () => {
+    cy.intercept('**/content_builder_layouts/project_page/upsert').as(
+      'saveProjectDescriptionBuilder'
+    );
+
+    // Creat a native survey phase for the project
+    cy.apiCreateNativeSurveyPhase({
+      projectId: projectId,
+      title: 'Survey Phase',
+      description: 'Survey Phase Description',
+      startAt: moment().subtract(1, 'month').format('DD/MM/YYYY'),
+      endAt: moment().add(3, 'month').format('DD/MM/YYYY'),
+      canPost: true,
+      canComment: true,
+      canReact: true,
+    }).then((survey) => {
+      const phaseId = survey.body.data.id;
+      cy.visit(`/admin/project-page-builder/projects/${projectId}`);
+
+      // Add about component to the project page
+      cy.get('#e2e-draggable-about-box').dragAndDrop('#e2e-project-page-body', {
+        position: 'inside',
+      });
+
+      cy.get('#e2e-content-builder-topbar-save').click();
+      cy.wait('@saveProjectDescriptionBuilder');
+      // Check about component is present with take the survey button in project page
+      cy.visit(`/projects/${projectSlug}`);
+      cy.get('#e2e-about-box').should('exist');
+      cy.get('#e2e-about-box').within(() => {
+        cy.get('#project-survey-button').should('be.visible');
+      });
+      // Check about component is present with take the survey button in mobile view
+      cy.viewport(375, 667);
+      cy.get('#e2e-about-box').should('exist');
+      cy.get('#e2e-about-box').within(() => {
+        cy.get('#project-survey-button').should('be.visible');
+      });
+      // back to desktop view
+      cy.viewport(1280, 720);
+      // Delete about box
+      cy.visit(`/admin/project-page-builder/projects/${projectId}`);
+      cy.get('#e2e-about-box').click({ force: true });
+      cy.get('#e2e-delete-button').click();
+      cy.get('#e2e-content-builder-topbar-save').click();
+      cy.wait('@saveProjectDescriptionBuilder');
+      // Delete native survey phase
+      cy.apiRemovePhase(phaseId);
+    });
   });
 });


### PR DESCRIPTION
🎩 What? Why?
When a native survey phase was active on a project, and a participation box has been added, the Take the survey button was not visible on mobile view.
This PR updates the showTakeNativeSurveyButton so that the button will be visible on mobile view.

🖥️ Testing
1. As an admin, go to a project with an active survey phase, and edit its content
2. Add a participation box at the top of the content and save (screenshot one)
3. Go to the project view page in the FO, and ensure you see the "Take the survey" button (screenshot two)
4. Change for mobile view, and ensure you still see the "Take the survey"  button (screenshot three)

📷 Screenshots
ONE
<img width="1385" height="824" alt="Capture d’écran 2026-08-05 à 11 47 53" src="https://github.com/user-attachments/assets/dd6dea48-fa5c-4647-be8e-3938b0312a59" />

TWO
<img width="1370" height="841" alt="Capture d’écran 2026-08-05 à 11 48 25" src="https://github.com/user-attachments/assets/c57909bc-4cc5-41bd-aa80-169dc922166a" />

THREE
<img width="1027" height="798" alt="Capture d’écran 2026-08-05 à 11 48 53" src="https://github.com/user-attachments/assets/1fa22489-3c75-4048-beae-aea0ac2ad43c" />

✅ Tasks
- [X] Added tests

# Changelog
## Fixed
- Take the survey button visible on mobile view

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
