### PR TITLE
[TAN-8465] Flaky E2E Fix: proposals.cy.ts — dock the CTA bar before asserting it

### DIFF
--- a/front/cypress/e2e/admin/phases/proposals.cy.ts
+++ b/front/cypress/e2e/admin/phases/proposals.cy.ts
@@ -59,6 +59,12 @@ describe('Admin: proposal phase', () => {
 
     // Verify proposal phase is created and published
     cy.get('#e2e-project-page').should('contain.text', projectTitleEN);
+    // The CTA bar only mounts once docked — when the phases section pins
+    // under the navbar, or when the page can't scroll at all. This fresh
+    // project page sits within a few pixels of the viewport height, so
+    // whether it ends up scrollable (hiding the undocked bar) flips with
+    // small layout changes. Dock deterministically before asserting.
+    cy.dockProjectCtaBar();
     cy.get('#e2e-ideation-cta-button').should('have.text', 'Add a proposal');
   });
 });


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `admin/phases/proposals.cy.ts`):** since the project-page-builder rework, the CTA bar only mounts once *docked* — when the phases section pins under the navbar, or when the page cannot scroll at all. The test asserted `#e2e-ideation-cta-button` without scrolling, which only ever worked because the fresh project page happened to fit inside the viewport. The page sits within a few pixels of that boundary, so a small layout change (likely #14447, removing the blank no-timeline section band) tipped async widget rendering into sometimes making the page scrollable — and then the whole bar renders nothing (diagnostic probe runs confirmed the bar and both button variants absent for the full timeout). Failed every nightly since Aug 7, and 2–4 of 6 nodes in probe runs.

**Why this fixes rather than suppresses:** `cy.dockProjectCtaBar()` scrolls the phases section under the navbar before asserting — the same deterministic docking helper the voting specs use. The assertion itself is unchanged.

**Stability evidence:** [pipeline 346626](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346626) — 6 nodes, 6/6 green (unfixed baseline the same day: 4/6 and 2/6 red).

# Changelog

## Technical

- Fixed the flaky proposals-phase E2E test by docking the CTA bar before asserting it.