### PR TITLE
TAN-8415-fix-e2e-test-router-history

### DIFF
--- a/front/cypress/e2e/router_history.cy.ts
+++ b/front/cypress/e2e/router_history.cy.ts
@@ -28,10 +28,7 @@ describe('router history', () => {
     // shell. Wait for the ideas request to resolve and the cards to render before
     // any test interacts with them — this is the async load that races in CI.
     cy.wait('@getIdeas');
-    cy.get('#e2e-ideas-list a', { timeout: 30000 }).should(
-      'have.length.greaterThan',
-      0
-    );
+    cy.get('#e2e-ideas-list a').should('have.length.greaterThan', 0);
   });
 
   it('works with nested routes (show idea)', () => {

--- a/front/cypress/e2e/router_history.cy.ts
+++ b/front/cypress/e2e/router_history.cy.ts
@@ -15,12 +15,22 @@ describe('router history', () => {
 
   beforeEach(() => {
     cy.setLoginCookie(email, password);
+    cy.intercept('GET', '**/web_api/v1/ideas?*').as('getIdeas');
     cy.visit('/projects/an-idea-bring-it-to-your-council');
     cy.get('#e2e-project-page');
 
     cy.location('pathname').should(
       'eq',
       '/en/projects/an-idea-bring-it-to-your-council'
+    );
+
+    // The ideas list is code-split + data-dependent, so it mounts after the page
+    // shell. Wait for the ideas request to resolve and the cards to render before
+    // any test interacts with them — this is the async load that races in CI.
+    cy.wait('@getIdeas');
+    cy.get('#e2e-ideas-list a', { timeout: 30000 }).should(
+      'have.length.greaterThan',
+      0
     );
   });
 


### PR DESCRIPTION
Problem: works with nested routes (show idea) failed in CI (never locally) with #e2e-ideas-list a "never found."

Cause: The test queried the ideas cards right after the page shell mounted, but the ideas list is code-split (lazy/Suspense) and only renders after GET /ideas resolves. The old beforeEach didn't wait for that, so on slower CI the cards weren't there yet.

Fix: Intercept the ideas request and cy.wait on it (plus assert the cards rendered) in beforeEach, so every test acts on a settled page instead of racing the async load.

Verification: Ran the spec in pipeline 3 times with no failures  ✅


# Changelog
## Fixed
- TAN-8415-Fix-e2e-test-router-history

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
