### PR TITLE
Fix Frankfurt post-deployment step

### DIFF
--- a/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
+++ b/back/engines/free/email_campaigns/app/controllers/email_campaigns/web_api/v1/campaigns_controller.rb
@@ -25,8 +25,14 @@ module EmailCampaigns
         @campaigns = @campaigns.where(id: supported_ids)
       end
 
+      delivery_service = EmailCampaigns::DeliveryService.new
+
+      # Records of campaigns whose feature is deactivated are kept around (they come back
+      # when the feature does), but they have no business in the admin dashboard meanwhile.
+      @campaigns = @campaigns.where(type: delivery_service.campaign_types)
+
       # Filter out campaigns that are hidden from the admin dashboard (e.g. the phone confirmation OTP campaign)
-      @campaigns = @campaigns.where.not(type: EmailCampaigns::DeliveryService.new.hidden_from_admin_campaign_types)
+      @campaigns = @campaigns.where.not(type: delivery_service.hidden_from_admin_campaign_types)
 
       @campaigns = case parse_bool(params[:manual])
       when true then manual_order(@campaigns.manual)

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/assure_campaigns_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/assure_campaigns_service.rb
@@ -21,24 +21,34 @@ module EmailCampaigns
 
     ## Removes the DB records of removed STI classes
     def remove_deprecated_campaigns
-      supported_campaigns = delivery_service.campaign_types
+      # Deliberately the feature-independent list: a campaign whose feature is switched
+      # off is dormant, not deprecated. Only types that no longer exist in the codebase
+      # are removed here.
+      supported_campaigns = delivery_service.all_campaign_types
       unsupported_ids     = EmailCampaigns::Campaign.where.not(type: supported_campaigns).pluck(:id)
 
       # This makes it possible to temporarily load the records without STI errors
       EmailCampaigns::Campaign.class_eval { self.inheritance_column = :_type_disabled }
 
-      ActiveRecord::Base.transaction do
-        # These have to be deleted manually since EmailCampaigns::Campaign
-        # does not have Trackable and RecipientConfigurable included.
+      begin
+        ActiveRecord::Base.transaction do
+          # These have to be deleted manually since EmailCampaigns::Campaign
+          # does not have Trackable and RecipientConfigurable included.
 
-        EmailCampaigns::CampaignsGroup.where(campaign_id: unsupported_ids).destroy_all
-        EmailCampaigns::Delivery.where(campaign_id: unsupported_ids).destroy_all
-        EmailCampaigns::Campaign.where(id: unsupported_ids).destroy_all
-        # We don't delete the user consents because we may be legally required to do so.
+          EmailCampaigns::CampaignsGroup.where(campaign_id: unsupported_ids).destroy_all
+          EmailCampaigns::Delivery.where(campaign_id: unsupported_ids).destroy_all
+          # Likewise: `dependent: :nullify` is declared on Campaigns::BaseSms, which the
+          # disabled inheritance column above puts out of reach. Unlinking rather than
+          # deleting keeps the delivery record, matching what that association intends.
+          EmailCampaigns::Sms::Delivery.where(campaign_id: unsupported_ids).update_all(campaign_id: nil)
+          EmailCampaigns::Campaign.where(id: unsupported_ids).destroy_all
+          # We don't delete the user consents because we may be legally required to do so.
+        end
+      ensure
+        # Make everything back to normal. In an `ensure` because otherwise a failure above
+        # leaves STI disabled on Campaign for the rest of the process.
+        EmailCampaigns::Campaign.class_eval { self.inheritance_column = :type }
       end
-
-      # Make everything back to normal
-      EmailCampaigns::Campaign.class_eval { self.inheritance_column = :type }
     end
 
     private

--- a/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
+++ b/back/engines/free/email_campaigns/app/services/email_campaigns/delivery_service.rb
@@ -59,6 +59,17 @@ module EmailCampaigns
       Campaigns::YourInputInScreening
     ].freeze
 
+    # Campaign classes that only join `campaign_classes` when the feature that exposes
+    # them is activated. They still exist in the codebase when it isn't, so they are part
+    # of `all_campaign_classes`.
+    FEATURE_GATED_CAMPAIGN_CLASSES = [
+      Campaigns::CommunityMonitorReport,
+      Campaigns::SmsManual,
+      Campaigns::PhoneConfirmation,
+      Campaigns::NewPhoneConfirmation
+    ].freeze
+
+    # The campaigns that may act right now: send, be offered for consent, be created.
     def campaign_classes
       @campaign_classes ||= begin
         classes = CAMPAIGN_CLASSES.deep_dup
@@ -72,18 +83,36 @@ module EmailCampaigns
       end
     end
 
+    # Every campaign class that exists in the codebase, whether or not the feature that
+    # exposes it is currently activated. A campaign whose feature is switched off is
+    # dormant, not deprecated: its records must survive (deleting them would destroy
+    # admin-authored content that should come back the moment the feature returns).
+    # Derived from `campaign_classes` so that engine patches feed both lists.
+    def all_campaign_classes
+      campaign_classes | FEATURE_GATED_CAMPAIGN_CLASSES
+    end
+
     def campaign_types
       campaign_classes.map(&:name)
     end
 
+    def all_campaign_types
+      all_campaign_classes.map(&:name)
+    end
+
+    # Whether a campaign is manual is a property of its class, not of the feature flag,
+    # so this covers dormant campaigns too. `Campaign.automatic` negates this list: were
+    # it feature-dependent, a dormant manual campaign would count as automatic.
     def manual_campaign_types
-      campaign_classes.select { |campaign| campaign.new.manual? }.map(&:name)
+      all_campaign_classes.select { |campaign| campaign.new.manual? }.map(&:name)
     end
 
     # Campaign types that should never surface in the admin campaigns UI
     # (e.g. transactional/internal campaigns like the phone-confirmation OTP).
+    # Feature-independent for the same reason as `manual_campaign_types`: a dormant
+    # OTP campaign must stay hidden rather than appear once its feature is switched off.
     def hidden_from_admin_campaign_types
-      campaign_classes.select { |campaign| campaign.new.hidden_from_admin? }.map(&:name)
+      all_campaign_classes.select { |campaign| campaign.new.hidden_from_admin? }.map(&:name)
     end
 
     def consentable_campaign_types_for(user)

--- a/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
+++ b/back/engines/free/email_campaigns/spec/acceptance/campaigns_spec.rb
@@ -58,11 +58,22 @@ resource 'Campaigns' do
         expect(json_response[:data].size).to eq 2
       end
 
-      example 'List only campaigns of a given channel' do
-        sms_campaign = create(:sms_manual_campaign)
+      context 'with the sms feature enabled' do
+        include_context 'with sms feature enabled'
+
+        example 'List only campaigns of a given channel' do
+          sms_campaign = create(:sms_manual_campaign)
+          do_request(channel: 'sms')
+          json_response = json_parse(response_body)
+          expect(json_response[:data].map { |c| c[:id] }).to contain_exactly(sms_campaign.id)
+        end
+      end
+
+      example 'Does not list campaigns whose feature is deactivated' do
+        create(:sms_manual_campaign) # the sms feature is off here
         do_request(channel: 'sms')
         json_response = json_parse(response_body)
-        expect(json_response[:data].map { |c| c[:id] }).to contain_exactly(sms_campaign.id)
+        expect(json_response[:data]).to be_empty
       end
 
       example 'List all manual campaigns' do

--- a/back/engines/free/email_campaigns/spec/services/email_campaigns/assure_campaigns_service_spec.rb
+++ b/back/engines/free/email_campaigns/spec/services/email_campaigns/assure_campaigns_service_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe EmailCampaigns::AssureCampaignsService do
+  subject(:service) { described_class.new }
+
+  describe '#remove_deprecated_campaigns' do
+    # A type that no longer exists in the codebase, which is the only thing this task
+    # is meant to clean up. Set past validation/STI, the way a removed class leaves it.
+    def deprecate!(campaign)
+      campaign.update_column(:type, 'EmailCampaigns::Campaigns::NoLongerExists')
+      campaign
+    end
+
+    it 'removes campaigns whose type no longer exists in the codebase' do
+      deprecated = deprecate!(create(:manual_campaign))
+      kept = create(:manual_campaign)
+
+      service.remove_deprecated_campaigns
+
+      expect(EmailCampaigns::Campaign.exists?(deprecated.id)).to be false
+      expect(EmailCampaigns::Campaign.exists?(kept.id)).to be true
+    end
+
+    it 'removes the campaign groups and email deliveries of a deprecated campaign' do
+      campaign = create(:manual_campaign)
+      campaigns_group = create(:campaigns_group, campaign: campaign)
+      delivery = create(:delivery, campaign: campaign)
+      deprecate!(campaign)
+
+      service.remove_deprecated_campaigns
+
+      expect(EmailCampaigns::CampaignsGroup.exists?(campaigns_group.id)).to be false
+      expect(EmailCampaigns::Delivery.exists?(delivery.id)).to be false
+    end
+
+    context 'when the sms feature is enabled' do
+      include_context 'with sms feature enabled'
+
+      it 'unlinks (but keeps) the sms deliveries of a deprecated campaign' do
+        campaign = create(:sms_manual_campaign)
+        delivery = create(:sms_delivery, campaign: campaign)
+        deprecate!(campaign)
+
+        service.remove_deprecated_campaigns
+
+        expect(EmailCampaigns::Campaign.exists?(campaign.id)).to be false
+        expect(delivery.reload.campaign_id).to be_nil
+      end
+
+      it 'keeps sms campaigns that are still supported' do
+        campaign = create(:sms_manual_campaign)
+
+        service.remove_deprecated_campaigns
+
+        expect(EmailCampaigns::Campaign.exists?(campaign.id)).to be true
+      end
+    end
+
+    # A campaign whose feature is switched off is dormant, not deprecated. Deleting it
+    # would destroy admin-authored content, and (for sms) trip the foreign key from
+    # sms_deliveries.
+    context 'when a feature is deactivated after its campaigns were created' do
+      it 'keeps the sms campaigns and their deliveries' do
+        SettingsService.new.activate_feature!('sms', settings: {
+          'twilio_account_sid' => 'AC_test',
+          'twilio_auth_token' => 'token',
+          'twilio_messaging_service_sid' => 'MG_test'
+        })
+        campaign = create(:sms_manual_campaign)
+        delivery = create(:sms_delivery, campaign: campaign)
+        SettingsService.new.deactivate_feature!('sms')
+
+        expect { service.remove_deprecated_campaigns }.not_to raise_error
+
+        expect(EmailCampaigns::Campaign.exists?(campaign.id)).to be true
+        expect(delivery.reload.campaign_id).to eq campaign.id
+      end
+
+      it 'keeps the community monitor report campaign' do
+        SettingsService.new.activate_feature!('community_monitor')
+        campaign = create(:community_monitor_report_campaign)
+        SettingsService.new.deactivate_feature!('community_monitor')
+
+        service.remove_deprecated_campaigns
+
+        expect(EmailCampaigns::Campaign.exists?(campaign.id)).to be true
+      end
+    end
+  end
+end

--- a/back/engines/free/email_campaigns/spec/tasks/email_campaigns_task_spec.rb
+++ b/back/engines/free/email_campaigns/spec/tasks/email_campaigns_task_spec.rb
@@ -30,9 +30,13 @@ describe Rake::Task do
     it 'creates the missing campaign records' do
       delivery_service = EmailCampaigns::DeliveryService.new
 
+      # A set difference, not size arithmetic: `manual_campaign_types` is
+      # feature-independent, so it can name types absent from `campaign_types`.
+      instantiatable = delivery_service.campaign_types - delivery_service.manual_campaign_types
+
       expect { task.execute }
         .to change(EmailCampaigns::Campaign, :count)
-        .by(delivery_service.campaign_types.size - delivery_service.manual_campaign_types.size)
+        .by(instantiatable.size)
     end
   end
 end


### PR DESCRIPTION
# Changelog
## Technical
- Make sure that disabling sms FF after having it had enabled and having sent out a campaign does not cause foreign key issues