### PR TITLE
[TAN-8438] Flaky E2E Fix: idea_reacting_permissions.cy.ts — await email-confirmation response

### DIFF
--- a/front/cypress/support/auth.ts
+++ b/front/cypress/support/auth.ts
@@ -21,7 +21,13 @@ const acceptPolicies = (cy: Cypress.Chainable) => {
 export const confirmEmail = (cy: Cypress.Chainable) => {
   cy.get('#code').should('exist');
   cy.get('#code').click().type('1234');
+  // The confirmation request can outlive the default 15s element timeout on
+  // a loaded backend, leaving the next auth step (built-in fields form) to
+  // time out while the button still spins — so await the response itself.
+  // The request fires on click, so only the response needs the long leash.
+  cy.intercept('POST', '**/user/confirm_code_*').as('confirmCode');
   cy.get('#e2e-verify-email-button > button').click({ force: true });
+  cy.wait('@confirmCode', { responseTimeout: 60000 });
 };
 
 export const confirmPhone = (cy: Cypress.Chainable) => {


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in the shared `cypress/support/auth.ts` signup helper):** after typing the confirmation code and clicking "Verify email", the test immediately looks for `#firstName` (the next auth step) with the default 15s timeout — but on a loaded nightly backend the `POST /user/confirm_code_email` request can run longer than that. Both failure screenshots (Jul 10 and Jul 16) show the confirm button still spinning when the timeout expired. Nothing is broken; the test races a slow mutation with no explicit wait.

**Why this fixes rather than suppresses:** `confirmEmail` now intercepts the confirm-code request before clicking and awaits its response (60s response leash; the request itself fires on click, so no request-start race). The next step's assertions stay tight — the modal advances client-side as soon as the response lands. As a shared-helper fix it also hardens the ~18 other specs using this signup flow, including `permitted_by_users` and `idea_posting_permissions` from the flaky table, whose downstream timeouts plausibly share this mechanism.

**Stability evidence:** [pipeline 346427](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346427) — 3 nodes, 15/15 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky signup-flow E2E wait in the email-confirmation helper.