### PR TITLE
[TAN-8421] Flaky E2E Fix: project_page_voting_single.cy.ts — gate on loaded basket state

### DIFF
--- a/front/cypress/e2e/project_page_voting_single.cy.ts
+++ b/front/cypress/e2e/project_page_voting_single.cy.ts
@@ -100,15 +100,23 @@ describe('Project with single voting phase', () => {
   });
 
   it('can submit the votes', () => {
-    cy.intercept(`**/baskets/**`).as('basketRequest');
-    cy.visit(`/en/projects/${projectSlug}`);
-    cy.wait('@basketRequest');
     cy.dockProjectCtaBar();
+    // The vote count from the previous test proves the basket state has
+    // loaded (a slow project → phase → basket fetch chain), without racing
+    // a network intercept whose request may start later than the 5s
+    // requestTimeout.
+    cy.dataCy('project-cta-bar-top').contains('4 out of 5 votes left');
     cy.get('#e2e-voting-submit-button')
       .should('be.visible')
       .should('not.have.class', 'disabled');
-    cy.wait(4000);
-    cy.get('#e2e-voting-submit-button').find('button').click({ force: true });
+
+    // Wait for the submission to actually persist before the test ends —
+    // the next test needs the basket in 'hasSubmitted' state on the backend.
+    cy.intercept('PATCH', '**/baskets/**').as('submitBasket');
+    cy.get('#e2e-voting-submit-button').find('button').click();
+    cy.wait('@submitBasket')
+      .its('response.statusCode')
+      .should('be.oneOf', [200, 201]);
 
     cy.contains('Vote submitted');
     cy.contains('Congratulations, your vote has been submitted');
@@ -120,11 +128,12 @@ describe('Project with single voting phase', () => {
 
   it('can modify and remove the votes', () => {
     cy.dockProjectCtaBar();
-    cy.get('#e2e-modify-votes')
+    // Longer timeout: the modify button renders only once the basket query
+    // (end of the project → phase → basket chain) resolves as submitted.
+    cy.get('#e2e-modify-votes', { timeout: 30000 })
       .should('be.visible')
       .should('contain', 'Modify your submission')
       .click();
-    cy.wait(1000);
 
     cy.get('.e2e-single-vote-button button')
       .should('be.visible')


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (two layers, in `project_page_voting_single.cy.ts`):**
1. "can submit the votes" gated on `cy.wait('@basketRequest')`, whose 5s *request* timeout races the start of the basket GET — that request only fires after the project and phase queries resolve, so on slow runs it timed out with "No request ever occurred" (Jul 31 failure).
2. The test never awaited the submit PATCH, so "can modify and remove the votes" could start before the basket persisted as `hasSubmitted` — and its `#e2e-modify-votes` lookup sits at the end of the same slow project→phase→basket chain (Jul 2 failure).

**Why this fixes rather than suppresses:** the network-start race is replaced by a UI-state gate (the "4 out of 5 votes left" counter can only render with basket state loaded, and retries the full default timeout); the submit test now waits for the PATCH response (200/201) before ending, closing the cross-test persistence race; the modify lookup gets an explicit 30s timeout justified by the fetch-chain depth. Also removed: two bare waits and a `{force: true}` click that masked button state.

**Stability evidence:** [pipeline 346349](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346349) — 3 nodes, 12/12 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky single-voting E2E tests (submit and modify votes).