### PR TITLE
Flaky E2E Fix: comment_reacting_permissions.cy.ts — scope native survey idea cleanup

### DIFF
--- a/front/cypress/e2e/native_survey/multiple_responses.cy.ts
+++ b/front/cypress/e2e/native_survey/multiple_responses.cy.ts
@@ -93,7 +93,7 @@ describe('Native survey: multiple responses per user', () => {
     });
 
     after(() => {
-      cy.apiRemoveIdeas().then(() => cy.apiRemoveProject(projectId));
+      cy.apiRemoveIdeas(projectId).then(() => cy.apiRemoveProject(projectId));
     });
 
     it('lets a registered user submit the survey more than once', () => {
@@ -123,7 +123,7 @@ describe('Native survey: multiple responses per user', () => {
     });
 
     after(() => {
-      cy.apiRemoveIdeas().then(() => cy.apiRemoveProject(projectId));
+      cy.apiRemoveIdeas(projectId).then(() => cy.apiRemoveProject(projectId));
     });
 
     it('blocks a second submission and hides the survey CTA', () => {

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -2348,10 +2348,11 @@ function deleteEventAttendances(
   });
 }
 
-function apiRemoveIdeas(projectId?: string) {
-  // When a projectId is passed, only ideas (incl. survey responses) belonging to
-  // that project are removed. Without it, ALL ideas in the tenant are deleted,
-  // which wipes seeded fixtures (e.g. the "Verified Idea") that other specs rely on.
+// projectId is required on purpose: scoping the deletion to one project is the
+// only safe form. A tenant-wide delete would also remove seeded fixtures (e.g.
+// the "Verified Idea") that other specs rely on, and because specs share one
+// backend it would break them from a different parallel node.
+function apiRemoveIdeas(projectId: string) {
   return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
     const adminJwt = response.body.jwt;
 
@@ -2359,7 +2360,7 @@ function apiRemoveIdeas(projectId?: string) {
       .request({
         method: 'GET',
         url: `/web_api/v1/ideas`,
-        qs: projectId ? { 'projects[]': projectId } : undefined,
+        qs: { 'projects[]': projectId },
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${adminJwt}`,


### PR DESCRIPTION
This PR has been generated with fix-flaky-e2e skill by Claude.
Notion card => https://app.notion.com/p/govocal/Fix-comment_reacting_permissions-cy-ts-3b59663b7b2680f69524db92de29b915 

# Changelog

## Technical
- Scoped the native survey `multiple_responses.cy.ts` cleanup to its own project so it no longer deletes every idea in the shared E2E tenant.
- `cy.apiRemoveIdeas` now requires a `projectId`, making the tenant-wide form unreachable.

---

Generated by Claude

**Flaky spec:** `cypress/e2e/comment_reacting_permissions.cy.ts` (fix lands in `cypress/e2e/native_survey/multiple_responses.cy.ts` + `cypress/support/commands.ts`)

**Root cause.** Both `after()` hooks in `multiple_responses.cy.ts` called `cy.apiRemoveIdeas()` with no project. That fetches and deletes *every* idea in the tenant — the ideas index defaults to 250 per page and the E2E tenant seeds 39, so nothing bounded it. Specs share one backend across parallel nodes, so this wiped seeded fixtures other specs rely on. `comment_reacting_permissions.cy.ts` then got a 404 for the "Verified Idea" it visits, rendered "Page not found", and all three of its tests failed looking for `.e2e-comment-reaction`. It only bit when the cleanup landed before that spec loaded the page — hence a rare flake (1 red night in 60).

**Why this addresses rather than suppresses it.** No waits, retries, or loosened assertions. The tests were correct; the data they depend on was being destroyed by an unrelated spec. Both hooks already had their project id in scope. Making `projectId` required means a future call site can't repeat this — the helper already carried a comment warning against the unscoped form, which wasn't enough to prevent it.

**Stability evidence.**
- Fixture survival, measured directly: fresh tenant 39 ideas / fixture HTTP 200 → after unfixed run **0 ideas / HTTP 404** → after fixed run **39 ideas / HTTP 200**. The fixed run's cleanup still ran (both suites completed their hooks, and the spec's own survey responses were removed) — it's scoped, not skipped.
- `comment_reacting_permissions.cy.ts` 3/3 passing locally against that state.
- CI pipeline 346474: **18/18 green** — both specs × 3 tests × 3 nodes, run in the hazardous order on every node.