### PR TITLE
TAN-8388 MitID / nemlogin issue

### DIFF
--- a/back/app/services/permissions/base_permissions_service.rb
+++ b/back/app/services/permissions/base_permissions_service.rb
@@ -50,7 +50,6 @@ module Permissions
       return if permission.permitted_by == 'everyone'
       return USER_DENIED_REASONS[:user_not_signed_in] unless user
       return USER_DENIED_REASONS[:user_blocked] if user.blocked?
-      return USER_DENIED_REASONS[:user_missing_requirements] if user.confirmation_required?
       return USER_DENIED_REASONS[:user_not_active] unless user.active?
       return if UserRoleService.new.can_moderate? permission, user
       return USER_DENIED_REASONS[:user_not_permitted] if permission.permitted_by == 'admins_moderators'

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -384,6 +384,7 @@ resource 'Permissions' do
             confirmation_required: false,
             verified: true
           )
+          @user.identities << create(:franceconnect_identity, user: @user)
           do_request
           assert_status 200
           expect(response_data[:attributes][:permitted]).to be true
@@ -397,6 +398,7 @@ resource 'Permissions' do
             confirmation_required: true,
             verified: true
           )
+          @user.identities << create(:franceconnect_identity, user: @user)
           do_request
           assert_status 200
           expect(response_data[:attributes][:permitted]).to be true

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -335,7 +335,7 @@ resource 'Permissions' do
           assert_status 200
           expect(response_data[:attributes]).to eq({
             permitted: false,
-            disabled_reason: 'user_missing_requirements',
+            disabled_reason: 'user_not_active',
             requirements: {
               authentication: {
                 permitted_by: 'users',

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -351,6 +351,58 @@ resource 'Permissions' do
           })
         end
       end
+
+      context "'users' permission with verification enabled but email disabled" do
+        before do
+          @permission = @phase.permissions.first
+          @permission.update!(
+            permitted_by: 'users',
+            require_verification: true,
+            require_confirmed_email: false,
+          )
+        end
+
+        let(:action) { @permission.action }
+
+        example 'Blocks participation if user has confirmed email but is not verified' do
+          @user.update!(
+            email: 'test@user.com', 
+            email_confirmed_at: Time.current,
+            confirmation_required: false,
+            verified: false
+          )
+          do_request
+          assert_status 200
+          expect(response_data[:attributes][:permitted]).to be false
+          expect(response_data[:attributes][:disabled_reason]).to eq 'user_missing_requirements'
+        end
+
+        example 'Allows participation is user has both email and is verified' do
+          @user.update!(
+            email: 'test@user.com', 
+            email_confirmed_at: Time.current,
+            confirmation_required: false,
+            verified: true
+          )
+          do_request
+          assert_status 200
+          expect(response_data[:attributes][:permitted]).to be true
+          expect(response_data[:attributes][:disabled_reason]).to be_nil
+        end
+
+        example 'Allows participation if user has no email but is verified' do
+          @user.update!(
+            email: nil,
+            email_confirmed_at: nil,
+            confirmation_required: true,
+            verified: true
+          )
+          do_request
+          assert_status 200
+          expect(response_data[:attributes][:permitted]).to be true
+          expect(response_data[:attributes][:disabled_reason]).to be_nil
+        end
+      end
     end
 
     get 'web_api/v1/permissions/:action/requirements' do

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -358,7 +358,7 @@ resource 'Permissions' do
           @permission.update!(
             permitted_by: 'users',
             require_verification: true,
-            require_confirmed_email: false,
+            require_confirmed_email: false
           )
         end
 
@@ -366,7 +366,7 @@ resource 'Permissions' do
 
         example 'Blocks participation if user has confirmed email but is not verified' do
           @user.update!(
-            email: 'test@user.com', 
+            email: 'test@user.com',
             email_confirmed_at: Time.current,
             confirmation_required: false,
             verified: false
@@ -379,7 +379,7 @@ resource 'Permissions' do
 
         example 'Allows participation is user has both email and is verified' do
           @user.update!(
-            email: 'test@user.com', 
+            email: 'test@user.com',
             email_confirmed_at: Time.current,
             confirmation_required: false,
             verified: true

--- a/back/spec/services/permissions/base_permissions_service_spec.rb
+++ b/back/spec/services/permissions/base_permissions_service_spec.rb
@@ -312,7 +312,7 @@ describe Permissions::BasePermissionsService do
         end
       end
 
-      context 'when verification is required' do
+      context 'when email and verification are required' do
         let(:permission) { create(:permission, permitted_by: 'users', require_verification: true) }
 
         context 'without groups' do
@@ -417,6 +417,47 @@ describe Permissions::BasePermissionsService do
 
             it { expect(denied_reason).to eq 'user_not_active' }
           end
+        end
+      end
+
+      context 'when verification is required but email is not' do
+        let(:permission) do
+          create(
+            :permission, 
+            permitted_by: 'users', 
+            require_verification: true, 
+            require_confirmed_email: false
+          )
+        end
+
+        context 'when not signed in' do
+          let(:user) { nil }
+
+          it { expect(denied_reason).to eq 'user_not_signed_in' }
+        end
+
+        context 'when verified resident' do
+          before { user.update!(verified: true) }
+
+          it { expect(denied_reason).to be_nil }
+        end
+
+        context 'when unverified resident' do
+          before { user.update!(verified: false) }
+
+          it { expect(denied_reason).to eq 'user_not_verified' }
+        end
+
+        context 'when verified resident without confirmed email' do
+          before do 
+            user.update!(
+              verified: true, 
+              email_confirmed_at: nil, 
+              confirmation_required: true
+            )
+          end
+
+          it { expect(denied_reason).to eq nil }
         end
       end
     end

--- a/back/spec/services/permissions/base_permissions_service_spec.rb
+++ b/back/spec/services/permissions/base_permissions_service_spec.rb
@@ -437,7 +437,10 @@ describe Permissions::BasePermissionsService do
         end
 
         context 'when verified resident' do
-          before { user.update!(verified: true) }
+          before do 
+            user.update!(verified: true)
+            user.identities << create(:franceconnect_identity, user: user)
+          end
 
           it { expect(denied_reason).to be_nil }
         end
@@ -455,6 +458,7 @@ describe Permissions::BasePermissionsService do
               email_confirmed_at: nil, 
               confirmation_required: true
             )
+            user.identities << create(:franceconnect_identity, user: user)
           end
 
           it { expect(denied_reason).to eq nil }

--- a/back/spec/services/permissions/base_permissions_service_spec.rb
+++ b/back/spec/services/permissions/base_permissions_service_spec.rb
@@ -126,26 +126,15 @@ describe Permissions::BasePermissionsService do
         end
       end
 
-      context 'when fully registered unconfirmed resident' do
+      context 'when unconfirmed resident' do
         before do
           user.update!(confirmation_required: true, email_confirmed_at: nil)
         end
 
-        it { expect(denied_reason).to eq 'user_missing_requirements' }
+        it { expect(denied_reason).to eq 'user_not_active' }
       end
 
-      context 'when fully registered confirmed resident' do
-        it { expect(denied_reason).to be_nil }
-      end
-
-      context 'when fully registered sso user' do
-        before do
-          facebook_identity = create(:facebook_identity)
-          user.identities << facebook_identity
-          user.update!(password_digest: nil)
-          user.save!
-        end
-
+      context 'when confirmed resident' do
         it { expect(denied_reason).to be_nil }
       end
 
@@ -161,7 +150,7 @@ describe Permissions::BasePermissionsService do
           user.update!(roles: [{ type: 'admin' }])
         end
 
-        it { expect(denied_reason).to eq 'user_missing_requirements' }
+        it { expect(denied_reason).to eq 'user_not_active' }
       end
 
       context 'when confirmed admin' do
@@ -189,13 +178,13 @@ describe Permissions::BasePermissionsService do
         context 'when light unconfirmed resident who is group member' do
           let(:user) { create(:unconfirmed_user, manual_groups: [groups.last]) }
 
-          it { expect(denied_reason).to eq 'user_missing_requirements' }
+          it { expect(denied_reason).to eq 'user_not_active' }
         end
 
         context 'when light unconfirmed resident who is not a group member' do
           let(:user) { create(:unconfirmed_user) }
 
-          it { expect(denied_reason).to eq 'user_missing_requirements' }
+          it { expect(denied_reason).to eq 'user_not_active' }
         end
 
         context 'when fully registered resident who is not a group member' do
@@ -375,13 +364,13 @@ describe Permissions::BasePermissionsService do
           context 'when unconfirmed resident who is group member' do
             let(:user) { create(:unconfirmed_user, manual_groups: [groups.last]) }
 
-            it { expect(denied_reason).to eq 'user_missing_requirements' }
+            it { expect(denied_reason).to eq 'user_not_active' }
           end
 
           context 'when unconfirmed resident who is not a group member' do
             let(:user) { create(:unconfirmed_user) }
 
-            it { expect(denied_reason).to eq 'user_missing_requirements' }
+            it { expect(denied_reason).to eq 'user_not_active' }
           end
 
           context 'when fully registered resident who is not a group member' do
@@ -507,12 +496,12 @@ describe Permissions::BasePermissionsService do
         it { expect(denied_reason).to eq 'user_not_permitted' }
       end
 
-      context 'when fully registered unconfirmed resident' do
+      context 'when unconfirmed resident' do
         before do
           user.update!(confirmation_required: true, email_confirmed_at: nil)
         end
 
-        it { expect(denied_reason).to eq 'user_missing_requirements' }
+        it { expect(denied_reason).to eq 'user_not_active' }
       end
 
       context 'when unconfirmed admin' do
@@ -524,7 +513,7 @@ describe Permissions::BasePermissionsService do
           )
         end
 
-        it { expect(denied_reason).to eq 'user_missing_requirements' }
+        it { expect(denied_reason).to eq 'user_not_active' }
       end
 
       context 'when confirmed admin' do

--- a/back/spec/services/permissions/base_permissions_service_spec.rb
+++ b/back/spec/services/permissions/base_permissions_service_spec.rb
@@ -412,9 +412,9 @@ describe Permissions::BasePermissionsService do
       context 'when verification is required but email is not' do
         let(:permission) do
           create(
-            :permission, 
-            permitted_by: 'users', 
-            require_verification: true, 
+            :permission,
+            permitted_by: 'users',
+            require_verification: true,
             require_confirmed_email: false
           )
         end
@@ -426,7 +426,7 @@ describe Permissions::BasePermissionsService do
         end
 
         context 'when verified resident' do
-          before do 
+          before do
             user.update!(verified: true)
             user.identities << create(:franceconnect_identity, user: user)
           end
@@ -441,16 +441,16 @@ describe Permissions::BasePermissionsService do
         end
 
         context 'when verified resident without confirmed email' do
-          before do 
+          before do
             user.update!(
-              verified: true, 
-              email_confirmed_at: nil, 
+              verified: true,
+              email_confirmed_at: nil,
               confirmation_required: true
             )
             user.identities << create(:franceconnect_identity, user: user)
           end
 
-          it { expect(denied_reason).to eq nil }
+          it { expect(denied_reason).to be_nil }
         end
       end
     end


### PR DESCRIPTION
# Changelog
## FIxed
- People voting on proposal with verification enabled but no email required were being rejected because the `base_permissions_service` was saying they weren't allowed to participate when if fact they were. The reason was a check in the service that checked if the user had a confirmed email regardless of whether confirmed email was required by the permission. Now this check is removed and instead the `user_requirements_service` checks the email requirement only if it's actually required by the permission.