### PR TITLE
Flaky E2E Fix: proposal_edit_page.cy.ts — Clear idea location when the form no longer has a location field

### DIFF
--- a/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
+++ b/front/app/components/CustomFieldsForm/IdeationForm/index.tsx
@@ -116,11 +116,16 @@ const IdeationForm = ({
           weglot_data: weglotData,
         };
         // Keep location_point_geojson consistent with location_description:
-        // if there is no description, force the geojson to null so a stale
-        // value from the idea's initial state can't ride through unchanged
-        // (e.g. when the location field is disabled in the form config and
-        // the LocationInput never mounts to clear it).
-        if (!requestBody.location_description) {
+        // null it when the user cleared the description, and also when the
+        // form config no longer contains an enabled location field. In that
+        // second case the LocationInput never mounts, but defaultValues
+        // spread all idea attributes (getInitialData), so the idea's old
+        // location_description sits in form state anyway and the idea would
+        // invisibly keep a location its form can no longer show or edit.
+        const formHasLocationField = customFields?.some(
+          (field) => field.key === 'location_description' && field.enabled
+        );
+        if (!requestBody.location_description || !formHasLocationField) {
           requestBody.location_point_geojson = null;
         }
         await updateIdea({


### PR DESCRIPTION
# Note
This was generated entirely by Claude during a pilot test of an automated flaky E2E fixing flow.

# Description
The edit form's defaultValues spread all idea attributes, so location_description always sits in form state even when the location field was deleted from the form config. The existing guard therefore never fired and the idea invisibly kept its old location_point_geojson on every edit. Also null the geojson when the form has no enabled location field, which is what the proposal_edit_page e2e spec asserts and makes its final map assertion deterministic instead of racing the Esri map mount.