### PR TITLE
Flaky E2E Fix: permitted_by_users.cy.ts — sync reg-flow to idea-form transition

### DIFF
--- a/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
@@ -109,15 +109,6 @@ describe('Ideation permitted by: users', () => {
 
       cy.get('#e2e-success-continue-button').click();
 
-      // 'Continue' fires the success action, which resolves the auth-user stream,
-      // fetches the project + phase sequentially, then navigates to
-      // /projects/<slug>/ideas/new; the form schema is only fetched after that.
-      // Under CI contention this whole chain has been observed to take 20-40s, so
-      // synchronise on the navigation and the schema fetch with explicit, generous
-      // ceilings rather than the default 15s command timeout (which otherwise
-      // flakes: either "to include '/ideas/new'" or "never found #title_multiloc").
-      // These are assertion/response waits, so they still resolve as soon as the
-      // app is ready — the larger ceiling only applies when the app is genuinely slow.
       cy.url({ timeout: 40000 }).should('include', '/ideas/new');
       cy.wait('@ideaFormFields', {
         requestTimeout: 40000,

--- a/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
@@ -99,7 +99,22 @@ describe('Ideation permitted by: users', () => {
 
       // Click submit and 'continue'
       cy.get('#e2e-signup-custom-fields-submit-btn').click();
+
+      // The idea form's fields (incl. #title_multiloc) are rendered from this
+      // request. Register the intercept before continuing so we can wait for the
+      // reg-flow -> idea-form transition to fully settle before interacting.
+      cy.intercept('GET', /\/custom_fields\?.*public_fields=true/).as(
+        'ideaFormFields'
+      );
+
       cy.get('#e2e-success-continue-button').click();
+
+      // 'Continue' redirects to /projects/<slug>/ideas/new and then loads the
+      // form schema. Under CI load both steps can be slow, so synchronise on the
+      // navigation and the schema fetch instead of racing a single DOM retry for
+      // #title_multiloc (which otherwise flakes: "never found #title_multiloc").
+      cy.url().should('include', '/ideas/new');
+      cy.wait('@ideaFormFields');
 
       const title = randomString(11);
       const body = randomString(40);

--- a/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
@@ -109,12 +109,20 @@ describe('Ideation permitted by: users', () => {
 
       cy.get('#e2e-success-continue-button').click();
 
-      // 'Continue' redirects to /projects/<slug>/ideas/new and then loads the
-      // form schema. Under CI load both steps can be slow, so synchronise on the
-      // navigation and the schema fetch instead of racing a single DOM retry for
-      // #title_multiloc (which otherwise flakes: "never found #title_multiloc").
-      cy.url().should('include', '/ideas/new');
-      cy.wait('@ideaFormFields');
+      // 'Continue' fires the success action, which resolves the auth-user stream,
+      // fetches the project + phase sequentially, then navigates to
+      // /projects/<slug>/ideas/new; the form schema is only fetched after that.
+      // Under CI contention this whole chain has been observed to take 20-40s, so
+      // synchronise on the navigation and the schema fetch with explicit, generous
+      // ceilings rather than the default 15s command timeout (which otherwise
+      // flakes: either "to include '/ideas/new'" or "never found #title_multiloc").
+      // These are assertion/response waits, so they still resolve as soon as the
+      // app is ready — the larger ceiling only applies when the app is genuinely slow.
+      cy.url({ timeout: 40000 }).should('include', '/ideas/new');
+      cy.wait('@ideaFormFields', {
+        requestTimeout: 40000,
+        responseTimeout: 40000,
+      });
 
       const title = randomString(11);
       const body = randomString(40);

--- a/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/permitted_by_users.cy.ts
@@ -100,9 +100,6 @@ describe('Ideation permitted by: users', () => {
       // Click submit and 'continue'
       cy.get('#e2e-signup-custom-fields-submit-btn').click();
 
-      // The idea form's fields (incl. #title_multiloc) are rendered from this
-      // request. Register the intercept before continuing so we can wait for the
-      // reg-flow -> idea-form transition to fully settle before interacting.
       cy.intercept('GET', /\/custom_fields\?.*public_fields=true/).as(
         'ideaFormFields'
       );


### PR DESCRIPTION
Generated by Claude

**Spec:** `cypress/e2e/ideation_permissions/permitted_by_users.cy.ts`

### Symptom
The two `In reg flow` tests intermittently failed. Two signatures, same root cause:

```
Timed out retrying after 15000ms: Expected to find element: `#title_multiloc`, but never found it.
Timed out retrying after 15000ms: expected 'http://…/projects/<slug>' to include '/ideas/new'
```

### Root cause
In the reg flow, clicking **Continue** fires the auth success action, which resolves
the auth-user stream, fetches the project + phase sequentially, then navigates to
`/projects/<slug>/ideas/new`; only then is the idea form's schema fetched from
`GET /projects/{id}/custom_fields?public_fields=true` (that response renders
`#title_multiloc`).

The test went straight from Continue into `fillOutTitleAndBody`, with no
synchronization on that transition — it relied solely on the single 15s
`defaultCommandTimeout` retry. Under CI resource contention the whole chain runs
20–40s+, so it overran the window: sometimes the redirect hadn't happened yet
(`to include '/ideas/new'`), sometimes the form schema hadn't loaded
(`never found #title_multiloc`). A CI screenshot confirmed the mechanism — on
`/ideas/new` with the `custom_fields` request still pending and an empty form.

### Fix (2 commits)
1. Synchronize on the transition: register a `cy.intercept` for the form-schema
   request before Continue, then after Continue wait for the `/ideas/new`
   navigation and the schema response before typing.
2. Give those two waits explicit **40s** ceilings (the default 15s is too tight for
   this contention-sensitive chain).

These are assertion/response waits, so they resolve as soon as the app is ready —
the larger ceiling only applies when the app is genuinely slow, never on healthy
runs. No bare `cy.wait(<ms>)`, no added retries, no loosened assertions, no
`{force: true}`. The auth modal loads its fields from a different endpoint
(`user_custom_fields_for_permission`), so the intercept matches only the idea form.

### Stability evidence
- **Local:** 4/4 passing (`npx cypress run` against the seeded `localhost` tenant).
  The two reg-flow tests resolve well within the 40s ceilings on an idle machine.
- **CI stress:** two concurrent single-spec `manually-e2e-tests` pipelines
  (6 nodes total) under mutual load — **0 failures across 24 executions**, with
  whole-test times reaching 51s (heavier than the run that originally flaked). A
  tripped 40s ceiling would have failed the test, so the transition waits resolved
  with headroom.
- Definitive verdict is the nightly trend: this spec should drop off the flaky
  report over the coming weeks.

Test-only change; no user-facing behaviour affected (no changelog entry needed).
