### PR TITLE
[TAN-8417] Require visibility of the reported input to create a spam report

### DIFF
--- a/back/app/policies/spam_report_policy.rb
+++ b/back/app/policies/spam_report_policy.rb
@@ -19,6 +19,9 @@ class SpamReportPolicy < ApplicationPolicy
     # The reportable is looked up from the URL, so it may not exist. Bail out
     # before Pundit is asked for a policy on nil.
     return false if record.spam_reportable.blank?
+    # `IdeaPolicy#show?` lets anyone see a draft, but a draft is visible to
+    # nobody but its author, so there is nothing legitimate to report.
+    return false if record.spam_reportable.try(:draft?)
 
     policy_for(record.spam_reportable).show?
   end

--- a/back/app/policies/spam_report_policy.rb
+++ b/back/app/policies/spam_report_policy.rb
@@ -14,15 +14,21 @@ class SpamReportPolicy < ApplicationPolicy
   end
 
   def create?
-    user&.active? && (record.user_id == user.id || user&.admin?)
+    return false unless active?
+    return false unless record.user_id == user.id || user.admin?
+    # The reportable is looked up from the URL, so it may not exist. Bail out
+    # before Pundit is asked for a policy on nil.
+    return false if record.spam_reportable.blank?
+
+    policy_for(record.spam_reportable).show?
   end
 
   def show?
-    user&.active? && (record.user_id == user.id || user&.admin?)
+    active? && (record.user_id == user.id || user&.admin?)
   end
 
   def update?
-    user&.active? && (record.user_id == user.id || user&.admin?)
+    active? && (record.user_id == user.id || user&.admin?)
   end
 
   def destroy?

--- a/back/spec/acceptance/idea_spam_report_spec.rb
+++ b/back/spec/acceptance/idea_spam_report_spec.rb
@@ -56,6 +56,42 @@ resource 'Spam Reports' do
       expect(json_response.dig(:data, :relationships, :user, :data, :id)).to eq @user.id
       expect(json_response.dig(:data, :attributes, :reason_code)).to eq 'inappropriate'
     end
+
+    context 'when signed in as a regular user' do
+      before { header_token_for create(:user) }
+
+      example_request 'Create a spam report for a publicly visible idea' do
+        expect(response_status).to eq 201
+      end
+
+      context 'when the input is a native survey response' do
+        before { create(:idea_status_proposed) }
+
+        let(:idea_id) { create(:native_survey_response).id }
+
+        example_request '[error] Create a spam report for an input the user cannot see' do
+          expect(response_status).to eq 401
+          expect(SpamReport.where(spam_reportable_id: idea_id)).to be_empty
+        end
+      end
+
+      context 'when the input is in a project the user has no access to' do
+        let(:idea_id) { create(:idea, project: create(:private_groups_project)).id }
+
+        example_request '[error] Create a spam report for an input in an inaccessible project' do
+          expect(response_status).to eq 401
+          expect(SpamReport.where(spam_reportable_id: idea_id)).to be_empty
+        end
+      end
+
+      context 'when the input does not exist' do
+        let(:idea_id) { SecureRandom.uuid }
+
+        example_request '[error] Create a spam report for an unknown input' do
+          expect(response_status).to eq 401
+        end
+      end
+    end
   end
 
   patch 'web_api/v1/spam_reports/:id' do

--- a/back/spec/acceptance/idea_spam_report_spec.rb
+++ b/back/spec/acceptance/idea_spam_report_spec.rb
@@ -84,6 +84,15 @@ resource 'Spam Reports' do
         end
       end
 
+      context 'when the input is still a draft' do
+        let(:idea_id) { create(:idea, publication_status: 'draft').id }
+
+        example_request '[error] Create a spam report for a draft input' do
+          expect(response_status).to eq 401
+          expect(SpamReport.where(spam_reportable_id: idea_id)).to be_empty
+        end
+      end
+
       context 'when the input does not exist' do
         let(:idea_id) { SecureRandom.uuid }
 


### PR DESCRIPTION
Child ticket of broader parent: [TAN-8317: Idea could be posted while the active phase was a survey](https://app.notion.com/p/govocal/Idea-could-be-posted-while-the-active-phase-was-a-survey-3aa9663b7b26817c80add2de5652656d)

`SpamReportPolicy#create?` never authorized the record being reported, so any signed-in user could POST a spam report against any input by id — including  survey responses and inputs in projects they have no access to. Every report fans out a notification and email to all moderators of that project.

 Now the policy delegates to the reportable's own `show?`. One check covers both ideas and comments, since `CommentPolicy#show?` already defers to its parent idea. Before this, the policy now also first guards against draft publication status, since there cannot be spam if the idea is not published (important, as a malicious user can create unlimited draft ideas).

 ## Also closed by this
- **Existence oracle**: an unknown UUID and an input the user can't see now both return 401. Previously a real id returned 201 and a bogus one a validation error, which let an unauthenticated guess confirm whether an input exists.
- **500 on unknown ids**: the reported record is looked up from the id in the request path and may not exist, so the policy bails out before Pundit is asked for a policy on `nil`.

# Changelog
## Technical
- [TAN-8417] Require visibility of the reported input to create a spam report
