### PR TITLE
[TAN-8417] Flaky E2E Fix: landing_page.cy.ts — a11y-valid tabs while loading

### DIFF
--- a/front/app/components/ProjectAndFolderCards/ProjectAndFolderCardsInner.tsx
+++ b/front/app/components/ProjectAndFolderCards/ProjectAndFolderCardsInner.tsx
@@ -165,7 +165,11 @@ const ProjectAndFolderCardsInner = ({
         />
       )}
 
-      {!loadingInitial && hasPublications && (
+      {/* Rendered under the same condition as the Topbar tabs (the list is
+          empty while loading), so the tab panels the tabs' aria-controls
+          point to always exist — axe flags aria-controls referencing a missing
+          id as an aria-valid-attr-value violation during the load window. */}
+      {!noAdminPublicationsAtAll && (
         <PublicationStatusTabs
           currentTab={currentTab}
           availableTabs={availableTabs}


### PR DESCRIPTION
# Changelog

## Fixed
- Fixed an accessibility issue on the homepage: while the projects section was still loading, the project tabs referenced content panels that didn't exist yet, which is invalid for screen readers (ARIA). The panels now always exist as soon as the tabs do.

# Context

Generated by Claude via the `fix-flaky-e2e` flow.

**Root cause:** the tabs render once the status-counts query resolves, but the panels only rendered after the separate publications-list query finished — in that window each tab's `aria-controls` pointed at a missing id, an `aria-valid-attr-value` violation that axe (via `cy.checkA11y()` in `landing_page.cy.ts`) intermittently caught on slow CI days. Verified empirically against axe-core 4.10.2.

**Why this fixes rather than suppresses:** the violation was real — the fix closes the race by rendering the panels under the same condition as the tabs (empty list while loading), so the ARIA id contract can't break. The e2e assertion is untouched.

**Stability evidence:** [pipeline 346314](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346314) — 3 independent nodes, 12/12 tests green (both homepage a11y checks included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)