### PR TITLE
[TAN-8416] Flaky E2E Fix: create_and_fill_form.cy.ts — stable address

### DIFF
--- a/front/cypress/e2e/input_form_builder/create_and_fill_form.cy.ts
+++ b/front/cypress/e2e/input_form_builder/create_and_fill_form.cy.ts
@@ -191,8 +191,12 @@ describe('Input form builder', () => {
     // Go to the next page of the idea form
     cy.dataCy('e2e-next-page').should('be.visible').click();
 
-    // Veryify location is present and properly geocoded (from the lat long in URL)
-    cy.contains('Steenakker 34, 5411').should('exist');
+    // Verify location is present and reverse-geocoded (from the lat long in
+    // URL). Match street + postcode but not the house number: that's the
+    // geocoding provider's data, which drifts over time (returned 36 until
+    // June 2026, then 34). The exact coordinates are asserted on submission
+    // via the ideaSubmission interception below.
+    cy.contains(/Steenakker \d+, 5411/).should('exist');
 
     // Cannot proceed to the next page without filling in the required custom field
     cy.dataCy('e2e-submit-form').click();


### PR DESCRIPTION
# Changelog

## Technical
- Made the `create_and_fill_form` E2E test robust against geocoding-provider data changes: it asserted the provider's exact house number for fixed test coordinates, which drifted in June 2026 ("Steenakker 36" → "34") and broke three nightly runs until hand-patched. The test now matches street + postcode only; exact coordinates are still verified precisely via the idea-submission API interception.

# Context

Generated by Claude via the `fix-flaky-e2e` flow.

**Root cause:** brittle third-party assertion, not a race — the reverse-geocoded house number is external data that changes over time (history: added as "36" in Sept 2025, hand-patched to "34" on 2026-06-30 in an unrelated PR).

**Why this fixes rather than suppresses:** the UI assertion's job is to prove reverse-geocoding ran and populated the field — street + postcode does that; the coordinate values themselves are asserted with `closeTo` on the submission response, unchanged.

**Stability evidence:** [pipeline 346251](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346251) — spec ran on 3 independent nodes, 6/6 tests green. (Local reproduction intentionally skipped: the failure is deterministic data drift, not a race, so local reruns prove nothing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)