### PR TITLE
[TAN-8228] Withdraw SMS consent for the use case when the recipient opts out

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/sms/events_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/hooks/sms/events_controller.rb
@@ -18,6 +18,10 @@ module EmailCampaigns
       delivery = EmailCampaigns::Sms::Delivery.find_by(message_sid: parsed[:message_sid])
       return head :not_found if delivery.nil?
 
+      if parsed[:opted_out]
+        EmailCampaigns::Sms::UseCaseConsentService.new.withdraw!(delivery.user, delivery.campaign_use_case)
+      end
+
       # If an unknown status is returned we log it for investigation but still
       # return 200 so the provider stops retrying.
       if parsed[:status].nil?

--- a/back/engines/free/email_campaigns/app/models/email_campaigns/sms/delivery.rb
+++ b/back/engines/free/email_campaigns/app/models/email_campaigns/sms/delivery.rb
@@ -44,6 +44,10 @@ module EmailCampaigns
       # The campaign that triggered this SMS, when sent as part of one.
       belongs_to :campaign, class_name: 'EmailCampaigns::Campaign', optional: true
 
+      def campaign_use_case
+        campaign&.class&.sms_use_case
+      end
+
       # Per-status counts (+ total) for a campaign's SMS deliveries.
       def self.status_counts(campaign_id)
         counts = where(campaign_id: campaign_id).group(:status).count

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/sms/provider_error.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/sms/provider_error.rb
@@ -3,6 +3,9 @@
 module EmailCampaigns
   module Sms
     class ProviderError < Error
+      # The recipient replied STOP to the messaging service this use case sends through.
+      class RecipientOptedOut < ProviderError; end
+
       # HTTP 429 — we are being rate limited.
       class RateLimit < ProviderError; end
 

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/sms/providers/base.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/sms/providers/base.rb
@@ -22,9 +22,11 @@ module EmailCampaigns
 
         # Normalises a provider callback into our own vocabulary.
         # @param params [ActionController::Parameters] the callback params
-        # @return [Hash{Symbol => String, nil}] { message_sid:, status:, raw_status: }
-        #   where status is one of Delivery::STATUSES (nil if the event is unmapped)
-        #   and raw_status is the provider's original status string (for diagnostics)
+        # @return [Hash] { message_sid:, status:, raw_status:, opted_out: }
+        #   where status is one of Delivery::STATUSES (nil if the event is unmapped),
+        #   raw_status is the provider's original status string (for diagnostics) and
+        #   opted_out says whether the message was refused because the recipient
+        #   replied STOP
         def parse_callback(params)
           raise NotImplementedError
         end

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/sms/providers/twilio.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/sms/providers/twilio.rb
@@ -16,6 +16,10 @@ module EmailCampaigns
           'failed' => 'failed'
         }.freeze
 
+        # Returned when the number replied STOP to the messaging service we're sending on.
+        # https://www.twilio.com/docs/api/errors/21610
+        OPTED_OUT_ERROR_CODE = 21_610
+
         MESSAGING_SERVICE_SID_SETTINGS = {
           UseCase::MANUAL_CAMPAIGNS => 'twilio_manual_campaigns_messaging_service_sid',
           UseCase::CONFIRMATION_CODES => 'twilio_confirmation_codes_messaging_service_sid'
@@ -54,16 +58,20 @@ module EmailCampaigns
             status: STATUS_MAPPING[params[:MessageStatus]],
             # The provider's original status string, kept for diagnostics when it
             # maps to nil (a status we don't track).
-            raw_status: params[:MessageStatus]
+            raw_status: params[:MessageStatus],
+            opted_out: params[:ErrorCode].to_i == OPTED_OUT_ERROR_CODE
           }
         end
 
         private
 
-        # Maps a Twilio REST error onto our provider error hierarchy by HTTP
-        # status: 429 -> RateLimit, 503 -> ServiceUnavailable, other 5xx ->
-        # ServerError (all retryable), anything else -> the permanent ProviderError.
+        # Maps a Twilio REST error onto our provider error hierarchy. An opt-out is
+        # recognised by its Twilio error code; everything else goes by HTTP status:
+        # 429 -> RateLimit, 503 -> ServiceUnavailable, other 5xx -> ServerError (all
+        # retryable), anything else -> the permanent ProviderError.
         def error_for(rest_error)
+          return ProviderError::RecipientOptedOut.new(rest_error.message) if rest_error.code == OPTED_OUT_ERROR_CODE
+
           error_class_for(rest_error.status_code).new(rest_error.message)
         end
 

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/sms/send_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/sms/send_service.rb
@@ -35,6 +35,10 @@ module EmailCampaigns
       rescue *ProviderError::RETRYABLE_ERRORS
         # Transient failure — leave the delivery pending so Sms::SendJob can retry it.
         raise
+      rescue ProviderError::RecipientOptedOut => e
+        UseCaseConsentService.new.withdraw!(delivery.user, use_case)
+        delivery.update!(status: 'failed', error_message: e.message)
+        raise
       rescue ProviderError => e
         # The provider took the message and rejected/failed it.
         delivery.update!(status: 'failed', error_message: e.message)

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/sms/use_case_consent_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/sms/use_case_consent_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module EmailCampaigns
+  module Sms
+    # Consent across every campaign on an SMS use case, where ConsentService records it
+    # for a single campaign.
+    class UseCaseConsentService
+      # A STOP silences the messaging service, so every campaign on that use case loses consent.
+      def withdraw!(user, use_case)
+        return if user.nil? || use_case.nil?
+
+        consentable_campaign_classes_for(use_case).each do |campaign_class|
+          consent = ConsentService.new.record!(user, campaign_class, consented: false)
+          SideFxConsentService.new.after_update(consent, user)
+        end
+      end
+
+      private
+
+      def consentable_campaign_classes_for(use_case)
+        DeliveryService.new.campaign_classes.select do |campaign_class|
+          campaign_class < Campaigns::BaseSms &&
+            campaign_class.sms_use_case == use_case &&
+            campaign_class.include?(Consentable)
+        end
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/acceptance/sms_events_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/sms_events_spec.rb
@@ -67,6 +67,50 @@ resource 'SMS Events' do
       end
     end
 
+    context 'when the callback reports the recipient opted out' do
+      # The campaigns to withdraw consent from are only registered when SMS is on.
+      include_context 'with sms feature enabled'
+
+      let(:user) { create(:user, :with_confirmed_phone) }
+      let(:campaign) { create(:sms_manual_campaign) }
+      let!(:delivery) do
+        EmailCampaigns::Sms::Delivery.create!(
+          body: 'hi', status: 'sent', message_sid: 'SM_123', user: user, campaign: campaign
+        )
+      end
+      let(:message_status) { 'undelivered' }
+      let(:callback_params) { { MessageSid: message_sid, MessageStatus: message_status, ErrorCode: '21610' } }
+
+      example 'withdraws the recipient consent for manual SMS campaigns' do
+        create(:consent, :sms_manual, user: user, consented: true)
+
+        do_request(callback_params)
+
+        expect(response_status).to eq 200
+        consent = EmailCampaigns::Consent.find_by(
+          user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name
+        )
+        expect(consent.consented).to be false
+        expect(delivery.reload.status).to eq 'undelivered'
+      end
+
+      context 'when the delivery belongs to a confirmation code campaign' do
+        let(:campaign) { EmailCampaigns::Campaigns::PhoneConfirmation.create! }
+
+        example 'leaves the manual SMS campaign consent alone' do
+          create(:consent, :sms_manual, user: user, consented: true)
+
+          do_request(callback_params)
+
+          expect(response_status).to eq 200
+          consent = EmailCampaigns::Consent.find_by(
+            user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name
+          )
+          expect(consent.consented).to be true
+        end
+      end
+    end
+
     context 'when the provider status is legitimate but unmapped (e.g. canceled)' do
       let(:message_status) { 'canceled' }
 

--- a/back/engines/free/email_campaigns/spec/models/email_campaigns/sms/delivery_spec.rb
+++ b/back/engines/free/email_campaigns/spec/models/email_campaigns/sms/delivery_spec.rb
@@ -23,6 +23,20 @@ RSpec.describe EmailCampaigns::Sms::Delivery do
     end
   end
 
+  describe '#campaign_use_case' do
+    it 'reads the use case off the campaign that triggered the send' do
+      delivery = described_class.create!(body: 'hi', status: 'sent', campaign: create(:sms_manual_campaign))
+
+      expect(delivery.campaign_use_case).to eq(EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS)
+    end
+
+    it 'is nil for an unlinked preview send' do
+      delivery = described_class.create!(body: 'hi', status: 'sent')
+
+      expect(delivery.campaign_use_case).to be_nil
+    end
+  end
+
   describe '#advance_status!' do
     subject(:delivery) { described_class.create!(body: 'hi', status: 'sent') }
 

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/sms/send_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/sms/send_service_spec.rb
@@ -152,6 +152,45 @@ RSpec.describe EmailCampaigns::Sms::SendService do
       expect(delivery.reload).to have_attributes(status: 'delivered', error_message: nil)
     end
 
+    context 'when the recipient opted out at the provider' do
+      let(:user) { create(:user, :with_confirmed_phone) }
+      let(:delivery) { EmailCampaigns::Sms::Delivery.create!(body: 'hi', status: 'pending', user: user) }
+
+      before do
+        allow(provider).to receive(:send).and_raise(EmailCampaigns::Sms::ProviderError::RecipientOptedOut, 'unsubscribed')
+      end
+
+      it 'withdraws the manual campaigns consent and marks the delivery failed' do
+        create(:consent, :sms_manual, user: user, consented: true)
+
+        expect { described_class.new.deliver(delivery, to: phone, use_case: use_case) }
+          .to raise_error(EmailCampaigns::Sms::ProviderError::RecipientOptedOut)
+
+        consent = EmailCampaigns::Consent.find_by(user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name)
+        expect(consent.consented).to be false
+        expect(delivery.reload.status).to eq('failed')
+      end
+
+      it 'records a withdrawn consent for a recipient that never had one' do
+        expect { described_class.new.deliver(delivery, to: phone, use_case: use_case) }
+          .to raise_error(EmailCampaigns::Sms::ProviderError::RecipientOptedOut)
+
+        consent = EmailCampaigns::Consent.find_by(user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name)
+        expect(consent.consented).to be false
+      end
+
+      it 'leaves the manual campaigns consent alone when the opt-out is on another use case' do
+        create(:consent, :sms_manual, user: user, consented: true)
+
+        expect do
+          described_class.new.deliver(delivery, to: phone, use_case: EmailCampaigns::Sms::UseCase::CONFIRMATION_CODES)
+        end.to raise_error(EmailCampaigns::Sms::ProviderError::RecipientOptedOut)
+
+        consent = EmailCampaigns::Consent.find_by(user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name)
+        expect(consent.consented).to be true
+      end
+    end
+
     context 'with an allowed-country list configured' do
       # +14155552671 is a US number.
       it 'sends when the destination country is on the allow-list' do

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/sms/use_case_consent_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/sms/use_case_consent_service_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe EmailCampaigns::Sms::UseCaseConsentService do
+  include_context 'with sms feature enabled'
+
+  let(:user) { create(:user, :with_confirmed_phone) }
+
+  def sms_manual_consent
+    EmailCampaigns::Consent.find_by(user: user, campaign_type: EmailCampaigns::Campaigns::SmsManual.name)
+  end
+
+  describe '#withdraw!' do
+    it 'withdraws consent for every consentable campaign on the use case' do
+      create(:consent, :sms_manual, user: user, consented: true)
+
+      described_class.new.withdraw!(user, EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS)
+
+      expect(sms_manual_consent.consented).to be false
+    end
+
+    it 'records a withdrawn consent for a user that never had one' do
+      described_class.new.withdraw!(user, EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS)
+
+      expect(sms_manual_consent.consented).to be false
+    end
+
+    it 'leaves campaigns on another use case untouched' do
+      create(:consent, :sms_manual, user: user, consented: true)
+
+      described_class.new.withdraw!(user, EmailCampaigns::Sms::UseCase::CONFIRMATION_CODES)
+
+      expect(sms_manual_consent.consented).to be true
+    end
+
+    it 'leaves email campaigns untouched' do
+      email_consent = create(:consent, user: user, consented: true)
+
+      described_class.new.withdraw!(user, EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS)
+
+      expect(email_consent.reload.consented).to be true
+    end
+
+    it 'logs the withdrawal' do
+      create(:consent, :sms_manual, user: user, consented: true)
+
+      expect { described_class.new.withdraw!(user, EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS) }
+        .to have_enqueued_job(LogActivityJob)
+    end
+
+    it 'does nothing without a user or a use case' do
+      expect { described_class.new.withdraw!(nil, EmailCampaigns::Sms::UseCase::MANUAL_CAMPAIGNS) }
+        .not_to change(EmailCampaigns::Consent, :count)
+      expect { described_class.new.withdraw!(user, nil) }.not_to change(EmailCampaigns::Consent, :count)
+    end
+  end
+end


### PR DESCRIPTION
# Changelog

## Changed
- When Twilio blocks a message because the recipient previously replied STOP, we now unsubscribe them from every campaign in that stream.