### PR TITLE
TAN-8394 Fix accessibility issue in email consent settings

### DIFF
--- a/front/app/components/CampaignConsentForm/ConsentGroup.tsx
+++ b/front/app/components/CampaignConsentForm/ConsentGroup.tsx
@@ -10,7 +10,7 @@ import {
 import CheckboxWithPartialCheck from 'components/UI/CheckboxWithPartialCheck';
 
 import { ScreenReaderOnly } from 'utils/a11y';
-import { FormattedMessage } from 'utils/cl-intl';
+import { FormattedMessage, useIntl } from 'utils/cl-intl';
 
 import messages from './messages';
 import {
@@ -26,41 +26,50 @@ interface Props {
   onToggleConsent: ToggleConsentHandler;
 }
 
-const ConsentGroup = ({ group, onToggleGroup, onToggleConsent }: Props) => (
-  <Accordion
-    title={<Text m="12px">{group.contentType}</Text>}
-    prefix={
-      <CheckboxWithPartialCheck
-        id={group.id}
-        checked={group.group_consented}
-        onChange={onToggleGroup(group)}
-      />
-    }
-  >
-    <Box ml="34px">
-      <ScreenReaderOnly>
-        <legend>
-          <FormattedMessage {...messages.ally_categoryLabel} />
-        </legend>
-      </ScreenReaderOnly>
-      {group.children.map(
-        ({
-          id,
-          consented,
-          campaign_type_description,
-        }: CampaignConsentChild) => (
-          <CheckboxWithLabel
-            key={id}
-            size="20px"
-            mb="12px"
-            checked={consented}
-            onChange={onToggleConsent(id)}
-            label={campaign_type_description}
-          />
-        )
-      )}
-    </Box>
-  </Accordion>
-);
+const ConsentGroup = ({ group, onToggleGroup, onToggleConsent }: Props) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <Accordion
+      title={<Text m="12px">{group.contentType}</Text>}
+      prefix={
+        // The accordion title sits in a sibling element, so it can't name this
+        // checkbox — it gets an explicit label instead.
+        <CheckboxWithPartialCheck
+          id={group.id}
+          checked={group.group_consented}
+          onChange={onToggleGroup(group)}
+          aria-label={formatMessage(messages.a11y_toggleAllInCategory, {
+            contentType: group.contentType,
+          })}
+        />
+      }
+    >
+      <Box ml="34px">
+        <ScreenReaderOnly>
+          <legend>
+            <FormattedMessage {...messages.ally_categoryLabel} />
+          </legend>
+        </ScreenReaderOnly>
+        {group.children.map(
+          ({
+            id,
+            consented,
+            campaign_type_description,
+          }: CampaignConsentChild) => (
+            <CheckboxWithLabel
+              key={id}
+              size="20px"
+              mb="12px"
+              checked={consented}
+              onChange={onToggleConsent(id)}
+              label={campaign_type_description}
+            />
+          )
+        )}
+      </Box>
+    </Accordion>
+  );
+};
 
 export default ConsentGroup;

--- a/front/app/components/CampaignConsentForm/messages.ts
+++ b/front/app/components/CampaignConsentForm/messages.ts
@@ -33,4 +33,8 @@ export default defineMessages({
     id: 'app.containers.CampaignsConsentForm.ally_categoryLabel2',
     defaultMessage: 'Notifications in this category',
   },
+  a11y_toggleAllInCategory: {
+    id: 'app.containers.CampaignsConsentForm.a11y_toggleAllInCategory',
+    defaultMessage: 'Toggle all {contentType} notifications',
+  },
 });

--- a/front/app/components/UI/CheckboxWithPartialCheck/index.tsx
+++ b/front/app/components/UI/CheckboxWithPartialCheck/index.tsx
@@ -89,22 +89,25 @@ type DefaultProps = {
 };
 
 /**
- * If we have a label, an id is required. Otherwise id is optional.
+ * The checkbox needs an accessible name. Visible `label` text provides one (a
+ * checkbox takes its name from its contents); without it an `aria-label` is
+ * required, otherwise screen readers announce a nameless "checkbox".
  */
 type LabelProps =
   | {
-      label: string | JSX.Element | null;
-      id: string;
+      label: string | JSX.Element;
+      'aria-label'?: string;
     }
   | {
       label?: undefined;
-      id?: string | undefined;
+      'aria-label': string;
     };
 
 type Props = DefaultProps &
   LabelProps & {
     checked: boolean | 'mixed';
     onChange: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    id?: string;
     className?: string;
     notFocusable?: boolean;
     disabled?: boolean;
@@ -172,13 +175,16 @@ export default class CheckboxWithPartialCheck extends PureComponent<Props> {
       label,
       size,
       checked,
+      id,
       className,
       notFocusable,
+      'aria-label': ariaLabel,
       'data-testid': testid,
     } = this.props;
 
     return (
       <Container
+        id={id}
         size={size as string}
         onMouseDown={removeFocusAfterMouseClick}
         onClick={this.handleOnClick}
@@ -188,6 +194,7 @@ export default class CheckboxWithPartialCheck extends PureComponent<Props> {
         }`}
         role="checkbox"
         aria-checked={checked}
+        aria-label={ariaLabel}
         tabIndex={notFocusable ? -1 : 0}
         data-testid={testid}
       >
@@ -199,7 +206,7 @@ export default class CheckboxWithPartialCheck extends PureComponent<Props> {
           )}
         </CustomInputWrapper>
 
-        <Label>{label}</Label>
+        {label && <Label>{label}</Label>}
       </Container>
     );
   }

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -1367,6 +1367,7 @@
   "app.containers.Authentication.steps.Phone.phoneNumber": "Phone number",
   "app.containers.Authentication.steps.Phone.phoneNumberFormatError": "Provide a phone number in the correct format, for example +32 470 12 34 56",
   "app.containers.Authentication.steps.Phone.phoneNumberMissingError": "Provide a phone number",
+  "app.containers.CampaignsConsentForm.a11y_toggleAllInCategory": "Toggle all {contentType} notifications",
   "app.containers.CampaignsConsentForm.ally_categoryLabel2": "Notifications in this category",
   "app.containers.CampaignsConsentForm.emailNotificationsSubTitle": "What kinds of email notifications do you want to receive?",
   "app.containers.CampaignsConsentForm.emailNotificationsTitle": "Email notifications",


### PR DESCRIPTION
# Changelog
## a11y
- Fixes accessibility issue in email consent settings 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
