### PR TITLE
[TAN-8421] Only notify moderators of repeat spam reports when something changed + rate limit spam reports

### DIFF
--- a/back/app/models/notifications/comment_marked_as_spam.rb
+++ b/back/app/models/notifications/comment_marked_as_spam.rb
@@ -76,25 +76,26 @@ module Notifications
     def self.make_notifications_on(activity)
       spam_report = activity.item
       initiator_id = spam_report&.user_id
-      if spam_report.spam_reportable_type == 'Comment' && initiator_id
-        attributes = {
-          initiating_user_id: initiator_id,
-          spam_report: spam_report,
-          comment_id: spam_report.spam_reportable.id,
-          idea: spam_report.spam_reportable.idea,
-          reason_code: activity.payload['reason_code'],
-          other_reason: activity.payload['other_reason'],
-          project_id: spam_report.spam_reportable.idea.project_id
-        }
+      return [] unless spam_report.spam_reportable_type == 'Comment' && initiator_id
 
-        recipient_ids(initiator_id, attributes[:project_id]).map do |recipient_id|
-          new(
-            recipient_id: recipient_id,
-            **attributes
-          )
-        end
-      else
-        []
+      comment = spam_report.spam_reportable
+      return [] unless notify?(comment, where(comment_id: comment.id).maximum(:created_at))
+
+      attributes = {
+        initiating_user_id: initiator_id,
+        spam_report: spam_report,
+        comment_id: comment.id,
+        idea: comment.idea,
+        reason_code: activity.payload['reason_code'],
+        other_reason: activity.payload['other_reason'],
+        project_id: comment.idea.project_id
+      }
+
+      recipient_ids(initiator_id, attributes[:project_id]).map do |recipient_id|
+        new(
+          recipient_id: recipient_id,
+          **attributes
+        )
       end
     end
   end

--- a/back/app/models/notifications/idea_marked_as_spam.rb
+++ b/back/app/models/notifications/idea_marked_as_spam.rb
@@ -75,12 +75,12 @@ module Notifications
 
     def self.make_notifications_on(activity)
       spam_report = activity.item
-      return [] if spam_report.spam_reportable_type != 'Idea'
+      initiator_id = spam_report.user_id
+      return [] unless spam_report.spam_reportable_type == 'Idea' && initiator_id
 
       idea = spam_report.spam_reportable
       return [] unless notify?(idea, where(idea_id: idea.id).maximum(:created_at))
 
-      initiator_id = spam_report.user_id
       project_id = idea.project_id
       recipient_ids(initiator_id, project_id).map do |recipient_id|
         new(

--- a/back/app/models/notifications/idea_marked_as_spam.rb
+++ b/back/app/models/notifications/idea_marked_as_spam.rb
@@ -75,20 +75,21 @@ module Notifications
 
     def self.make_notifications_on(activity)
       spam_report = activity.item
-      if spam_report.spam_reportable_type == 'Idea'
-        initiator_id = spam_report.user_id
-        project_id = spam_report.spam_reportable.project_id
-        recipient_ids(initiator_id, project_id).map do |recipient_id|
-          new(
-            recipient_id: recipient_id,
-            initiating_user_id: initiator_id,
-            spam_report: spam_report,
-            idea: spam_report.spam_reportable,
-            project_id: project_id
-          )
-        end
-      else
-        []
+      return [] if spam_report.spam_reportable_type != 'Idea'
+
+      idea = spam_report.spam_reportable
+      return [] unless notify?(idea, where(idea_id: idea.id).maximum(:created_at))
+
+      initiator_id = spam_report.user_id
+      project_id = idea.project_id
+      recipient_ids(initiator_id, project_id).map do |recipient_id|
+        new(
+          recipient_id: recipient_id,
+          initiating_user_id: initiator_id,
+          spam_report: spam_report,
+          idea: idea,
+          project_id: project_id
+        )
       end
     end
   end

--- a/back/app/models/notifications/marked_as_spam.rb
+++ b/back/app/models/notifications/marked_as_spam.rb
@@ -83,32 +83,23 @@ module Notifications
       []
     end
 
-    # Moderators are told about the first report on a piece of content. Repeat
-    # reports are still recorded, but they are only mailed out again when
-    # something has moved since the last notification: a moderator dismissed the
-    # flag and the content was reported anew, or the content itself was edited.
-    # Without this, every report on the same content notifies every moderator of
-    # the project again.
+    # Notify on the first report, then only when the flag was re-opened or the
+    # content was edited since. Repeat reports are recorded, not mailed.
     def self.notify?(flaggable, last_notified_at)
       return true if last_notified_at.blank?
 
       flag_reopened_since?(flaggable, last_notified_at) || edited_since?(flaggable, last_notified_at)
     end
 
-    # `InappropriateContentFlagService#introduce_flag!` clears `deleted_at` and
-    # saves when a report re-opens a dismissed flag, so a live flag touched after
-    # the last notification was re-opened by this report. We read the flag record
-    # rather than its activity: the record is written synchronously in
-    # `SideFxSpamReportService#after_create`, while the activity is logged by a
-    # job that races the one building this notification.
+    # `introduce_flag!` clears `deleted_at` on re-open. Read the record, not its
+    # activity: the activity is logged by a job that races this one.
     def self.flag_reopened_since?(flaggable, time)
       flag = flaggable.try(:inappropriate_content_flag)
       flag.present? && flag.deleted_at.nil? && flag.updated_at > time
     end
     private_class_method :flag_reopened_since?
 
-    # `updated_at` on the flaggable is no use here: reaction and comment counters
-    # touch it, so a single like would let the next report through.
+    # Not `flaggable.updated_at`: reaction and comment counters touch it.
     def self.edited_since?(flaggable, time)
       Activity.where(item: flaggable, action: 'changed').exists?(['acted_at > ?', time])
     end

--- a/back/app/models/notifications/marked_as_spam.rb
+++ b/back/app/models/notifications/marked_as_spam.rb
@@ -82,5 +82,36 @@ module Notifications
     def self.make_notifications_on(_activity)
       []
     end
+
+    # Moderators are told about the first report on a piece of content. Repeat
+    # reports are still recorded, but they are only mailed out again when
+    # something has moved since the last notification: a moderator dismissed the
+    # flag and the content was reported anew, or the content itself was edited.
+    # Without this, every report on the same content notifies every moderator of
+    # the project again.
+    def self.notify?(flaggable, last_notified_at)
+      return true if last_notified_at.blank?
+
+      flag_reopened_since?(flaggable, last_notified_at) || edited_since?(flaggable, last_notified_at)
+    end
+
+    # `InappropriateContentFlagService#introduce_flag!` clears `deleted_at` and
+    # saves when a report re-opens a dismissed flag, so a live flag touched after
+    # the last notification was re-opened by this report. We read the flag record
+    # rather than its activity: the record is written synchronously in
+    # `SideFxSpamReportService#after_create`, while the activity is logged by a
+    # job that races the one building this notification.
+    def self.flag_reopened_since?(flaggable, time)
+      flag = flaggable.try(:inappropriate_content_flag)
+      flag.present? && flag.deleted_at.nil? && flag.updated_at > time
+    end
+    private_class_method :flag_reopened_since?
+
+    # `updated_at` on the flaggable is no use here: reaction and comment counters
+    # touch it, so a single like would let the next report through.
+    def self.edited_since?(flaggable, time)
+      Activity.where(item: flaggable, action: 'changed').exists?(['acted_at > ?', time])
+    end
+    private_class_method :edited_since?
   end
 end

--- a/back/config/initializers/rack_attack.rb
+++ b/back/config/initializers/rack_attack.rb
@@ -186,4 +186,18 @@ class Rack::Attack
       req.remote_ip
     end
   end
+
+  # Spam reports by IP. Limits are well above plausible human volume: this runs
+  # before authentication, so an office behind a single NAT is one key.
+  throttle('spam_reports/ip', limit: 10, period: 1.minute) do |req|
+    if %r{\A/web_api/v1/(ideas|comments)/[^/]+/spam_reports\z}.match?(req.path) && req.post?
+      req.remote_ip
+    end
+  end
+
+  throttle('spam_reports/ip/day', limit: 100, period: 24.hours) do |req|
+    if %r{\A/web_api/v1/(ideas|comments)/[^/]+/spam_reports\z}.match?(req.path) && req.post?
+      req.remote_ip
+    end
+  end
 end

--- a/back/spec/models/notifications/idea_marked_as_spam_spec.rb
+++ b/back/spec/models/notifications/idea_marked_as_spam_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Notifications::IdeaMarkedAsSpam do
       expect(report_spam!).to be_present
     end
 
-    it 'does not notify again when the same input is reported once more' do
+    it 'does not notify again when the input is reported once more and nothing has changed' do
       report_spam!.each(&:save!)
 
       expect(report_spam!).to be_empty

--- a/back/spec/models/notifications/idea_marked_as_spam_spec.rb
+++ b/back/spec/models/notifications/idea_marked_as_spam_spec.rb
@@ -21,6 +21,13 @@ RSpec.describe Notifications::IdeaMarkedAsSpam do
       expect(report_spam!).to be_present
     end
 
+    it 'does not notify when the report has no author' do
+      spam_report = create(:spam_report, spam_reportable: idea, user: nil)
+      activity = create(:activity, item: spam_report, action: 'created')
+
+      expect(described_class.make_notifications_on(activity)).to be_empty
+    end
+
     it 'does not notify again when the input is reported once more and nothing has changed' do
       report_spam!.each(&:save!)
 

--- a/back/spec/models/notifications/idea_marked_as_spam_spec.rb
+++ b/back/spec/models/notifications/idea_marked_as_spam_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Notifications::IdeaMarkedAsSpam do
+  describe 'make_notifications_on' do
+    let!(:admin) { create(:admin) }
+    let(:idea) { create(:idea) }
+
+    def report_spam!
+      spam_report = create(:spam_report, spam_reportable: idea)
+      activity = create(:activity, item: spam_report, action: 'created')
+      described_class.make_notifications_on(activity)
+    end
+
+    def flag_for(idea)
+      FlagInappropriateContent::InappropriateContentFlag.create!(flaggable: idea)
+    end
+
+    it 'notifies moderators of the first report' do
+      expect(report_spam!).to be_present
+    end
+
+    it 'does not notify again when the same input is reported once more' do
+      report_spam!.each(&:save!)
+
+      expect(report_spam!).to be_empty
+    end
+
+    it 'does not notify again while an untouched flag is still open' do
+      flag_for(idea).update_columns(updated_at: 1.minute.ago)
+      report_spam!.each(&:save!)
+
+      expect(report_spam!).to be_empty
+    end
+
+    it 'notifies again when the input was edited since the last notification' do
+      report_spam!.each(&:save!)
+      create(:activity, item: idea, action: 'changed', acted_at: 1.minute.from_now)
+
+      expect(report_spam!).to be_present
+    end
+
+    it 'notifies again when a dismissed flag is re-opened by the new report' do
+      report_spam!.each(&:save!)
+      flag_for(idea).update_columns(deleted_at: nil, updated_at: 1.minute.from_now)
+
+      expect(report_spam!).to be_present
+    end
+  end
+end

--- a/back/spec/requests/rack_attack_spec.rb
+++ b/back/spec/requests/rack_attack_spec.rb
@@ -577,4 +577,43 @@ describe 'Rack::Attack' do
       expect(status).to eq(200) # ok
     end
   end
+
+  describe 'spam reports' do
+    let(:headers) { { 'CONTENT_TYPE' => 'application/json', 'REMOTE_ADDR' => '1.2.3.4' } }
+    let(:params) { '{ "spam_report": { "reason_code": "other", "other_reason": "spam" } }' }
+
+    def report_spam(path)
+      post(path, params: params, headers: headers)
+    end
+
+    it 'limits spam reports on ideas from same IP to 10 in a minute' do
+      path = "/web_api/v1/ideas/#{SecureRandom.uuid}/spam_reports"
+
+      freeze_time do
+        10.times { report_spam(path) }
+        expect(status).to eq(401) # Unauthorized, but not throttled
+
+        report_spam(path)
+        expect(status).to eq(429) # Too many requests
+      end
+
+      travel_to(1.minute.from_now) do
+        report_spam(path)
+        expect(status).to eq(401) # Unauthorized
+      end
+    end
+
+    it 'counts spam reports on comments against the same limit' do
+      idea_path = "/web_api/v1/ideas/#{SecureRandom.uuid}/spam_reports"
+      comment_path = "/web_api/v1/comments/#{SecureRandom.uuid}/spam_reports"
+
+      freeze_time do
+        10.times { report_spam(idea_path) }
+        expect(status).to eq(401) # Unauthorized, but not throttled
+
+        report_spam(comment_path)
+        expect(status).to eq(429) # Too many requests
+      end
+    end
+  end
 end


### PR DESCRIPTION
Child ticket of broader parent: [TAN-8317: Idea could be posted while the active phase was a survey](https://app.notion.com/p/govocal/Idea-could-be-posted-while-the-active-phase-was-a-survey-3aa9663b7b26817c80add2de5652656d)

Every spam report notified every moderator of the project, so repeat reports on the same content multiplied — four reports meant 24 notifications.

Moderators are now notified of the first report, and again only if something has moved since: a dismissed flag was re-opened, or the content was edited. Repeat reports are still recorded, still keep the flag open, and still feed the reason shown in the moderation queue.

To bound scripted bursts, basic `Rack::Attack` throttles were also added.

Two review notes: the check reads the flag record, not its activity (the record is written synchronously, the activity by a racing job); and "edited" comes from the `changed` activity, not `updated_at`, which reaction and comment counters bump.

## Not included: unique index on reports
A partial unique index on `(user_id, spam_reportable_type, spam_reportable_id)` would be the obvious companion. I'd skip it: duplicate rows are harmless once the notifications are deduped, and production already violates it, so it needs a cross-tenant cleanup task first.

# Changelog
## Technical
- [TAN-8421] Only notify moderators of repeat spam reports when something changed + rate limit spam reports.
