### PR TITLE
[TAN-8419] Fix custom page e2e test after pages-menu tab swap

### DIFF
--- a/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
+++ b/front/cypress/e2e/admin/pages_and_menu/create_update_and_view_custom_page.cy.ts
@@ -3,7 +3,7 @@ import { randomString } from '../../../support/commands';
 describe('Admin: can', () => {
   beforeEach(() => {
     cy.setAdminLoginCookie();
-    cy.visit('/admin/pages-menu/');
+    cy.visit('/admin/pages-menu/pages');
   });
 
   describe('create', () => {
@@ -19,7 +19,7 @@ describe('Admin: can', () => {
     it('and view a custom page successfully', () => {
       cy.intercept('POST', '**/static_pages').as('createCustomPage');
 
-      cy.visit('/admin/pages-menu/');
+      cy.visit('/admin/pages-menu/pages');
 
       // go to custom page creation form
       cy.get('#create-custom-page').click();


### PR DESCRIPTION
# Changelog

## Technical
- Fixed the `create_update_and_view_custom_page` E2E test, which failed every nightly run since 2026-08-05: TAN-7949 intentionally changed the `/admin/pages-menu/` default tab from Pages to Menu, so the test no longer landed on the tab containing the "create custom page" button. The test now visits `/admin/pages-menu/pages` explicitly, making it independent of the default-tab choice.

# Context

Generated by Claude via the `fix-flaky-e2e` flow (detected as an emerging regression, not a flake — 57 straight passes, then 3 consecutive failures starting with the first nightly after the TAN-7949 merges).

**Root cause:** commit `44d4e11` ("Swap tabs") changed the index redirect from `/pages` to `/menu`; `#create-custom-page` lives on the Pages tab.

**Stability evidence:** [pipeline 346321](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346321) — 3 nodes, 12/12 tests green.

@IvaKop authored the tab swap — please confirm the test change matches the intended new default-tab behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)