### PR TITLE
Sort out SSO custom fields mess

### DIFF
--- a/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
+++ b/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
@@ -13,11 +13,11 @@ module LockedUserCustomFieldsConcern
   def build_locked_custom_fields_constraints
     return {} unless current_user
 
-    locked_custom_field_keys = Verification::VerificationService.new.locked_custom_fields(current_user).map(&:to_s)
+    locked_custom_field_keys = Verification::VerificationService.new.locked_custom_fields_keys(current_user).map(&:to_s)
 
-    # `locked_custom_fields` returns keys, so the constraints are keyed by key as
-    # well. Not every locked field has a code (e.g. verification methods that
-    # lock a field configured by key), so we cannot key them by code.
+    # The constraints are keyed by key as well: not every locked field has a code
+    # (e.g. verification methods that lock a field configured by key), so we
+    # cannot key them by code.
     CustomField.where(key: locked_custom_field_keys).to_h { |field| [field.key.to_sym, { locked: true }] }
   end
 end

--- a/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
+++ b/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
@@ -14,10 +14,6 @@ module LockedUserCustomFieldsConcern
     return {} unless current_user
 
     locked_custom_field_keys = Verification::VerificationService.new.locked_custom_fields_keys(current_user).map(&:to_s)
-
-    # The constraints are keyed by key as well: not every locked field has a code
-    # (e.g. verification methods that lock a field configured by key), so we
-    # cannot key them by code.
     CustomField.where(key: locked_custom_field_keys).to_h { |field| [field.key.to_sym, { locked: true }] }
   end
 end

--- a/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
+++ b/back/app/controllers/concerns/locked_user_custom_fields_concern.rb
@@ -14,15 +14,10 @@ module LockedUserCustomFieldsConcern
     return {} unless current_user
 
     locked_custom_field_keys = Verification::VerificationService.new.locked_custom_fields(current_user).map(&:to_s)
-    constraints = {}
 
-    # Find the corresponding codes for the locked custom field keys
-    # The serializer expects constraints keyed by 'code', not 'key'
-    CustomField.where(key: locked_custom_field_keys).each do |field|
-      code_key = field.code&.to_sym
-      constraints[code_key] = { locked: true } if code_key
-    end
-
-    constraints
+    # `locked_custom_fields` returns keys, so the constraints are keyed by key as
+    # well. Not every locked field has a code (e.g. verification methods that
+    # lock a field configured by key), so we cannot key them by code.
+    CustomField.where(key: locked_custom_field_keys).to_h { |field| [field.key.to_sym, { locked: true }] }
   end
 end

--- a/back/app/models/custom_field.rb
+++ b/back/app/models/custom_field.rb
@@ -136,6 +136,10 @@ class CustomField < ApplicationRecord
   scope :not_hidden, -> { where(hidden: false) }
   scope :hidden, -> { where(hidden: true) }
 
+  def self.keys_by_code(codes)
+    where(code: codes).pluck(:code, :key).to_h
+  end
+
   def policy_class
     case resource_type
     when 'User'

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -271,12 +271,25 @@ class User < ApplicationRecord
   scope :not_blocked, -> { where(block_end_at: nil).or(where('? > block_end_at', Time.zone.now)) }
   scope :active, -> { registered.not_blocked }
 
+  # Assigns `attributes`, merging (rather than replacing) the `custom_field_values`
+  # hash so that custom fields the caller doesn't know about are preserved.
+  #
+  # The merge is applied *after* the other attributes have been assigned, so that
+  # `store_accessor` attributes (:gender, :birthyear, :domicile), which write into
+  # `custom_field_values` themselves, are not silently overwritten.
+  def assign_merging_custom_fields(attributes)
+    # `to_h` so that this also accepts ActionController::Parameters (it raises
+    # ActionController::UnfilteredParameters on unpermitted params, just as
+    # `assign_attributes` would have raised ForbiddenAttributesError).
+    attributes = attributes.to_h.deep_stringify_keys
+    new_custom_field_values = attributes.delete('custom_field_values') || {}
+    assign_attributes(attributes)
+    self.custom_field_values = custom_field_values.merge(new_custom_field_values)
+  end
+
   def update_merging_custom_fields!(attributes)
-    attributes = attributes.deep_stringify_keys
-    update!(
-      **attributes,
-      custom_field_values: custom_field_values.merge(attributes['custom_field_values'] || {})
-    )
+    assign_merging_custom_fields(attributes)
+    save!
   end
 
   def to_token_payload

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -274,9 +274,12 @@ class User < ApplicationRecord
   # Assigns `attributes`, merging (rather than replacing) the `custom_field_values`
   # hash so that custom fields the caller doesn't know about are preserved.
   #
-  # The merge is applied *after* the other attributes have been assigned, so that
-  # `store_accessor` attributes (:gender, :birthyear, :domicile), which write into
-  # `custom_field_values` themselves, are not silently overwritten.
+  # The merge is applied *after* the other attributes have been assigned. The
+  # `store_accessor` declaration above gives :gender, :birthyear and :domicile
+  # `user.gender` / `user.gender=` methods that read and write straight into the
+  # `custom_field_values` hash, so `assign_attributes(gender: 'female')` is a
+  # write to that hash too. Merging first and assigning after would throw those
+  # writes away.
   def assign_merging_custom_fields(attributes)
     # `to_h` so that this also accepts ActionController::Parameters (it raises
     # ActionController::UnfilteredParameters on unpermitted params, just as

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -62,6 +62,9 @@ class User < ApplicationRecord
   include UserDoorkeeper
 
   GENDERS = %w[male female unspecified].freeze
+  # Registration custom fields that ship with the platform, and so are validated
+  # on every save rather than only against the tenant's custom field schema.
+  BUILT_IN_CUSTOM_FIELD_KEYS = %w[gender birthyear domicile].freeze
   INVITE_STATUSES = %w[pending accepted].freeze
   EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
   EMAIL_DOMAIN_BLACKLIST = EmailDomainBlacklist.load
@@ -229,7 +232,6 @@ class User < ApplicationRecord
   has_many :jobs_trackers, class_name: 'Jobs::Tracker', foreign_key: :owner_id, dependent: :nullify
   has_many :invites_imports, foreign_key: :importer_id, dependent: :destroy
 
-  store_accessor :custom_field_values, :gender, :birthyear, :domicile
   store_accessor :onboarding, :topics_and_areas
 
   validates :locale, presence: true, unless: :invite_pending?
@@ -242,6 +244,10 @@ class User < ApplicationRecord
   validates :first_name, :last_name, format: { without: /@/ }, allow_nil: true
   validates :locale, inclusion: { in: proc { AppConfiguration.instance.settings('core', 'locales') } }
   validates :bio_multiloc, multiloc: { presence: false, html: true }
+  # These three are ordinary registration custom fields living in
+  # `custom_field_values` (see `read_attribute_for_validation`), but they are
+  # built into the platform, so we always validate them — the JSON schema
+  # validation below only runs on the :form_submission context.
   validates :gender, inclusion: { in: GENDERS }, allow_nil: true
   validates :birthyear, numericality: { only_integer: true, greater_than_or_equal_to: 1900, less_than: Time.zone.now.year }, allow_nil: true
   validates :domicile, inclusion: { in: proc { ['outside'] + Area.select(:id).map(&:id) } }, allow_nil: true
@@ -271,15 +277,25 @@ class User < ApplicationRecord
   scope :not_blocked, -> { where(block_end_at: nil).or(where('? > block_end_at', Time.zone.now)) }
   scope :active, -> { registered.not_blocked }
 
+  # `gender`, `birthyear` and `domicile` are built-in registration custom fields:
+  # they live in `custom_field_values` like every other custom field and have no
+  # top-level accessor of their own. Pointing validation at the right place lets
+  # the `validates` declarations above refer to them by name, which keeps their
+  # validation errors keyed on :gender / :birthyear / :domicile rather than on
+  # :custom_field_values.
+  def read_attribute_for_validation(key)
+    # `&.` because the column is nullable, and `store_accessor`'s reader — which
+    # this replaces — tolerated a nil store.
+    return custom_field_values&.dig(key.to_s) if BUILT_IN_CUSTOM_FIELD_KEYS.include?(key.to_s)
+
+    super
+  end
+
   # Assigns `attributes`, merging (rather than replacing) the `custom_field_values`
   # hash so that custom fields the caller doesn't know about are preserved.
-  #
-  # The merge is applied *after* the other attributes have been assigned. The
-  # `store_accessor` declaration above gives :gender, :birthyear and :domicile
-  # `user.gender` / `user.gender=` methods that read and write straight into the
-  # `custom_field_values` hash, so `assign_attributes(gender: 'female')` is a
-  # write to that hash too. Merging first and assigning after would throw those
-  # writes away.
+  # Custom fields are only ever addressed through `custom_field_values`; there
+  # are no top-level attributes that write into it. The merge is applied after
+  # `assign_attributes` regardless, so that stays true if that ever changes.
   def assign_merging_custom_fields(attributes)
     # `to_h` so that this also accepts ActionController::Parameters (it raises
     # ActionController::UnfilteredParameters on unpermitted params, just as

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -288,10 +288,6 @@ class User < ApplicationRecord
     custom_field_values&.dig(key)
   end
 
-  # Merges `values` into the user's custom fields rather than replacing them, so
-  # that fields the caller doesn't know about are preserved. Counterpart of
-  # `assign_attributes`, which writes the regular columns: a caller writing both
-  # calls both.
   def merge_custom_field_values(values)
     self.custom_field_values = custom_field_values.merge(values.deep_stringify_keys)
   end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ApplicationRecord
   GENDERS = %w[male female unspecified].freeze
   # Registration custom fields that ship with the platform, and so are validated
   # on every save rather than only against the tenant's custom field schema.
+  # see validate :gender etc calls below and `read_attribute_for_validation`
   BUILT_IN_CUSTOM_FIELD_KEYS = %w[gender birthyear domicile].freeze
   INVITE_STATUSES = %w[pending accepted].freeze
   EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
@@ -244,10 +245,6 @@ class User < ApplicationRecord
   validates :first_name, :last_name, format: { without: /@/ }, allow_nil: true
   validates :locale, inclusion: { in: proc { AppConfiguration.instance.settings('core', 'locales') } }
   validates :bio_multiloc, multiloc: { presence: false, html: true }
-  # These three are ordinary registration custom fields living in
-  # `custom_field_values` (see `read_attribute_for_validation`), but they are
-  # built into the platform, so we always validate them — the JSON schema
-  # validation below only runs on the :form_submission context.
   validates :gender, inclusion: { in: GENDERS }, allow_nil: true
   validates :birthyear, numericality: { only_integer: true, greater_than_or_equal_to: 1900, less_than: Time.zone.now.year }, allow_nil: true
   validates :domicile, inclusion: { in: proc { ['outside'] + Area.select(:id).map(&:id) } }, allow_nil: true
@@ -277,12 +274,7 @@ class User < ApplicationRecord
   scope :not_blocked, -> { where(block_end_at: nil).or(where('? > block_end_at', Time.zone.now)) }
   scope :active, -> { registered.not_blocked }
 
-  # `gender`, `birthyear` and `domicile` are built-in registration custom fields:
-  # they live in `custom_field_values` like every other custom field and have no
-  # top-level accessor of their own. Pointing validation at the right place lets
-  # the `validates` declarations above refer to them by name, which keeps their
-  # validation errors keyed on :gender / :birthyear / :domicile rather than on
-  # :custom_field_values.
+  # HACK: makes sure we can validate values inside custom fields
   def read_attribute_for_validation(key)
     # `&.` because the column is nullable, and `store_accessor`'s reader — which
     # this replaces — tolerated a nil store.
@@ -291,24 +283,12 @@ class User < ApplicationRecord
     super
   end
 
-  # Assigns `attributes`, merging (rather than replacing) the `custom_field_values`
-  # hash so that custom fields the caller doesn't know about are preserved.
-  # Custom fields are only ever addressed through `custom_field_values`; there
-  # are no top-level attributes that write into it. The merge is applied after
-  # `assign_attributes` regardless, so that stays true if that ever changes.
-  def assign_merging_custom_fields(attributes)
-    # `to_h` so that this also accepts ActionController::Parameters (it raises
-    # ActionController::UnfilteredParameters on unpermitted params, just as
-    # `assign_attributes` would have raised ForbiddenAttributesError).
-    attributes = attributes.to_h.deep_stringify_keys
-    new_custom_field_values = attributes.delete('custom_field_values') || {}
-    assign_attributes(attributes)
-    self.custom_field_values = custom_field_values.merge(new_custom_field_values)
-  end
-
-  def update_merging_custom_fields!(attributes)
-    assign_merging_custom_fields(attributes)
-    save!
+  # Merges `values` into the user's custom fields rather than replacing them, so
+  # that fields the caller doesn't know about are preserved. Counterpart of
+  # `assign_attributes`, which writes the regular columns: a caller writing both
+  # calls both.
+  def merge_custom_field_values(values)
+    self.custom_field_values = custom_field_values.merge(values.deep_stringify_keys)
   end
 
   def to_token_payload

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -65,7 +65,7 @@ class User < ApplicationRecord
   # Registration custom fields that ship with the platform, and so are validated
   # on every save rather than only against the tenant's custom field schema.
   # see validate :gender etc calls below and `read_attribute_for_validation`
-  BUILT_IN_CUSTOM_FIELD_KEYS = %w[gender birthyear domicile].freeze
+  BUILT_IN_CUSTOM_FIELD_CODES = %w[gender birthyear domicile].freeze
   INVITE_STATUSES = %w[pending accepted].freeze
   EMAIL_REGEX = /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
   EMAIL_DOMAIN_BLACKLIST = EmailDomainBlacklist.load
@@ -275,12 +275,17 @@ class User < ApplicationRecord
   scope :active, -> { registered.not_blocked }
 
   # HACK: makes sure we can validate values inside custom fields
-  def read_attribute_for_validation(key)
-    # `&.` because the column is nullable, and `store_accessor`'s reader — which
-    # this replaces — tolerated a nil store.
-    return custom_field_values&.dig(key.to_s) if BUILT_IN_CUSTOM_FIELD_KEYS.include?(key.to_s)
+  def read_attribute_for_validation(attribute)
+    return super unless BUILT_IN_CUSTOM_FIELD_CODES.include?(attribute.to_s)
 
-    super
+    built_in_custom_field_value(attribute)
+  end
+
+  def built_in_custom_field_value(code)
+    key = CustomField.registration.find_by(code: code.to_s)&.key
+    return unless key
+
+    custom_field_values&.dig(key)
   end
 
   # Merges `values` into the user's custom fields rather than replacing them, so

--- a/back/app/models/verification/README.md
+++ b/back/app/models/verification/README.md
@@ -76,7 +76,7 @@ module Verification
       # A list of custom field keys that should be unchangeable by the user,
       # when they're verified using this method. Make sure that the 
       # corresponding custom field is in place and enabled.
-      def locked_custom_fields
+      def locked_custom_fields_keys
         [:gender]
       end
 

--- a/back/app/models/verification/README.md
+++ b/back/app/models/verification/README.md
@@ -76,8 +76,10 @@ module Verification
       # A list of custom field keys that should be unchangeable by the user,
       # when they're verified using this method. Make sure that the 
       # corresponding custom field is in place and enabled.
+      # Never hardcode the key of a field that has a code (gender, birthyear,
+      # domicile, ...): the key is tenant-specific, so look it up by code.
       def locked_custom_fields_keys
-        [:gender]
+        [CustomField.registration.find_by(code: 'gender')&.key].compact
       end
 
     end

--- a/back/app/policies/user_policy.rb
+++ b/back/app/policies/user_policy.rb
@@ -130,11 +130,11 @@ class UserPolicy < ApplicationPolicy
   end
 
   def allowed_custom_fields
-    CustomField.registration.not_hidden.where.not(key: locked_custom_fields)
+    CustomField.registration.not_hidden.where.not(key: locked_custom_fields_keys)
   end
 
-  def locked_custom_fields
-    verification_service.locked_custom_fields(record)
+  def locked_custom_fields_keys
+    verification_service.locked_custom_fields_keys(record)
   end
 
   def verification_service

--- a/back/app/serializers/web_api/v1/custom_field_serializer.rb
+++ b/back/app/serializers/web_api/v1/custom_field_serializer.rb
@@ -40,7 +40,9 @@ class WebApi::V1::CustomFieldSerializer < WebApi::V1::BaseSerializer
 
   attribute :constraints do |object, params|
     if params[:constraints]
-      params[:constraints][object.code&.to_sym] || {}
+      # Participation method constraints are keyed by code, locked user custom
+      # fields by key (not every locked field has a code).
+      params[:constraints][object.code&.to_sym] || params[:constraints][object.key&.to_sym] || {}
     else
       {}
     end

--- a/back/app/services/anonymize_user_service.rb
+++ b/back/app/services/anonymize_user_service.rb
@@ -25,7 +25,7 @@ class AnonymizeUserService
   def anonymized_attributes(locales, user: nil, start_at: nil)
     locale = locales.sample
     custom_field_values = random_custom_field_values user: user
-    gender = custom_field_values['gender']
+    gender = custom_field_values[demographic_keys['gender']]
     first_name = random_first_name gender
     last_name = random_last_name locale
     email = random_email first_name, last_name
@@ -55,18 +55,15 @@ class AnonymizeUserService
   private
 
   def random_custom_field_values(user: nil)
-    custom_field_values = {}
-    if user
-      properties = %w[gender birthyear]
-      user[:custom_field_values].each do |property, value|
-        if properties.include? property
-          custom_field_values[property] = value
-        end
-      end
-    end
-    custom_field_values['gender'] ||= User::GENDERS.sample
-    custom_field_values['birthyear'] ||= random_birthyear
+    keys = demographic_keys
+    custom_field_values = user ? (user[:custom_field_values] || {}).slice(*keys.values) : {}
+    custom_field_values[keys['gender']] ||= User::GENDERS.sample if keys['gender']
+    custom_field_values[keys['birthyear']] ||= random_birthyear if keys['birthyear']
     custom_field_values
+  end
+
+  def demographic_keys
+    @demographic_keys ||= CustomField.registration.keys_by_code(%w[gender birthyear])
   end
 
   def mismatch_gender(gender)

--- a/back/app/services/export/geojson/value_visitor.rb
+++ b/back/app/services/export/geojson/value_visitor.rb
@@ -75,7 +75,10 @@ module Export
       attr_reader :model, :option_index, :multiloc_service
 
       def value_for(field)
-        return model.public_send field.key if field.built_in?
+        # Built-in fields are backed by a real column (an idea's title, budget, ...),
+        # except on User: `gender`, `birthyear` and `domicile` are built into the
+        # platform but still live in `custom_field_values` like any other custom field.
+        return model.public_send field.key if field.built_in? && field.resource_type != 'User'
 
         model.custom_field_values[field.key]
       end

--- a/back/app/services/export/xlsx/value_visitor.rb
+++ b/back/app/services/export/xlsx/value_visitor.rb
@@ -146,12 +146,19 @@ module Export
       end
 
       def value_for(field)
-        stored_value = if field.built_in?
+        stored_value = if built_in_column?(field)
           model.public_send field.key
         else
           model.custom_field_values[field.key]
         end
         stored_value.nil? ? '' : stored_value
+      end
+
+      # Built-in fields are backed by a real column (an idea's title, budget, ...),
+      # except on User: `gender`, `birthyear` and `domicile` are built into the
+      # platform but still live in `custom_field_values` like any other custom field.
+      def built_in_column?(field)
+        field.built_in? && field.resource_type != 'User'
       end
 
       def value_for_multiloc(maybe_multiloc)

--- a/back/app/services/id_method_service.rb
+++ b/back/app/services/id_method_service.rb
@@ -74,13 +74,13 @@ class IdMethodService
     # Custom fields
     custom_fields = CustomField.registration
     locked_custom_fields = if method.respond_to?(:locked_custom_fields)
-      method.locked_custom_fields.filter_map { |code| custom_fields.find { |f| f.code == code.to_s }&.title_multiloc }
+      method.locked_custom_fields.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
     else
       []
     end
 
     other_custom_fields = if method.respond_to?(:other_custom_fields)
-      method.other_custom_fields.filter_map { |code| custom_fields.find { |f| f.code == code.to_s }&.title_multiloc }
+      method.other_custom_fields.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
     else
       []
     end

--- a/back/app/services/id_method_service.rb
+++ b/back/app/services/id_method_service.rb
@@ -73,14 +73,14 @@ class IdMethodService
 
     # Custom fields
     custom_fields = CustomField.registration
-    locked_custom_fields = if method.respond_to?(:locked_custom_fields)
-      method.locked_custom_fields.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
+    locked_custom_field_titles = if method.respond_to?(:locked_custom_fields_keys)
+      method.locked_custom_fields_keys.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
     else
       []
     end
 
-    other_custom_fields = if method.respond_to?(:other_custom_fields)
-      method.other_custom_fields.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
+    other_custom_field_titles = if method.respond_to?(:other_custom_fields_keys)
+      method.other_custom_fields_keys.filter_map { |key| custom_fields.find { |f| f.key == key.to_s }&.title_multiloc }
     else
       []
     end
@@ -90,8 +90,9 @@ class IdMethodService
       name: name,
       locked_attributes: locked_attributes,
       other_attributes: other_attributes,
-      locked_custom_fields: locked_custom_fields,
-      other_custom_fields: other_custom_fields
+      # These are the titles of the custom fields, not their keys
+      locked_custom_fields: locked_custom_field_titles,
+      other_custom_fields: other_custom_field_titles
     }
   end
 end

--- a/back/app/services/permissions/permissions_custom_fields_service.rb
+++ b/back/app/services/permissions/permissions_custom_fields_service.rb
@@ -112,7 +112,7 @@ module Permissions
       return fields unless method.respond_to?(:locked_custom_fields) && method.locked_custom_fields.present?
 
       # Get the IDs of the custom fields that are locked to the verification method
-      custom_field_required_array = CustomField.where(code: method.locked_custom_fields).map do |field|
+      custom_field_required_array = CustomField.where(key: method.locked_custom_fields).map do |field|
         { id: field.id, required: true }
       end
 

--- a/back/app/services/permissions/permissions_custom_fields_service.rb
+++ b/back/app/services/permissions/permissions_custom_fields_service.rb
@@ -109,10 +109,10 @@ module Permissions
     # Add any fields that are locked to verification method
     def add_verification_fields(permission, fields)
       method = Verification::VerificationService.new.first_method_enabled
-      return fields unless method.respond_to?(:locked_custom_fields) && method.locked_custom_fields.present?
+      return fields unless method.respond_to?(:locked_custom_fields_keys) && method.locked_custom_fields_keys.present?
 
       # Get the IDs of the custom fields that are locked to the verification method
-      custom_field_required_array = CustomField.where(key: method.locked_custom_fields).map do |field|
+      custom_field_required_array = CustomField.where(key: method.locked_custom_fields_keys).map do |field|
         { id: field.id, required: true }
       end
 

--- a/back/app/services/permissions/user_requirements_service.rb
+++ b/back/app/services/permissions/user_requirements_service.rb
@@ -199,10 +199,10 @@ class Permissions::UserRequirementsService
 
     if user.verified?
       # Remove custom fields that are locked - we should never ask them to be filled in the flow - even if they are returned empty
-      locked_fields = verification_service.locked_custom_fields(user)
+      locked_field_keys = verification_service.locked_custom_fields_keys(user)
 
       requirements[:custom_fields]&.each_key do |key|
-        requirements[:custom_fields].delete(key) if locked_fields.include?(key.to_sym)
+        requirements[:custom_fields].delete(key) if locked_field_keys.include?(key.to_sym)
       end
     end
 

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -151,7 +151,7 @@ class SideFxUserService
   end
 
   def create_followers(user)
-    area = Area.where(id: user.domicile).first
+    area = Area.where(id: user.custom_field_values['domicile']).first
     Follower.find_or_create_by(followable: area, user: user) if area
   end
 

--- a/back/app/services/side_fx_user_service.rb
+++ b/back/app/services/side_fx_user_service.rb
@@ -151,7 +151,7 @@ class SideFxUserService
   end
 
   def create_followers(user)
-    area = Area.where(id: user.custom_field_values['domicile']).first
+    area = Area.where(id: user.built_in_custom_field_value('domicile')).first
     Follower.find_or_create_by(followable: area, user: user) if area
   end
 

--- a/back/app/services/user_service.rb
+++ b/back/app/services/user_service.rb
@@ -69,7 +69,8 @@ class UserService
       user.find_or_create_confirmation(:email_confirmation).confirm! if confirm_user
       # Merge rather than replace `custom_field_values`: the invite may have
       # pre-filled custom fields that the SSO does not return.
-      user.assign_merging_custom_fields(user_params.merge(invite_status: 'accepted'))
+      user.assign_merging_custom_fields(user_params)
+      user.invite_status = 'accepted'
       user
     end
 

--- a/back/app/services/user_service.rb
+++ b/back/app/services/user_service.rb
@@ -67,7 +67,9 @@ class UserService
       # If the user's email came from/matches the authver one, and the provider
       # says it was confirmed: we mark the user's email as confirmed.
       user.find_or_create_confirmation(:email_confirmation).confirm! if confirm_user
-      user.assign_attributes(user_params.merge(invite_status: 'accepted'))
+      # Merge rather than replace `custom_field_values`: the invite may have
+      # pre-filled custom fields that the SSO does not return.
+      user.assign_merging_custom_fields(user_params.merge(invite_status: 'accepted'))
       user
     end
 

--- a/back/app/services/user_service.rb
+++ b/back/app/services/user_service.rb
@@ -56,7 +56,9 @@ class UserService
 
       resolve_sso_email!(user, user_params, sso_user_attrs[:email], authver_method.email_confirmed?(auth))
 
-      user.update_merging_custom_fields!(user_params)
+      user.assign_attributes(user_params.except(:custom_field_values))
+      user.merge_custom_field_values(user_params[:custom_field_values] || {})
+      user.save!
     end
 
     def assign_params_in_accept_invite(user, user_params, confirm_user: false)
@@ -67,9 +69,10 @@ class UserService
       # If the user's email came from/matches the authver one, and the provider
       # says it was confirmed: we mark the user's email as confirmed.
       user.find_or_create_confirmation(:email_confirmation).confirm! if confirm_user
-      # Merge rather than replace `custom_field_values`: the invite may have
-      # pre-filled custom fields that the SSO does not return.
-      user.assign_merging_custom_fields(user_params)
+      user.assign_attributes(user_params.except(:custom_field_values))
+      # Merge rather than replace: the invite may have pre-filled custom fields
+      # that the SSO does not return.
+      user.merge_custom_field_values(user_params[:custom_field_values] || {})
       user.invite_status = 'accepted'
       user
     end

--- a/back/app/services/verification/verification_service.rb
+++ b/back/app/services/verification/verification_service.rb
@@ -57,9 +57,9 @@ module Verification
       response = method.verify_sync(**verification_parameters)
       uid = response[:uid]
       user_attributes = response[:attributes] || {}
-      user.update_merging_custom_fields!(
-        user_attributes.merge(custom_field_values: response[:custom_field_values] || {})
-      )
+      user.assign_attributes(user_attributes)
+      user.merge_custom_field_values(response[:custom_field_values] || {})
+      user.save!
       make_verification(user:, method:, uid:)
     end
 

--- a/back/app/services/verification/verification_service.rb
+++ b/back/app/services/verification/verification_service.rb
@@ -90,19 +90,19 @@ module Verification
       attributes.uniq
     end
 
-    def locked_custom_fields(user)
+    def locked_custom_fields_keys(user)
       method_names = user.verifications.active.pluck(:method_name).uniq || []
-      custom_fields = method_names.flat_map do |method_name|
+      keys = method_names.flat_map do |method_name|
         ver_method = @id_method_service.method_by_name(method_name)
-        if ver_method.respond_to? :locked_custom_fields
-          ver_method.locked_custom_fields
+        if ver_method.respond_to? :locked_custom_fields_keys
+          ver_method.locked_custom_fields_keys
         else
           []
         end
       end
 
-      # Only return the locked custom fields if they exist
-      CustomField.where(key: custom_fields).pluck(:key).map(&:to_sym)
+      # Only return the keys of the locked custom fields that exist
+      CustomField.where(key: keys).pluck(:key).map(&:to_sym)
     end
 
     def verifications_by_uid(uid, method)

--- a/back/config/tenant_templates/e2etests_template.yml
+++ b/back/config/tenant_templates/e2etests_template.yml
@@ -416,9 +416,6 @@ models:
     last_name: Kalinoski
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     registration_completed_at: '2018-03-28 13:34:57'
     password: democracy2.0
     remote_avatar_url: https://cl2-seed-and-template-assets.s3.eu-central-1.amazonaws.com/images/avatars/initials_avatars/sk_avatar.png
@@ -432,9 +429,6 @@ models:
     last_name: Ankunding
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     created_at: '2018-03-28 13:35:02'
@@ -446,9 +440,6 @@ models:
     last_name: Luettgen
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     roles: []
@@ -461,9 +452,6 @@ models:
     last_name: Charles
     locale: fr-BE
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     roles: []
@@ -476,9 +464,6 @@ models:
     last_name: Macejkovic
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     roles: []
@@ -490,9 +475,6 @@ models:
     last_name: Collins
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$wSfT0drbbyCYYclUriA76u33HHMunpjkPoOh.dQWhJiJxx60ih/2e"
     remote_avatar_url:
     roles: []
@@ -504,9 +486,6 @@ models:
     last_name: Toy
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$I1S3K3nNuHuq8WzPCPyf..Xs0N6e8DLJh2QxIV5Ek.jwVvOtvup4K"
     remote_avatar_url:
     roles: []
@@ -518,9 +497,6 @@ models:
     last_name: Schaefer
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$CRh2rjLDeraWqqbUvFYg7.jKGhoe.CNBHQpPy2SfZhOKKGIQupx8e"
     remote_avatar_url:
     roles:
@@ -533,9 +509,6 @@ models:
     last_name: Blick
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$sZwQpPuMiJkkOOoc5ZvDxe48tpnA7EWNmoS7QvoMctD/uZROYrnz."
     remote_avatar_url:
     roles: []
@@ -547,9 +520,6 @@ models:
     last_name: Lowe
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$L4ekuM6mZl7qa4MLRQRHFetMnMMr7JACfWdDzZ2Moj..IZZI.PqDa"
     remote_avatar_url:
     roles: []
@@ -561,9 +531,6 @@ models:
     last_name: Kulas
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$cKr5m15WIbhsR1QJmdWZ8OUCQQ/oz1WDOzrh0TsOf/QnW2.4xFkxG"
     remote_avatar_url:
     roles: []
@@ -575,9 +542,6 @@ models:
     last_name:
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$W3AKY8LVvXlNrbf28tRLYul25b2oIcU/XBOCOSpgFzup3dgbTTjuS"
     remote_avatar_url:
     roles: []
@@ -589,9 +553,6 @@ models:
     last_name: Auer
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$NFU2JwunuN3vzp8AOGy76.XhbGVg3FgMLGoriCE4/NBnDdu13FRjC"
     remote_avatar_url:
     roles: []
@@ -603,9 +564,6 @@ models:
     last_name: Adams
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$u9mkhE/suGQlXcVb6bgf6.f5S/i39hycOOcLkd4qqRrIBbcRMkOLO"
     remote_avatar_url:
     roles: []
@@ -617,9 +575,6 @@ models:
     last_name: Strosin
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$.X258VC6KFXWZ1doF2rIy.2yjOvDYTC1EcW7KCeqjcqUWp8iFg/Fq"
     remote_avatar_url:
     roles:
@@ -632,9 +587,6 @@ models:
     last_name: Hayes
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$zFqLIiT/RRVC.wSQZ065xeTsxPlHxJ2HBYVWxpH2GikSkiUFv7QhC"
     remote_avatar_url:
     roles: []
@@ -646,9 +598,6 @@ models:
     last_name: Stehr
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$uR48yypIVWE6np2hRN4kceeFZeJc8hBOCB8534mK/oKU61fB1pVP."
     remote_avatar_url:
     roles: []
@@ -660,9 +609,6 @@ models:
     last_name: Flatley
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$L91ykn5UGZeZ59j57Ai.gOoLC/wQ3suSQ.Q6c9k.hIErR2TvY8s4a"
     remote_avatar_url:
     roles: []
@@ -674,9 +620,6 @@ models:
     last_name: Greenfelder
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$VTHFZHun6iy9HXhGPR/xyuz/DWyDeS4QkXrmArhmsKTLvMCNVgzjK"
     remote_avatar_url:
     roles: []
@@ -688,9 +631,6 @@ models:
     last_name: Schimmel
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$T9gaXQEjp3wctbZrWlr/U.VezpM31prSfL3P6Nk/Vx0oOmJLY4l7."
     remote_avatar_url:
     roles:
@@ -703,9 +643,6 @@ models:
     last_name:
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password_digest: "$2a$10$xfxVN6QSwzMGy9/RsmYSs./iOUfz8tTZFiQEH5a/WsVxjgC4c9vCa"
     remote_avatar_url:
     roles: []
@@ -720,9 +657,6 @@ models:
     last_name: Expired
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     roles: []
@@ -736,9 +670,6 @@ models:
     last_name: Expired
     locale: en
     bio_multiloc: {}
-    gender:
-    birthyear:
-    domicile:
     password: democracy2.0
     remote_avatar_url:
     roles: []

--- a/back/engines/commercial/analysis/spec/acceptance/stats_users_spec.rb
+++ b/back/engines/commercial/analysis/spec/acceptance/stats_users_spec.rb
@@ -45,7 +45,7 @@ resource 'Analysis - Stats - Users' do
       Area.recreate_custom_field_options
       @somewhere_else_option = cf_domicile.options.left_joins(:area).find_by(areas: { id: nil })
 
-      authors = [@area1.id, @area1.id, @area2.id, nil, 'outside'].map { |domicile| create(:user, domicile: domicile) }
+      authors = [@area1.id, @area1.id, @area2.id, nil, 'outside'].map { |domicile| create(:user, custom_field_values: { 'domicile' => domicile }) }
       create(:idea, project: project, author: authors[0], likes_count: 5)
       create(:idea, project: project, author: authors[0], likes_count: 5)
       create(:idea, project: project, author: authors[1], likes_count: 5)
@@ -78,8 +78,8 @@ resource 'Analysis - Stats - Users' do
 
     before do
       birthyears = [1962, 1976, 1980, 1990, 1991]
-      authors = birthyears.map { |year| create(:user, birthyear: year) }
-      author_without_birthyear = create(:user, birthyear: nil)
+      authors = birthyears.map { |year| create(:user, custom_field_values: { 'birthyear' => year }) }
+      author_without_birthyear = create(:user, custom_field_values: { 'birthyear' => nil })
       create(:idea, project: project, author: authors[0])
       create(:idea, project: project, author: authors[1])
       create(:idea, project: project, author: authors[2])

--- a/back/engines/commercial/analytics/spec/acceptance/analytics_participations_spec.rb
+++ b/back/engines/commercial/analytics/spec/acceptance/analytics_participations_spec.rb
@@ -33,14 +33,14 @@ resource 'Analytics - FactParticipations' do
         create(:dimension_type, name: type[:name], parent: type[:parent])
       end
 
-      male = create(:user, gender: 'male')
-      female = create(:user, gender: 'female')
-      _unspecified = create(:user, gender: 'unspecified')
+      male = create(:user, custom_field_values: { 'gender' => 'male' })
+      female = create(:user, custom_field_values: { 'gender' => 'female' })
+      _unspecified = create(:user, custom_field_values: { 'gender' => 'unspecified' })
 
       # Create participations (3 by citizens, 1 by admin)
       idea = create(:idea, created_at: times[0], author: male)
       create(:comment, created_at: times[2], idea: idea, author: female)
-      create(:reaction, created_at: times[3], user: create(:admin, gender: 'female'), reactable: idea)
+      create(:reaction, created_at: times[3], user: create(:admin, custom_field_values: { 'gender' => 'female' }), reactable: idea)
     end
 
     example 'group participations by month' do

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/auth0/auth0_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/auth0/auth0_verification.rb
@@ -42,7 +42,7 @@ module CustomIdMethods::Auth0
       []
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bogus/bogus_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bogus/bogus_verification.rb
@@ -62,7 +62,7 @@ module CustomIdMethods::Bogus
       [:last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       [:gender]
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bogus/bogus_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bogus/bogus_verification.rb
@@ -51,9 +51,7 @@ module CustomIdMethods::Bogus
           attributes: {
             last_name: 'BOGUS'
           },
-          custom_field_values: {
-            gender: 'female'
-          }
+          custom_field_values: gender_key ? { gender_key => 'female' } : {}
         }
       end
     end
@@ -63,7 +61,14 @@ module CustomIdMethods::Bogus
     end
 
     def locked_custom_fields_keys
-      [:gender]
+      [gender_key].compact
+    end
+
+    private
+
+    # The key of the gender field is not necessarily 'gender', so we look it up by code
+    def gender_key
+      CustomField.registration.find_by(code: 'gender')&.key
     end
   end
 end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bosa_fas/bosa_fas_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/bosa_fas/bosa_fas_verification.rb
@@ -36,7 +36,7 @@ module CustomIdMethods::BosaFas
       %i[first_name last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/clave_unica/clave_unica_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/clave_unica/clave_unica_omniauth.rb
@@ -75,7 +75,7 @@ module CustomIdMethods::ClaveUnica
       super + %i[first_name last_name custom_field_values]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       %i[rut_verified]
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/clave_unica/clave_unica_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/clave_unica/clave_unica_verification.rb
@@ -42,7 +42,7 @@ module CustomIdMethods::ClaveUnica
       %i[first_name last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/criipto/criipto_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/criipto/criipto_verification.rb
@@ -135,7 +135,7 @@ module CustomIdMethods::Criipto
     end
 
     def updateable_user_attrs
-      super + %i[custom_field_values birthyear]
+      super + %i[custom_field_values]
     end
   end
 end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/criipto/criipto_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/criipto/criipto_verification.rb
@@ -127,7 +127,7 @@ module CustomIdMethods::Criipto
       []
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       [
         config[:birthday_custom_field_key].presence,
         config[:birthyear_custom_field_key].presence

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/facebook/facebook_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/facebook/facebook_omniauth.rb
@@ -62,12 +62,13 @@ module CustomIdMethods::Facebook
         last_name: auth.info['last_name'],
         email: auth.info['email'],
         locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale),
-        remote_avatar_url: remote_avatar_url(auth)
+        remote_avatar_url: remote_avatar_url(auth),
+        custom_field_values: {}
       }
 
       gender = auth.extra.raw_info&.gender
       if gender
-        user_attrs[:gender] = gender
+        user_attrs[:custom_field_values]['gender'] = gender
       else
         Rails.logger.info "Gender was not provided by facebook, auth instance was #{auth}"
       end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/facebook/facebook_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/facebook/facebook_omniauth.rb
@@ -68,7 +68,8 @@ module CustomIdMethods::Facebook
 
       gender = auth.extra.raw_info&.gender
       if gender
-        user_attrs[:custom_field_values]['gender'] = gender
+        gender_key = CustomField.registration.find_by(code: 'gender')&.key
+        user_attrs[:custom_field_values][gender_key] = gender if gender_key
       else
         Rails.logger.info "Gender was not provided by facebook, auth instance was #{auth}"
       end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
@@ -19,10 +19,13 @@ module CustomIdMethods::FakeSso
     def profile_to_user_attrs(auth)
       birthdate = auth.extra.raw_info['birthdate']
 
-      custom_field_values = {
-        'gender' => auth.extra.raw_info['gender'],
-        'birthyear' => (Date.parse(birthdate).year if birthdate.present?)
-      }.compact
+      keys = CustomField.registration.keys_by_code(%w[gender birthyear])
+      custom_field_values = {}
+      custom_field_values[keys['gender']] = auth.extra.raw_info['gender'] if keys['gender']
+      if keys['birthyear'] && birthdate.present?
+        custom_field_values[keys['birthyear']] = Date.parse(birthdate).year
+      end
+      custom_field_values.compact!
 
       {
         first_name: auth.info['first_name'],

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
@@ -17,12 +17,18 @@ module CustomIdMethods::FakeSso
     end
 
     def profile_to_user_attrs(auth)
+      birthdate = auth.extra.raw_info['birthdate']
+
+      custom_field_values = {
+        'gender' => auth.extra.raw_info['gender'],
+        'birthyear' => (Date.parse(birthdate).year if birthdate.present?)
+      }.compact
+
       {
         first_name: auth.info['first_name'],
         email: auth.info['email'],
         last_name: auth.info['last_name'],
-        gender: auth.extra.raw_info['gender'],
-        birthyear: Date.parse(auth.extra.raw_info['birthdate']).year
+        custom_field_values: custom_field_values
       }
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_verification.rb
@@ -37,11 +37,11 @@ module CustomIdMethods::FakeSso
       %i[email]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       %i[gender birthyear]
     end
 
-    def other_custom_fields
+    def other_custom_fields_keys
       []
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_verification.rb
@@ -38,7 +38,7 @@ module CustomIdMethods::FakeSso
     end
 
     def locked_custom_fields_keys
-      %i[gender birthyear]
+      CustomField.registration.keys_by_code(%w[gender birthyear]).values_at('gender', 'birthyear').compact
     end
 
     def other_custom_fields_keys

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/federa/federa_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/federa/federa_omniauth.rb
@@ -43,8 +43,9 @@ module CustomIdMethods::Federa
       custom_field_values = {}
 
       birthdate = attrs['dataNascita']
-      if birthdate.present? && CustomField.find_by(key: 'birthyear')
-        custom_field_values['birthyear'] = Date.parse(birthdate).year
+      birthyear_key = CustomField.registration.find_by(code: 'birthyear')&.key
+      if birthdate.present? && birthyear_key
+        custom_field_values[birthyear_key] = Date.parse(birthdate).year
       end
 
       # NOTE: Attribute not currently returned by Federa

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/federa/federa_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/federa/federa_verification.rb
@@ -58,7 +58,7 @@ module CustomIdMethods::Federa
       %i[first_name last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
@@ -40,13 +40,15 @@ module CustomIdMethods::Franceconnect
         remote_avatar_url: auth.info['image']
       }.tap do |attrs|
         custom_fields = CustomField.registration.enabled.pluck(:code)
+        custom_field_values = {}
         if custom_fields.include?('birthyear')
           birthdate = auth.extra.raw_info.birthdate
-          attrs[:birthyear] = Date.parse(birthdate).year if birthdate.present?
+          custom_field_values['birthyear'] = Date.parse(birthdate).year if birthdate.present?
         end
         if custom_fields.include?('gender')
-          attrs[:gender] = auth.extra.raw_info.gender
+          custom_field_values['gender'] = auth.extra.raw_info.gender
         end
+        attrs[:custom_field_values] = custom_field_values.compact
       end
     end
 
@@ -117,7 +119,7 @@ module CustomIdMethods::Franceconnect
     end
 
     def updateable_user_attrs
-      super + %i[first_name last_name birthyear gender remote_avatar_url]
+      super + %i[first_name last_name custom_field_values remote_avatar_url]
     end
 
     # To make this method return false and so to reproduce merging error, you need:

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_omniauth.rb
@@ -39,14 +39,14 @@ module CustomIdMethods::Franceconnect
         locale: AppConfiguration.instance.closest_locale_to('fr-FR'),
         remote_avatar_url: auth.info['image']
       }.tap do |attrs|
-        custom_fields = CustomField.registration.enabled.pluck(:code)
+        keys = CustomField.registration.enabled.keys_by_code(%w[birthyear gender])
         custom_field_values = {}
-        if custom_fields.include?('birthyear')
+        if keys['birthyear']
           birthdate = auth.extra.raw_info.birthdate
-          custom_field_values['birthyear'] = Date.parse(birthdate).year if birthdate.present?
+          custom_field_values[keys['birthyear']] = Date.parse(birthdate).year if birthdate.present?
         end
-        if custom_fields.include?('gender')
-          custom_field_values['gender'] = auth.extra.raw_info.gender
+        if keys['gender']
+          custom_field_values[keys['gender']] = auth.extra.raw_info.gender
         end
         attrs[:custom_field_values] = custom_field_values.compact
       end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/franceconnect/franceconnect_verification.rb
@@ -65,7 +65,7 @@ module CustomIdMethods::Franceconnect
       %i[first_name last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
   end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/gent_rrn/gent_rrn_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/gent_rrn/gent_rrn_verification.rb
@@ -50,7 +50,7 @@ module CustomIdMethods::GentRrn
       }
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       [config[:custom_field_key]]
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
@@ -60,7 +60,7 @@ module CustomIdMethods::Google
         email: auth.info['email'],
         remote_avatar_url: remote_avatar_url(auth),
         locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale),
-        custom_field_values: { 'gender' => auth.extra.raw_info.gender }.compact
+        custom_field_values: gender_custom_field_values(auth)
       }
     end
 
@@ -73,6 +73,14 @@ module CustomIdMethods::Google
     end
 
     private
+
+    def gender_custom_field_values(auth)
+      key = CustomField.registration.find_by(code: 'gender')&.key
+      gender = auth.extra.raw_info.gender
+      return {} if key.nil? || gender.nil?
+
+      { key => gender }
+    end
 
     def remote_avatar_url(auth)
       return unless AppConfiguration.instance.feature_activated?('user_avatars')

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
@@ -59,8 +59,8 @@ module CustomIdMethods::Google
         last_name: auth.info['last_name'],
         email: auth.info['email'],
         remote_avatar_url: remote_avatar_url(auth),
-        gender: auth.extra.raw_info.gender,
-        locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale)
+        locale: AppConfiguration.instance.closest_locale_to(auth.extra.raw_info.locale),
+        custom_field_values: { 'gender' => auth.extra.raw_info.gender }.compact
       }
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/hoplr/hoplr_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/hoplr/hoplr_omniauth.rb
@@ -115,7 +115,7 @@ module CustomIdMethods::Hoplr
       super + %i[first_name last_name custom_field_values]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       %i[neighbourhood]
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/id_austria/id_austria_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/id_austria/id_austria_verification.rb
@@ -55,7 +55,7 @@ module CustomIdMethods::IdAustria
       %i[first_name last_name]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
 

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/nemlog_in/nemlog_in_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/nemlog_in/nemlog_in_omniauth.rb
@@ -110,7 +110,7 @@ module CustomIdMethods::NemlogIn
       super + %i[custom_field_values]
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       [
         :municipality_code,
         config[:birthday_custom_field_key].presence,

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/oostende_rrn/oostende_rrn_verification.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/oostende_rrn/oostende_rrn_verification.rb
@@ -36,7 +36,7 @@ module CustomIdMethods::OostendeRrn
       }
     end
 
-    def locked_custom_fields
+    def locked_custom_fields_keys
       []
     end
 

--- a/back/engines/commercial/custom_id_methods/spec/acceptance/bogus_verification_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/acceptance/bogus_verification_spec.rb
@@ -16,7 +16,9 @@ resource 'Verifications' do
       enabled: true,
       id_methods: [{ name: 'bogus' }]
     }
-    create(:custom_field, key: 'gender')
+    # The key of the gender field is deliberately different from its code, since
+    # bogus should locate the field by code and write to its key
+    create(:custom_field, key: 'geslacht', code: 'gender')
     configuration.save!
   end
 
@@ -32,7 +34,7 @@ resource 'Verifications' do
         assert_status 201
         expect(@user.reload.verified).to be true
         expect(@user.last_name).to eq 'BOGUS'
-        expect(@user.custom_field_values['gender']).to eq 'female'
+        expect(@user.custom_field_values['geslacht']).to eq 'female'
       end
     end
 
@@ -45,7 +47,7 @@ resource 'Verifications' do
         assert_status 201
         expect(@user.reload.verified).to be true
         expect(@user.last_name).to eq 'BOGUS'
-        expect(@user.custom_field_values['gender']).to eq 'female'
+        expect(@user.custom_field_values['geslacht']).to eq 'female'
       end
     end
 

--- a/back/engines/commercial/custom_id_methods/spec/lib/federa_omniauth_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/lib/federa_omniauth_spec.rb
@@ -32,7 +32,7 @@ describe CustomIdMethods::Federa::FederaOmniauth do
 
     before do
       # Create user custom fields that will be filled by the auth hash
-      create(:custom_field, key: 'birthyear', resource_type: 'User')
+      create(:custom_field_birthyear)
       create(:custom_field, key: 'municipality_code', resource_type: 'User')
     end
 

--- a/back/engines/commercial/custom_id_methods/spec/lib/google_omniauth_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/lib/google_omniauth_spec.rb
@@ -7,6 +7,7 @@ describe CustomIdMethods::Google::GoogleOmniauth do
 
   describe 'profile_to_user_attrs' do
     it 'correctly interprets gender, locale and image for google' do
+      create(:custom_field_gender)
       auth = OmniAuth::AuthHash.new(
         provider: 'google',
         info: {

--- a/back/engines/commercial/custom_id_methods/spec/lib/google_omniauth_spec.rb
+++ b/back/engines/commercial/custom_id_methods/spec/lib/google_omniauth_spec.rb
@@ -28,7 +28,7 @@ describe CustomIdMethods::Google::GoogleOmniauth do
 
       expect(user_attrs).to include({
         locale: 'fr-FR',
-        gender: 'female',
+        custom_field_values: { 'gender' => 'female' },
         remote_avatar_url: 'http://www.josnet.com/my-picture'
       })
     end

--- a/back/engines/commercial/report_builder/spec/acceptance/graph_data_units_spec.rb
+++ b/back/engines/commercial/report_builder/spec/acceptance/graph_data_units_spec.rb
@@ -58,9 +58,9 @@ resource 'Graph data units' do
 
     # With the current implementation, registration_completed_at is used to filter users by startAt/endAt.
     # But the participation date can be used instead in the future (Idea#created_at).
-    participant = create(:user, gender: @gender, registration_completed_at: filtered_date)
+    participant = create(:user, custom_field_values: { 'gender' => @gender }, registration_completed_at: filtered_date)
     create(:idea, project: project, created_at: filtered_date, author: participant)
-    _not_returned_idea = create(:idea, project: create(:project), created_at: filtered_date, author: create(:user, gender: @gender))
+    _not_returned_idea = create(:idea, project: create(:project), created_at: filtered_date, author: create(:user, custom_field_values: { 'gender' => @gender }))
   end
 
   def expected_series

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/r_scores_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/r_scores_spec.rb
@@ -93,7 +93,7 @@ resource 'R-scores (Representativeness scores)' do
 
           before do
             birthyears = [1970, 1980, 1990, 2000]
-            _users = birthyears.map { |year| create(:user, birthyear: year) }
+            _users = birthyears.map { |year| create(:user, custom_field_values: { 'birthyear' => year }) }
           end
 
           example 'returns the R-score' do

--- a/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/acceptance/stats_users_spec.rb
@@ -445,8 +445,8 @@ resource 'Stats - Users' do
 
       travel_to start_at + 16.days do
         birthyears = [1962, 1976, 1980, 1990, 1991, 2005, 2006]
-        users = birthyears.map { |year| create(:user, birthyear: year) }
-        user_without_birthyear = create(:user, birthyear: nil)
+        users = birthyears.map { |year| create(:user, custom_field_values: { 'birthyear' => year }) }
+        user_without_birthyear = create(:user, custom_field_values: { 'birthyear' => nil })
 
         @group = create_group(users + [user_without_birthyear])
       end

--- a/back/engines/commercial/user_custom_fields/spec/models/user_custom_fields/representativeness/binned_distribution_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/models/user_custom_fields/representativeness/binned_distribution_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe UserCustomFields::Representativeness::BinnedDistribution do
 
     let(:users) do
       birthyears = [2000, 1950]
-      users = birthyears.map { |year| create(:user, birthyear: year) }
+      users = birthyears.map { |year| create(:user, custom_field_values: { 'birthyear' => year }) }
       # Users without year of birth should not affect the score.
       users << create(:user)
       User.where(id: users)

--- a/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UserCustomFields::FieldValueCounter do
 
       before do
         # Create user with invalid value for gender custom field.
-        user = build(:user, gender: 'unicorn')
+        user = build(:user, custom_field_values: { 'gender' => 'unicorn' })
         user.save!(validate: false)
       end
 
@@ -33,7 +33,7 @@ RSpec.describe UserCustomFields::FieldValueCounter do
         # Domicile field must be created before the user, otherwise the user is not
         # valid.
         @domicile_field = create(:custom_field_domicile)
-        create(:user, domicile: area.id)
+        create(:user, custom_field_values: { 'domicile' => area.id })
       end
 
       context 'and custom field is domicile' do
@@ -59,7 +59,7 @@ RSpec.describe UserCustomFields::FieldValueCounter do
         # Regression test. For the test to be effective, we need at least one user with
         # domicile. The code expected option keys, while domicile field uses area ids in
         # custom_field_values. This resulted in warnings about unknown option keys.
-        create(:user, domicile: areas.first.id)
+        create(:user, custom_field_values: { 'domicile' => areas.first.id })
         expect(ErrorReporter).not_to receive(:report)
         counts
       end

--- a/back/lib/id_methods/base.rb
+++ b/back/lib/id_methods/base.rb
@@ -54,6 +54,16 @@ module IdMethods
     end
 
     # Extracts user attributes from the Omniauth response auth.
+    #
+    # Custom fields MUST always be returned nested under the `:custom_field_values`
+    # key, never as top-level attributes. `User` exposes `store_accessor`s for
+    # :gender, :birthyear and :domicile, so returning those flat happens to work
+    # when creating a user, but it breaks on every other path: they are dropped by
+    # the `updateable_user_attrs` slice on re-login, and they cannot be merged with
+    # the custom fields a user already has. Only real `users` columns
+    # (:first_name, :email, :locale, :remote_avatar_url, :unique_code, ...) belong
+    # at the top level.
+    #
     # @param [OmniAuth::AuthHash] auth
     # @return [Hash] The user attributes
     def profile_to_user_attrs(_auth)

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -1768,7 +1768,7 @@ resource 'Users' do
             expect(response_status).to eq 200
             @user.reload
             expect(@user.locale).to eq locale
-            expect(@user.birthyear).to eq birthyear
+            expect(@user.custom_field_values['birthyear']).to eq birthyear
           end
         end
 

--- a/back/spec/factories/users.rb
+++ b/back/spec/factories/users.rb
@@ -41,8 +41,12 @@ FactoryBot.define do
     end
 
     factory :user_with_demographics do
-      gender { ['male', 'female', 'unspecified', nil][rand(4)] }
-      birthyear { rand(2) == 0 ? (Time.now.year - 12 - rand(100)) : nil }
+      custom_field_values do
+        {
+          'gender' => ['male', 'female', 'unspecified', nil][rand(4)],
+          'birthyear' => (rand(2) == 0 ? (Time.now.year - 12 - rand(100)) : nil)
+        }.compact
+      end
     end
 
     factory :sso_user do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -250,14 +250,6 @@ RSpec.describe User do
       user.update_merging_custom_fields!({ first_name: 'Jos', custom_field_values: { 'birthyear' => 1990 } })
       expect(user.reload.first_name).to eq 'Jos'
     end
-
-    # `store_accessor` attributes write into `custom_field_values` themselves, so
-    # they used to be silently discarded by the subsequent merge assignment.
-    it 'does not discard store_accessor attributes' do
-      user.update_merging_custom_fields!({ birthyear: 1990, gender: 'male' })
-      expect(user.reload.custom_field_values)
-        .to eq({ 'domicile' => 'outside', 'gender' => 'male', 'birthyear' => 1990 })
-    end
   end
 
   describe 'blocked?' do
@@ -694,47 +686,47 @@ RSpec.describe User do
     end
 
     it '(gender) is valid when male, female or unspecified' do
-      expect(build(:user, gender: 'male')).to be_valid
-      expect(build(:user, gender: 'female')).to be_valid
-      expect(build(:user, gender: 'unspecified')).to be_valid
+      expect(build(:user, custom_field_values: { 'gender' => 'male' })).to be_valid
+      expect(build(:user, custom_field_values: { 'gender' => 'female' })).to be_valid
+      expect(build(:user, custom_field_values: { 'gender' => 'unspecified' })).to be_valid
     end
 
     it '(gender) is invalid when not male, female or unspecified' do
-      user = build(:user, gender: 'somethingelse')
+      user = build(:user, custom_field_values: { 'gender' => 'somethingelse' })
       expect { user.valid? }.to(change { user.errors[:gender] })
     end
 
     it '(birthyear) is valid when in realistic range' do
-      expect(build(:user, birthyear: (Time.now.year - 117))).to be_valid
-      expect(build(:user, birthyear: (Time.now.year - 13))).to be_valid
+      expect(build(:user, custom_field_values: { 'birthyear' => (Time.now.year - 117) })).to be_valid
+      expect(build(:user, custom_field_values: { 'birthyear' => (Time.now.year - 13) })).to be_valid
     end
 
     it '(birthyear) is invalid when unrealistic' do
-      user = build(:user, birthyear: Time.now.year + 1)
+      user = build(:user, custom_field_values: { 'birthyear' => Time.now.year + 1 })
       expect { user.valid? }.to(change { user.errors[:birthyear] })
-      user = build(:user, birthyear: 1850)
+      user = build(:user, custom_field_values: { 'birthyear' => 1850 })
       expect { user.valid? }.to(change { user.errors[:birthyear] })
-      user = build(:user, birthyear: 'eighteen hundred')
+      user = build(:user, custom_field_values: { 'birthyear' => 'eighteen hundred' })
       expect { user.valid? }.to(change { user.errors[:birthyear] })
     end
 
     it '(birthyear) is invalid when not an integer' do
-      user = build(:user, birthyear: 'eighteen hundred')
+      user = build(:user, custom_field_values: { 'birthyear' => 'eighteen hundred' })
       expect { user.valid? }.to(change { user.errors[:birthyear] })
-      user = build(:user, birthyear: 1930.4)
+      user = build(:user, custom_field_values: { 'birthyear' => 1930.4 })
       expect { user.valid? }.to(change { user.errors[:birthyear] })
     end
 
     it "(domicile) is valid when an area id or 'outside'" do
       create_list(:area, 5)
-      expect(build(:user, domicile: Area.offset(rand(5)).first.id)).to be_valid
-      expect(build(:user, domicile: 'outside')).to be_valid
+      expect(build(:user, custom_field_values: { 'domicile' => Area.offset(rand(5)).first.id })).to be_valid
+      expect(build(:user, custom_field_values: { 'domicile' => 'outside' })).to be_valid
     end
 
     it "(domicile) is invalid when not an area id or 'outside'" do
-      user = build(:user, domicile: 'somethingelse')
+      user = build(:user, custom_field_values: { 'domicile' => 'somethingelse' })
       expect { user.valid? }.to(change { user.errors[:domicile] })
-      user = build(:user, domicile: 5)
+      user = build(:user, custom_field_values: { 'domicile' => 5 })
       expect { user.valid? }.to(change { user.errors[:domicile] })
     end
   end

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -231,24 +231,30 @@ RSpec.describe User do
     end
   end
 
-  describe '#update_merging_custom_fields!' do
+  describe '#merge_custom_field_values' do
     let(:user) { create(:user, custom_field_values: { 'domicile' => 'outside', 'gender' => 'female' }) }
 
-    it 'merges nested custom_field_values into the existing ones' do
-      user.update_merging_custom_fields!({ custom_field_values: { 'birthyear' => 1990 } })
-      expect(user.reload.custom_field_values)
+    it 'merges the given values into the existing ones' do
+      user.merge_custom_field_values({ 'birthyear' => 1990 })
+      expect(user.custom_field_values)
         .to eq({ 'domicile' => 'outside', 'gender' => 'female', 'birthyear' => 1990 })
     end
 
     it 'overwrites only the custom fields it is given' do
-      user.update_merging_custom_fields!({ custom_field_values: { 'gender' => 'male' } })
-      expect(user.reload.custom_field_values)
+      user.merge_custom_field_values({ 'gender' => 'male' })
+      expect(user.custom_field_values)
         .to eq({ 'domicile' => 'outside', 'gender' => 'male' })
     end
 
-    it 'assigns regular attributes as well' do
-      user.update_merging_custom_fields!({ first_name: 'Jos', custom_field_values: { 'birthyear' => 1990 } })
-      expect(user.reload.first_name).to eq 'Jos'
+    it 'accepts symbol keys' do
+      user.merge_custom_field_values({ birthyear: 1990 })
+      expect(user.custom_field_values)
+        .to eq({ 'domicile' => 'outside', 'gender' => 'female', 'birthyear' => 1990 })
+    end
+
+    it 'leaves the existing values alone when given nothing' do
+      user.merge_custom_field_values({})
+      expect(user.custom_field_values).to eq({ 'domicile' => 'outside', 'gender' => 'female' })
     end
   end
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -231,6 +231,35 @@ RSpec.describe User do
     end
   end
 
+  describe '#update_merging_custom_fields!' do
+    let(:user) { create(:user, custom_field_values: { 'domicile' => 'outside', 'gender' => 'female' }) }
+
+    it 'merges nested custom_field_values into the existing ones' do
+      user.update_merging_custom_fields!({ custom_field_values: { 'birthyear' => 1990 } })
+      expect(user.reload.custom_field_values)
+        .to eq({ 'domicile' => 'outside', 'gender' => 'female', 'birthyear' => 1990 })
+    end
+
+    it 'overwrites only the custom fields it is given' do
+      user.update_merging_custom_fields!({ custom_field_values: { 'gender' => 'male' } })
+      expect(user.reload.custom_field_values)
+        .to eq({ 'domicile' => 'outside', 'gender' => 'male' })
+    end
+
+    it 'assigns regular attributes as well' do
+      user.update_merging_custom_fields!({ first_name: 'Jos', custom_field_values: { 'birthyear' => 1990 } })
+      expect(user.reload.first_name).to eq 'Jos'
+    end
+
+    # `store_accessor` attributes write into `custom_field_values` themselves, so
+    # they used to be silently discarded by the subsequent merge assignment.
+    it 'does not discard store_accessor attributes' do
+      user.update_merging_custom_fields!({ birthyear: 1990, gender: 'male' })
+      expect(user.reload.custom_field_values)
+        .to eq({ 'domicile' => 'outside', 'gender' => 'male', 'birthyear' => 1990 })
+    end
+  end
+
   describe 'blocked?' do
     let!(:user1) { create(:user, block_end_at: 1.day.from_now) }
     let!(:user2) { create(:user, block_end_at: 5.minutes.ago) }

--- a/back/spec/services/export/geojson/value_visitor_spec.rb
+++ b/back/spec/services/export/geojson/value_visitor_spec.rb
@@ -14,6 +14,7 @@ describe Export::Geojson::ValueVisitor do
       let(:field) do
         create(
           :custom_field,
+          :for_custom_form,
           input_type: 'number',
           key: 'proposed_budget',
           code: 'proposed_budget'
@@ -119,7 +120,7 @@ describe Export::Geojson::ValueVisitor do
         let(:resource_type) { 'User' }
         let(:code) { 'domicile' }
         let(:field_key) { :domicile }
-        let(:model) { create(:user, field_key => value) }
+        let(:model) { create(:user, custom_field_values: { field_key.to_s => value }.compact) }
 
         context 'when there is no value' do
           let(:value) { nil }

--- a/back/spec/services/export/xlsx/value_visitor_spec.rb
+++ b/back/spec/services/export/xlsx/value_visitor_spec.rb
@@ -16,6 +16,7 @@ describe Export::Xlsx::ValueVisitor do
       let(:field) do
         create(
           :custom_field,
+          :for_custom_form,
           input_type: 'number',
           key: 'proposed_budget',
           code: 'proposed_budget'
@@ -205,7 +206,7 @@ describe Export::Xlsx::ValueVisitor do
         let(:resource_type) { 'User' }
         let(:code) { 'domicile' }
         let(:field_key) { :domicile }
-        let(:model) { create(:user, field_key => value) }
+        let(:model) { create(:user, custom_field_values: { field_key.to_s => value }.compact) }
 
         context 'when there is no value' do
           let(:value) { nil }

--- a/back/spec/services/permissions/phase_permissions_service_actions_spec.rb
+++ b/back/spec/services/permissions/phase_permissions_service_actions_spec.rb
@@ -154,7 +154,7 @@ describe Permissions::PhasePermissionsService do
       end
 
       context 'for a verified user' do
-        let(:user) { create(:user, verified: true, birthyear: 2008) }
+        let(:user) { create(:user, verified: true, custom_field_values: { 'birthyear' => 2008 }) }
 
         it 'returns nil' do
           permission = project.phases.first.permissions.find_by(action: 'posting_idea')

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -54,7 +54,7 @@ describe SideFxUserService do
 
     it 'creates a follower for the domicile' do
       area = create(:area)
-      user = create(:user, domicile: area.id)
+      user = create(:user, custom_field_values: { 'domicile' => area.id })
 
       expect do
         service.after_create user, user
@@ -211,7 +211,7 @@ describe SideFxUserService do
 
     it 'creates a follower for the domicile' do
       area = create(:area)
-      user.update!(domicile: area.id)
+      user.update!(custom_field_values: { 'domicile' => area.id })
 
       expect do
         service.after_update user, user

--- a/back/spec/services/side_fx_user_service_spec.rb
+++ b/back/spec/services/side_fx_user_service_spec.rb
@@ -53,6 +53,7 @@ describe SideFxUserService do
     end
 
     it 'creates a follower for the domicile' do
+      create(:custom_field_domicile)
       area = create(:area)
       user = create(:user, custom_field_values: { 'domicile' => area.id })
 
@@ -210,6 +211,7 @@ describe SideFxUserService do
     end
 
     it 'creates a follower for the domicile' do
+      create(:custom_field_domicile)
       area = create(:area)
       user.update!(custom_field_values: { 'domicile' => area.id })
 

--- a/back/spec/services/user_service_spec.rb
+++ b/back/spec/services/user_service_spec.rb
@@ -330,6 +330,15 @@ describe UserService do
       expect(user.invite_status).to eq 'accepted'
     end
 
+    it 'merges the custom fields from the SSO into the ones set by the invite' do
+      user = create(:invited_user, custom_field_values: { 'domicile' => 'outside', 'gender' => 'female' })
+
+      service.assign_params_in_accept_invite(user, { custom_field_values: { 'birthyear' => 1990 } })
+
+      expect(user.custom_field_values)
+        .to eq({ 'domicile' => 'outside', 'gender' => 'female', 'birthyear' => 1990 })
+    end
+
     context 'when confirm_user is true' do
       it 'confirms the user email' do
         user = create(:invited_user)

--- a/back/spec/services/verification/verification_service_spec.rb
+++ b/back/spec/services/verification/verification_service_spec.rb
@@ -158,11 +158,11 @@ describe Verification::VerificationService do
     end
   end
 
-  describe 'locked_custom_fields' do
+  describe 'locked_custom_fields_keys' do
     context 'for a user only authenticated with facebook' do
       it 'returns no locked custom field keys' do
         identity = create(:facebook_identity)
-        expect(service.locked_custom_fields(identity.user)).to eq []
+        expect(service.locked_custom_fields_keys(identity.user)).to eq []
       end
     end
 
@@ -170,12 +170,12 @@ describe Verification::VerificationService do
       it 'returns some locked custom field keys when the custom field exists' do
         create(:custom_field_gender)
         verification = create(:verification, method_name: 'bogus')
-        expect(service.locked_custom_fields(verification.user)).to contain_exactly(:gender)
+        expect(service.locked_custom_fields_keys(verification.user)).to contain_exactly(:gender)
       end
 
       it 'does not return locked custom field keys when the field does not exist' do
         verification = create(:verification, method_name: 'bogus')
-        expect(service.locked_custom_fields(verification.user)).to be_empty
+        expect(service.locked_custom_fields_keys(verification.user)).to be_empty
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Technical
- For some reason, the omniauth configs would sometimes return attributes as a flat object, and sometimes as an object, leading half-broken behavior in either case. Now we always require them to be an object.
- Remove weird gender, birthyear and domicile accessor behavior. Now they are just treated as all custom fields and saved and accessed as such