### PR TITLE
[TAN-8405] Remove the blank section when a phase shows no content

### DIFF
--- a/front/app/components/ProjectPageBuilder/Widgets/InputFeed/InputFeedContent.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/InputFeed/InputFeedContent.tsx
@@ -1,0 +1,60 @@
+import React, { Suspense } from 'react';
+
+import usePhases from 'api/phases/usePhases';
+import { getLatestRelevantPhase, hideTimelineUI } from 'api/phases/utils';
+import useProjectById from 'api/projects/useProjectById';
+
+import useLocale from 'hooks/useLocale';
+
+import { usePermission } from 'utils/permissions';
+import { useParams } from 'utils/router';
+
+import EditModeHeightCap from '../EditModeHeightCap';
+import EmptyParticipationPreview from '../EmptyState/EmptyParticipationPreview';
+import SectionBackground from '../SectionBackground';
+import useIsPageBodyChild from '../useIsPageBodyChild';
+import useWidgetProjectId from '../useWidgetProjectId';
+
+const PublicInputContent = React.lazy(() => import('./PublicInputContent'));
+
+type Props = {
+  colored: boolean;
+};
+
+const InputFeedContent = ({ colored }: Props) => {
+  const projectId = useWidgetProjectId();
+  const isPageBodyChild = useIsPageBodyChild();
+  const { slug } = useParams({ strict: false }) as { slug?: string };
+  const currentLocale = useLocale();
+  const { data: project } = useProjectById(projectId);
+  const canModerate = usePermission({
+    item: project?.data ?? null,
+    action: 'moderate',
+  });
+  const { data: phases } = usePhases(projectId);
+
+  if (!projectId || !phases) return null;
+
+  if (!getLatestRelevantPhase(phases.data)) {
+    return canModerate ? <EmptyParticipationPreview /> : null;
+  }
+
+  const startsGreyBand = hideTimelineUI(phases.data, currentLocale);
+
+  return (
+    <EditModeHeightCap>
+      <SectionBackground
+        colored={colored}
+        fullBleed={!!slug && isPageBodyChild}
+        pb="40px"
+        pt={startsGreyBand ? '40px' : undefined}
+      >
+        <Suspense fallback={null}>
+          <PublicInputContent projectId={projectId} />
+        </Suspense>
+      </SectionBackground>
+    </EditModeHeightCap>
+  );
+};
+
+export default InputFeedContent;

--- a/front/app/components/ProjectPageBuilder/Widgets/InputFeed/index.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/InputFeed/index.tsx
@@ -1,71 +1,29 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 import { useEditor } from '@craftjs/core';
 
-import usePhases from 'api/phases/usePhases';
-import { getLatestRelevantPhase, hideTimelineUI } from 'api/phases/utils';
-import useProjectById from 'api/projects/useProjectById';
-
-import useLocale from 'hooks/useLocale';
-
-import { usePermission } from 'utils/permissions';
 import { useParams } from 'utils/router';
 
-import EditModeHeightCap from '../EditModeHeightCap';
-import EmptyParticipationPreview from '../EmptyState/EmptyParticipationPreview';
-import SectionBackground from '../SectionBackground';
-import useIsPageBodyChild from '../useIsPageBodyChild';
-import useWidgetProjectId from '../useWidgetProjectId';
-
-const PublicInputContent = React.lazy(() => import('./PublicInputContent'));
+import InputFeedContent from './InputFeedContent';
 
 type Props = {
   colored: boolean;
 };
 
 const InputFeedSection = ({ colored }: Props) => {
-  const projectId = useWidgetProjectId();
-  const isPageBodyChild = useIsPageBodyChild();
   const { slug } = useParams({ strict: false }) as { slug?: string };
-  const onPublicRoute = !!slug;
   const { enabled: inEditor } = useEditor((state) => ({
     enabled: state.options.enabled,
   }));
-  const currentLocale = useLocale();
-  const { data: project } = useProjectById(projectId);
-  const canModerate = usePermission({
-    item: project?.data ?? null,
-    action: 'moderate',
-  });
-  const { data: phases } = usePhases(projectId);
-  const hasParticipation = !!phases && !!getLatestRelevantPhase(phases.data);
-  const startsGreyBand = !!phases && hideTimelineUI(phases.data, currentLocale);
 
   return (
     <Box
       id="e2e-project-page-input-feed"
-      pointerEvents={onPublicRoute ? 'auto' : 'none'}
+      pointerEvents={slug ? 'auto' : 'none'}
       minHeight={inEditor ? '40px' : undefined}
     >
-      {projectId &&
-        phases &&
-        (hasParticipation ? (
-          <EditModeHeightCap>
-            <SectionBackground
-              colored={colored}
-              fullBleed={onPublicRoute && isPageBodyChild}
-              pb="40px"
-              pt={startsGreyBand ? '40px' : undefined}
-            >
-              <Suspense fallback={null}>
-                <PublicInputContent projectId={projectId} />
-              </Suspense>
-            </SectionBackground>
-          </EditModeHeightCap>
-        ) : canModerate ? (
-          <EmptyParticipationPreview />
-        ) : null)}
+      <InputFeedContent colored={colored} />
     </Box>
   );
 };

--- a/front/app/components/ProjectPageBuilder/Widgets/SectionBackground.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/SectionBackground.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Box, colors } from '@citizenlab/cl2-component-library';
+import styled from 'styled-components';
 
 import useIsPageBodyChild from './useIsPageBodyChild';
 
@@ -8,6 +9,15 @@ export type SectionBackgroundChoice = 'colored' | 'white';
 
 export const useDefaultSectionBackground = (): SectionBackgroundChoice =>
   useIsPageBodyChild() ? 'colored' : 'white';
+
+// The padding is what gives a section its band of background. When the content
+// inside renders nothing, that padding would be all that is left, so collapse
+// it rather than leave an empty band behind.
+const Section = styled(Box)`
+  &:empty {
+    display: none;
+  }
+`;
 
 type Props = {
   colored: boolean;
@@ -26,7 +36,7 @@ const SectionBackground = ({
   py,
   children,
 }: Props) => (
-  <Box
+  <Section
     background={colored ? colors.background : undefined}
     mx={fullBleed ? 'calc(-50vw + 50%)' : undefined}
     pt={pt}
@@ -34,7 +44,7 @@ const SectionBackground = ({
     py={py}
   >
     {children}
-  </Box>
+  </Section>
 );
 
 export default SectionBackground;

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseDocumentAnnotation/index.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseDocumentAnnotation/index.tsx
@@ -12,24 +12,17 @@ import messages from './messages';
 
 interface Props {
   phase: IPhaseData;
+  documentUrl: string;
 }
 
-const PhaseDocumentAnnotation = ({ phase }: Props) => {
-  const documentUrl = phase.attributes.document_annotation_embed_url;
+const PhaseDocumentAnnotation = ({ phase, documentUrl }: Props) => (
+  <Box position="relative" minHeight="500px">
+    <Title variant="h2" mt="0" color="tenantText">
+      <FormattedMessage {...messages.document} />
+    </Title>
 
-  if (documentUrl) {
-    return (
-      <Box position="relative" minHeight="500px">
-        <Title variant="h2" mt="0" color="tenantText">
-          <FormattedMessage {...messages.document} />
-        </Title>
-
-        <DocumentAnnotation phase={phase} documentUrl={documentUrl} />
-      </Box>
-    );
-  }
-
-  return null;
-};
+    <DocumentAnnotation phase={phase} documentUrl={documentUrl} />
+  </Box>
+);
 
 export default PhaseDocumentAnnotation;

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseParticipationContent.test.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseParticipationContent.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+
+import { phasesData } from 'api/phases/__mocks__/_mockServer';
+import { IPhaseData, ParticipationMethod } from 'api/phases/types';
+import { project1 } from 'api/projects/__mocks__/_mockServer';
+
+import { render, screen, waitFor } from 'utils/testUtils/rtl';
+
+import PhaseParticipationContent from './PhaseParticipationContent';
+
+// Every piece of content a phase can render, stubbed down to one marker, so the
+// assertions are about which branches fire rather than what the leaves draw.
+jest.mock('components/StatusModule', () => () => (
+  <div data-testid="phase-content" />
+));
+jest.mock('./Ideas', () => () => <div data-testid="phase-content" />);
+jest.mock('./VotingResults', () => () => <div data-testid="phase-content" />);
+jest.mock('./CommonGround/CommonGroundTabs', () => () => (
+  <div data-testid="phase-content" />
+));
+jest.mock('./PhaseReport', () => () => <div data-testid="phase-content" />);
+jest.mock('../shared/survey', () => () => <div data-testid="phase-content" />);
+jest.mock('../shared/poll', () => () => <div data-testid="phase-content" />);
+jest.mock('../shared/volunteering', () => () => (
+  <div data-testid="phase-content" />
+));
+jest.mock(
+  'containers/ProjectsShowPage/shared/document_annotation',
+  () => () => <div data-testid="phase-content" />
+);
+
+const buildPhase = (
+  participation_method: ParticipationMethod,
+  attributes: Partial<IPhaseData['attributes']> = {},
+  relationships: Partial<IPhaseData['relationships']> = {}
+): IPhaseData => {
+  const base = phasesData[0];
+
+  return {
+    ...base,
+    attributes: { ...base.attributes, participation_method, ...attributes },
+    relationships: { ...base.relationships, ...relationships },
+  };
+};
+
+const publicReport = {
+  report: { data: { id: 'report-id', type: 'report' } },
+};
+
+const withContent: [string, IPhaseData][] = [
+  ['ideation', buildPhase('ideation')],
+  ['proposals', buildPhase('proposals')],
+  ['voting', buildPhase('voting', { voting_method: 'budgeting' })],
+  ['common ground', buildPhase('common_ground')],
+  ['poll', buildPhase('poll')],
+  ['volunteering', buildPhase('volunteering')],
+  [
+    'an embedded external survey',
+    buildPhase('survey', {
+      survey_service: 'typeform',
+      survey_embed_url: 'https://example.com',
+    }),
+  ],
+  [
+    'document annotation',
+    buildPhase('document_annotation', {
+      document_annotation_embed_url: 'https://example.com',
+    }),
+  ],
+  [
+    'information with a public report',
+    buildPhase('information', { report_public: true }, publicReport),
+  ],
+];
+
+const withoutContent: [string, IPhaseData][] = [
+  ['a native survey', buildPhase('native_survey')],
+  ['a community monitor survey', buildPhase('community_monitor_survey')],
+  ['an external survey without an embed url', buildPhase('survey')],
+  ['document annotation without a document', buildPhase('document_annotation')],
+  [
+    'information with a private report',
+    buildPhase('information', { report_public: false }, publicReport),
+  ],
+  ['information without a report', buildPhase('information')],
+];
+
+// Rendered into a host element so "renders nothing" can be asserted without the
+// test providers' own markup getting in the way.
+const renderPhase = (phase: IPhaseData) =>
+  render(
+    <div data-testid="host">
+      <PhaseParticipationContent
+        project={project1}
+        phase={phase}
+        wrapReportInSuspense
+      />
+    </div>
+  );
+
+describe('PhaseParticipationContent', () => {
+  it.each(withContent)('renders content for %s', async (_, phase) => {
+    renderPhase(phase);
+
+    await waitFor(() => {
+      expect(screen.queryAllByTestId('phase-content').length).toBeGreaterThan(
+        0
+      );
+    });
+  });
+
+  // An empty wrapper left behind here is what the surrounding section paints as
+  // a blank coloured band, so nothing at all may reach the DOM.
+  it.each(withoutContent)('renders nothing at all for %s', async (_, phase) => {
+    renderPhase(phase);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('host')).toBeEmptyDOMElement();
+    });
+  });
+});

--- a/front/app/containers/ProjectsShowPage/timeline/PhaseParticipationContent.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/PhaseParticipationContent.tsx
@@ -35,8 +35,13 @@ const PhaseParticipationContent = ({
 }: Props) => {
   const projectId = project.id;
   const phaseId = phase.id;
-  const participationMethod = phase.attributes.participation_method;
-  const votingMethod = phase.attributes.voting_method;
+  const {
+    participation_method: participationMethod,
+    voting_method: votingMethod,
+    survey_embed_url: surveyEmbedUrl,
+    survey_service: surveyService,
+    document_annotation_embed_url: documentUrl,
+  } = phase.attributes;
   const isPastPhase =
     !!phase.attributes.end_at &&
     pastPresentOrFuture(phase.attributes.end_at) === 'past';
@@ -48,41 +53,72 @@ const PhaseParticipationContent = ({
     (isVotingPhase && !phase.attributes.autoshare_results_enabled);
   const showVotingResults =
     isVotingPhase && isPastPhase && phase.attributes.autoshare_results_enabled;
+  const showSurvey =
+    participationMethod === 'survey' && !!surveyEmbedUrl && !!surveyService;
+  const showDocumentAnnotation =
+    participationMethod === 'document_annotation' && !!documentUrl;
+  const showPoll = participationMethod === 'poll';
+  const showVolunteering = participationMethod === 'volunteering';
+  const showCommonGround = participationMethod === 'common_ground';
   const reportId = phase.relationships.report?.data?.id;
   const showReport =
     participationMethod === 'information' &&
     !!reportId &&
     phase.attributes.report_public;
 
+  // The report brings its own width and spacing, so it sits outside the
+  // container. Skipping the container when nothing goes in it leaves no empty
+  // wrapper behind, which is what lets the surrounding section collapse.
+  const hasContainedContent =
+    !!children ||
+    isVotingPhase ||
+    showSurvey ||
+    showDocumentAnnotation ||
+    showPoll ||
+    showVolunteering ||
+    showIdeas ||
+    showVotingResults ||
+    showCommonGround;
+
+  if (!hasContainedContent && !showReport) return null;
+
   return (
     <>
-      <ContentContainer maxWidth={maxPageWidth}>
-        {children}
-        {isVotingPhase && (
-          <StatusModule
-            phase={phase}
-            project={project}
-            votingMethod={votingMethod}
-          />
-        )}
-        <PhaseSurvey phaseId={phaseId} />
-        {participationMethod === 'document_annotation' && (
-          <PhaseDocumentAnnotation phase={phase} />
-        )}
-        <PhasePoll projectId={projectId} phaseId={phaseId} />
-        <PhaseVolunteering phaseId={phaseId} />
-        {showIdeas && <PhaseIdeas projectId={projectId} phaseId={phaseId} />}
-        {showVotingResults && votingMethod && (
-          <VotingResults phaseId={phaseId} votingMethod={votingMethod} />
-        )}
-        {participationMethod === 'common_ground' && (
-          <CommonGroundTabs
-            phase={phase}
-            project={project}
-            isPastPhase={isPastPhase}
-          />
-        )}
-      </ContentContainer>
+      {hasContainedContent && (
+        <ContentContainer maxWidth={maxPageWidth}>
+          {children}
+          {isVotingPhase && (
+            <StatusModule
+              phase={phase}
+              project={project}
+              votingMethod={votingMethod}
+            />
+          )}
+          {showSurvey && (
+            <PhaseSurvey
+              phase={phase}
+              surveyEmbedUrl={surveyEmbedUrl}
+              surveyService={surveyService}
+            />
+          )}
+          {showDocumentAnnotation && (
+            <PhaseDocumentAnnotation phase={phase} documentUrl={documentUrl} />
+          )}
+          {showPoll && <PhasePoll projectId={projectId} phaseId={phaseId} />}
+          {showVolunteering && <PhaseVolunteering phase={phase} />}
+          {showIdeas && <PhaseIdeas projectId={projectId} phaseId={phaseId} />}
+          {showVotingResults && votingMethod && (
+            <VotingResults phaseId={phaseId} votingMethod={votingMethod} />
+          )}
+          {showCommonGround && (
+            <CommonGroundTabs
+              phase={phase}
+              project={project}
+              isPastPhase={isPastPhase}
+            />
+          )}
+        </ContentContainer>
+      )}
       {showReport &&
         (wrapReportInSuspense ? (
           <Suspense fallback={null}>

--- a/front/app/containers/ProjectsShowPage/timeline/Poll.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Poll.tsx
@@ -1,9 +1,6 @@
 import React, { memo } from 'react';
 
-import { Title } from '@citizenlab/cl2-component-library';
-import styled from 'styled-components';
-
-import usePhase from 'api/phases/usePhase';
+import { Box, Title } from '@citizenlab/cl2-component-library';
 
 import messages from 'containers/ProjectsShowPage/messages';
 
@@ -11,31 +8,19 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 import Poll from '../shared/poll';
 
-const Container = styled.div``;
-
 interface Props {
   projectId: string;
   phaseId: string;
   className?: string;
 }
 
-const PollContainer = memo<Props>(({ projectId, phaseId, className }) => {
-  const { data: phase } = usePhase(phaseId);
-
-  if (phase && phase.data.attributes.participation_method === 'poll') {
-    return (
-      <Container
-        className={`e2e-timeline-project-poll-container ${className || ''}`}
-      >
-        <Title variant="h2" mt="0" color="tenantText">
-          <FormattedMessage {...messages.navPoll} />
-        </Title>
-        <Poll phaseId={phaseId} projectId={projectId} />
-      </Container>
-    );
-  }
-
-  return null;
-});
+const PollContainer = memo<Props>(({ projectId, phaseId, className }) => (
+  <Box className={`e2e-timeline-project-poll-container ${className || ''}`}>
+    <Title variant="h2" mt="0" color="tenantText">
+      <FormattedMessage {...messages.navPoll} />
+    </Title>
+    <Poll phaseId={phaseId} projectId={projectId} />
+  </Box>
+));
 
 export default PollContainer;

--- a/front/app/containers/ProjectsShowPage/timeline/Survey.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Survey.tsx
@@ -1,8 +1,8 @@
 import React, { memo } from 'react';
 
-import styled from 'styled-components';
+import { Box } from '@citizenlab/cl2-component-library';
 
-import usePhase from 'api/phases/usePhase';
+import { IPhaseData, TSurveyService } from 'api/phases/types';
 
 import messages from 'containers/ProjectsShowPage/messages';
 
@@ -11,40 +11,27 @@ import { FormattedMessage } from 'utils/cl-intl';
 
 import Survey from '../shared/survey';
 
-const Container = styled.div`
-  position: relative;
-`;
-
 interface Props {
-  phaseId: string | null;
+  phase: IPhaseData;
+  surveyEmbedUrl: string;
+  surveyService: TSurveyService;
   className?: string;
 }
 
-const SurveyContainer = memo<Props>(({ phaseId, className }) => {
-  const { data: phase } = usePhase(phaseId);
-
-  if (
-    phase &&
-    phase.data.attributes.participation_method === 'survey' &&
-    phase.data.attributes.survey_embed_url &&
-    phase.data.attributes.survey_service
-  ) {
-    return (
-      <Container className={className || ''}>
-        <ScreenReaderOnly>
-          <FormattedMessage tagName="h3" {...messages.invisibleTitleSurvey} />
-        </ScreenReaderOnly>
-        <Survey
-          className={className}
-          phase={phase.data}
-          surveyEmbedUrl={phase.data.attributes.survey_embed_url}
-          surveyService={phase.data.attributes.survey_service}
-        />
-      </Container>
-    );
-  }
-
-  return null;
-});
+const SurveyContainer = memo<Props>(
+  ({ phase, surveyEmbedUrl, surveyService, className }) => (
+    <Box position="relative" className={className || ''}>
+      <ScreenReaderOnly>
+        <FormattedMessage tagName="h3" {...messages.invisibleTitleSurvey} />
+      </ScreenReaderOnly>
+      <Survey
+        className={className}
+        phase={phase}
+        surveyEmbedUrl={surveyEmbedUrl}
+        surveyService={surveyService}
+      />
+    </Box>
+  )
+);
 
 export default SurveyContainer;

--- a/front/app/containers/ProjectsShowPage/timeline/Volunteering.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/Volunteering.tsx
@@ -1,34 +1,22 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { Box } from '@citizenlab/cl2-component-library';
 
-import usePhase from 'api/phases/usePhase';
+import { IPhaseData } from 'api/phases/types';
 
 import Volunteering from '../shared/volunteering';
 
-const Container = styled.div``;
-
 interface Props {
-  phaseId: string | null;
+  phase: IPhaseData;
   className?: string;
 }
 
-const VolunteeringContainer = ({ className, phaseId }: Props) => {
-  const { data: phase } = usePhase(phaseId);
-
-  if (phase?.data.attributes.participation_method === 'volunteering') {
-    return (
-      <Container
-        className={`e2e-timeline-project-volunteering-container ${
-          className || ''
-        }`}
-      >
-        <Volunteering phase={phase.data} />
-      </Container>
-    );
-  }
-
-  return null;
-};
+const VolunteeringContainer = ({ className, phase }: Props) => (
+  <Box
+    className={`e2e-timeline-project-volunteering-container ${className || ''}`}
+  >
+    <Volunteering phase={phase} />
+  </Box>
+);
 
 export default VolunteeringContainer;


### PR DESCRIPTION
# Changelog

## Fixed
- Project pages no longer show an empty grey band between sections when the active phase has nothing for visitors to take part in. It was most visible on projects with a single information phase with no end date or description, where the timeline is hidden