### PR TITLE
[TAN-8443] Flaky E2E Fix: iframe_component.cy.ts — deterministic component selection

### DIFF
--- a/front/cypress/e2e/project_description_builder/components/iframe_component.cy.ts
+++ b/front/cypress/e2e/project_description_builder/components/iframe_component.cy.ts
@@ -44,6 +44,11 @@ describe('Project description builder Iframe component', () => {
     cy.get('#e2e-draggable-iframe').dragAndDrop('#e2e-project-page-body', {
       position: 'inside',
     });
+    // dragAndDrop drops once per matched target, so a transient duplicate
+    // match inserts the component twice — which the two later tests then
+    // trip over (a 2-element click, and a frame click that selects nothing
+    // deletable). Fail fast here, at the cause.
+    cy.get('.e2e-content-builder-iframe-component').should('have.length', 1);
     cy.get('#e2e-content-builder-iframe-url-input').type(
       // Typeform survey created in CitizenLab Methods Squad workspace specifically for e2e
       'https://citizenlabco.typeform.com/to/cZtXQzTf'
@@ -99,7 +104,14 @@ describe('Project description builder Iframe component', () => {
     );
     cy.get('.e2e-content-builder-iframe-component').should('exist');
 
-    cy.get('#e2e-content-builder-frame').click();
+    // Select the iframe node itself rather than clicking the frame's center
+    // and relying on the component happening to sit at that coordinate. The
+    // cross-origin iframe covers the wrapper and swallows real clicks, so
+    // force is needed — the craftjs selection handler is on the wrapper
+    // (same pattern as the error test above).
+    cy.get('.e2e-content-builder-iframe-component').click('center', {
+      force: true,
+    });
     cy.get('#e2e-delete-button').click();
     cy.get('#e2e-content-builder-topbar-save').click();
     cy.wait('@saveProjectDescriptionBuilder');


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (one anomaly, two cascading failures — Jul 29 nightly, in `iframe_component.cy.ts`):** the first test's drag-and-drop occasionally inserts the iframe component **twice** (the failure screenshot shows two stacked Typeform embeds; the shared `dragAndDrop` command drops once per matched target, so a transient duplicate target match double-inserts). Downstream: the error test crashed clicking a 2-element subject, and the delete test clicked the *frame's center* relying on the iframe sitting at that coordinate — with the shifted layout it selected nothing deletable, so `#e2e-delete-button` never appeared.

**Why this fixes rather than suppresses:** after the drag-and-drop, the spec now asserts exactly one iframe component exists — a double insert fails immediately at the cause with a clear message instead of two cryptic failures later. The delete test selects the component directly (forced click, because the cross-origin iframe covers the wrapper and swallows real clicks — the same pattern the error test already uses) instead of the positional frame click. The shared `dragAndDrop` command (51 call sites) is deliberately left untouched.

**Stability evidence:** [pipeline 346452](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346452) — 3 nodes, 9/9 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky iframe-component E2E tests in the project description builder.