### PR TITLE
E2E Fix: project_page_ideas.cy.ts — gate map click on the Esri render canvas

### DIFF
--- a/front/cypress/e2e/project_page_ideas.cy.ts
+++ b/front/cypress/e2e/project_page_ideas.cy.ts
@@ -305,12 +305,16 @@ describe('timeline project with no active ideation phase', () => {
   it('allows admin users to add an idea via the map for a non-active phase', () => {
     // Select map view
     cy.get('#view-tab-2').click();
-    cy.wait(2000);
+    // The map (and the whole ArcGIS bundle) is lazy-loaded on first
+    // selection, and the Esri view swallows clicks until its rendering
+    // canvas is up — the fixed waits this replaces fired the one-shot
+    // click below too early. The surface div itself mounts synchronously
+    // with the MapView, so the canvas inside it is the readiness signal.
+    cy.get('#e2e-ideas-map .esri-view-surface canvas', {
+      timeout: 30000,
+    }).should('be.visible');
     // Click map to open popup
-    cy.get('#e2e-ideas-map').should('exist');
-    cy.wait(1000);
     cy.get('#e2e-ideas-map').click('center');
-    cy.wait(1000);
     // Add idea button should appear, click it
     cy.get('#e2e-idea-from-map-button').click();
     // Shold redirect to new idea page with phase id in URL


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Not a flake — a test regression.** `timeline project with no active ideation phase › allows admin users to add an idea via the map for a non-active phase` passed 62 consecutive nightly runs, then went 4/4 red starting with the Aug 7 nightly (confirmed 3/3 red re-running the spec against master).

**Root cause:** since #14438, the map view (and the whole ArcGIS bundle) is lazy-loaded when the map tab is first selected. The spec's fixed waits (`cy.wait(2000)` + `cy.wait(1000)`) then fire its single `click('center')` while the chunk is still being fetched/parsed and the Esri MapView is still initializing — a click before the view's input surface is live is silently swallowed, so the `#e2e-idea-from-map-button` popup never appears. On CI CPUs this reliably exceeds the old ~3s budget, hence the consistent failure. (The reported `#view-tab-2` error is a retry artifact: attempts 2–3 start on a page already stuck in map view.)

**Why this fixes rather than suppresses:** the fixed waits are replaced with a deterministic readiness gate — waiting for the render `canvas` inside `.esri-view-surface`. Checked against the ArcGIS SDK internals: the surface div mounts synchronously with the MapView (too early to signal readiness), while the canvas only appears once the view is initialized and rendering — the earliest DOM signal that clicks are processed. This waits exactly as long as needed on any machine speed.

**Stability evidence:** [pipeline 346417](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346417) — 3 nodes, 36/36 tests green across the spec, including 3/3 on the previously failing test.

# Changelog

## Technical

- Fixed the ideas-map E2E test broken by the map view becoming lazy-loaded.