### PR TITLE
[TAN-8420] Flaky E2E Fix: community_monitor_survey.cy.ts — wait for enabled buttons

### DIFF
--- a/front/cypress/e2e/community_monitor/community_monitor_survey.cy.ts
+++ b/front/cypress/e2e/community_monitor/community_monitor_survey.cy.ts
@@ -1,6 +1,16 @@
 import { ICustomFieldResponse } from '../../../app/api/custom_fields/types';
 import { randomString } from '../../support/commands';
 
+// The next/submit buttons stay disabled until the page's last question has
+// been scrolled into view (IntersectionObserver in PageControlButtons), so
+// scroll there and wait for the enabled state instead of force-clicking —
+// a force-click on the still-disabled button silently does nothing.
+const clickPageButton = (dataCy: 'e2e-next-page' | 'e2e-submit-form') => {
+  cy.get('[data-question-id]').last().scrollIntoView();
+  cy.dataCy(dataCy).should('be.visible').should('not.have.class', 'disabled');
+  cy.dataCy(dataCy).click();
+};
+
 describe('Submit community monitor survey', () => {
   let communityMonitorProjectId: string;
   let communityMonitorPhaseId: string;
@@ -42,18 +52,13 @@ describe('Submit community monitor survey', () => {
     // Select first question
     cy.get('#place_to_live-linear-scale-option-1').click();
 
-    cy.dataCy('e2e-next-page').should('be.visible').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-next-page');
     cy.contains('Service delivery').should('be.visible');
-    cy.dataCy('e2e-next-page').should('be.visible').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-next-page');
     cy.contains('Governance and trust').should('be.visible');
-    cy.wait(4000);
 
     // save the form
-    cy.dataCy('e2e-submit-form').should('be.visible');
-    cy.dataCy('e2e-submit-form').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-submit-form');
 
     // Confirm submissions was successful
     cy.dataCy('e2e-after-submission').should('exist');
@@ -74,18 +79,13 @@ describe('Submit community monitor survey', () => {
     cy.get('#place_to_live-linear-scale-option-1').click();
 
     // Go to last page
-    cy.dataCy('e2e-next-page').should('be.visible').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-next-page');
     cy.contains('Service delivery').should('be.visible');
-    cy.dataCy('e2e-next-page').should('be.visible').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-next-page');
     cy.contains('Governance and trust').should('be.visible');
-    cy.wait(4000);
 
     // save the form
-    cy.dataCy('e2e-submit-form').should('be.visible');
-    cy.dataCy('e2e-submit-form').click({ force: true });
-    cy.wait(2000);
+    clickPageButton('e2e-submit-form');
 
     // Confirm submissions was successful
     cy.dataCy('e2e-after-submission').should('exist');


### PR DESCRIPTION

## Technical
- Fixed the flaky community monitor survey E2E tests: the survey's next/submit buttons intentionally stay disabled until the page's last question has been scrolled into view, but the tests force-clicked them — which silently does nothing when the button is still disabled. The tests now scroll to the last question and wait for the button to enable before clicking (and the redundant fixed waits are gone).

# Context

Generated by Claude via the `fix-flaky-e2e` flow.

**Root cause:** `PageControlButtons` disables next/submit until an IntersectionObserver sees the page's last question (deliberate UX). The community monitor's first page is taller than the CI viewport; `{force: true}` bypassed the actionability check that would have waited, so when the observer hadn't fired yet the click landed on a `.disabled` button (visible in the CI failure screenshot) and the page never advanced.

**Why this fixes rather than suppresses:** the fix makes the test perform the same act a user must (scroll through the questions) and replaces force-clicks with an assertion-based wait on the enabled state — the product behavior is untouched and now actually exercised.

**Stability evidence:** [pipeline 346343](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346343) — 3 nodes, 21/21 tests green across the whole spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)