### PR TITLE
[TAN-8368] Fix boot crash when `QUE_AIVEN_PG_SECURITY_COMPAT` is enabled

### DIFF
--- a/back/config/initializers/que.rb
+++ b/back/config/initializers/que.rb
@@ -23,6 +23,8 @@ end
 # Opt-in compatibility layer that overwrites the `clean_lockers` query for PostgreSQL
 # protected by the aiven-pg-security extension (e.g. Scaleway Managed Database).
 if ENV.fetch('QUE_AIVEN_PG_SECURITY_COMPAT', false) == 'true'
-  CitizenLab::Que::AivenPgSecurityCompat.apply!
-  Rails.logger.info('[que] clean_lockers patched for aiven-pg-security (QUE_AIVEN_PG_SECURITY_COMPAT)')
+  Rails.application.config.to_prepare do
+    CitizenLab::Que::AivenPgSecurityCompat.apply!
+    Rails.logger.info('[que] clean_lockers patched for aiven-pg-security (QUE_AIVEN_PG_SECURITY_COMPAT)')
+  end
 end


### PR DESCRIPTION

# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
