### PR TITLE
Fix flaky e2e project_page_voting_budgeting test

### DIFF
--- a/front/cypress/e2e/project_page_voting_budgeting.cy.ts
+++ b/front/cypress/e2e/project_page_voting_budgeting.cy.ts
@@ -120,12 +120,11 @@ describe('Budgeting project', () => {
 
   it('can submit the budget', () => {
     cy.dockProjectCtaBar();
-    cy.get('#e2e-voting-submit-button').should('be.visible');
-    cy.wait(4000);
-    cy.get('#e2e-voting-submit-button').find('button').click({ force: true });
+    cy.get('#e2e-voting-submit-button').should('be.visible').click({ force: true });
     cy.wait(1000);
 
     cy.contains('Budget submitted');
+    cy.scrollTo('bottom');
     cy.contains('You have participated in this project');
 
     cy.get('#e2e-ideas-container')


### PR DESCRIPTION
# Changelog
## Technical
- Fix flaky test due to 2 problems:  
1. after checking that the voting button was visible, there was a scroll on the page around the cy.wait(4000) making the btn disappear. Fixed by chaining visibility check and btn click
2.  the sentence 'You have participated in this project' wasn't visible because of a scroll on the page. Fixed by scrolling back on the bottom of the page

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
