### PR TITLE
[TAN-8421] Flaky E2E Fix: project_page_voting_single.cy.ts — wait for vote button re-enable after modify

### DIFF
--- a/front/cypress/e2e/project_page_voting_single.cy.ts
+++ b/front/cypress/e2e/project_page_voting_single.cy.ts
@@ -138,6 +138,10 @@ describe('Project with single voting phase', () => {
     cy.get('.e2e-single-vote-button button')
       .should('be.visible')
       .should('have.class', 'primary')
+      // Clicking "Modify your submission" reopens the basket via a mutation,
+      // and the vote buttons stay disabled until it settles — a click in
+      // that window is a no-op and the class never toggles.
+      .should('not.have.class', 'disabled')
       .click()
       .should('have.class', 'primary-outlined');
 


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

Follow-up to #14485, which recurred once in the Aug 7 nightly. The reported error (`#e2e-modify-votes` not found in 30s) was a retry artifact — attempt 1's screenshot shows the test got *past* the modify button and failed one step later: clicking "Modify your submission" reopens the basket via a mutation, and the vote buttons stay `disabled` until it settles. The deselect click landed inside that window as a silent no-op, so the button never toggled to `primary-outlined`; retries then couldn't find `#e2e-modify-votes` because attempt 1 had already un-submitted the basket. This is a third, distinct race that predates #14485 (same lines in the pre-fix spec).

**Why this fixes rather than suppresses:** one added assertion — `.should('not.have.class', 'disabled')` before the deselect click — the same gate the spec already applies to the submit button. The click can no longer fire during the reopen mutation.

**Stability evidence:** [pipeline 346613](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346613) — 3 nodes, 12/12 tests green across the spec.

# Changelog

## Technical

- Fixed a remaining race in the single-voting E2E modify test.