### PR TITLE
Flaky E2E Fix: idea_posting_permissions.cy.ts — fetch auth requirements fresh so post-login redirect fires

### DIFF
--- a/front/app/api/authentication/authentication_requirements/getAuthenticationRequirements.ts
+++ b/front/app/api/authentication/authentication_requirements/getAuthenticationRequirements.ts
@@ -1,19 +1,25 @@
 import fetcher from 'utils/cl-react-query/fetcher';
-import { queryClient } from 'utils/cl-react-query/queryClient';
 
-import requirementsKeys from './keys';
 import {
   AuthenticationContext,
   AuthenticationRequirementsResponse,
 } from './types';
 
+// The authentication state machine reads requirements at each decision point
+// (e.g. after sign-in, to decide whether to run the success action) and MUST
+// reflect the CURRENT auth state. Going through queryClient.fetchQuery with the
+// app-wide staleTime: Infinity let a post-login read reuse — or dedupe into —
+// the requirements request fired while logged out when the modal opened. The
+// code then saw stale anonymous requirements (group_membership unmet,
+// email_action_required: 'provide_email') and diverted permitted users to
+// access-denied, silently dropping post-login actions such as the redirect to
+// the idea form. Fetch directly so every decision-point read is fresh and
+// carries the current token. Components observe requirements via the separate
+// useAuthenticationRequirements hook and are unaffected.
 const getAuthenticationRequirements = (
   authenticationContext: AuthenticationContext
 ) => {
-  return queryClient.fetchQuery(
-    requirementsKeys.item(authenticationContext),
-    () => fetchAuthenticationRequirements(authenticationContext)
-  );
+  return fetchAuthenticationRequirements(authenticationContext);
 };
 
 export const fetchAuthenticationRequirements = (


### PR DESCRIPTION
Generated by Claude

**Flaky spec:** `cypress/e2e/ideation_permissions/idea_posting_permissions.cy.ts`
(test: *idea posting restricted to a group › redirects users after authentication to form page if they are permitted*)

### Root cause
The authentication state machine reads permission `requirements` at each decision point via an imperative `getAuthenticationRequirements`, which wrapped `queryClient.fetchQuery`. With the app-wide `staleTime: Infinity`, the **post-login** read reused / deduped into the `posting_idea/requirements` request fired **while logged out** when the modal first opened. The code then saw stale anonymous requirements (`group_membership: true`, `email_action_required: "provide_email"`) and diverted the permitted group member to the **access-denied** path, silently dropping the success action that redirects to `/ideas/new`. Under CI contention the automated login usually completes while that logged-out request is still in flight, which is why the test flaked (~1/3 on the manual runner, ~1/60 on the nightly).

### Fix
`getAuthenticationRequirements` now fetches directly instead of via the shared `fetchQuery` cache, so every decision-point read reflects the current auth state and carries the fresh token. This addresses the mechanism (stale/deduped read) rather than suppressing the symptom — no added waits, retries, or loosened assertions. Components read requirements via the separate `useAuthenticationRequirements` hook and are unaffected.

### Stability evidence
- A diagnostic spec that captures the post-login requirements payload reproduced the bug **without** the fix (`group_membership: true`, logged-out payload; 1/5 executors) and passes **6/6 with** the fix.
- The real spec `idea_posting_permissions.cy.ts` ran **green on all 6 CI executors** (target test + full file).
- CI pipeline `manually-e2e-tests` #346462 — **48/48** tests passing across 6 parallel nodes.
- Lint, typecheck, and the module's unit tests pass.

### Changelog
**Fixed**
- Users who are permitted to post are now reliably taken to the submission form after signing in from the "Add an idea" button (previously an occasional race could leave them on the project page).
