### PR TITLE
[TAN-8456] Bump json gem. Fix for CVE-2026-71847

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -675,7 +675,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     jmespath (1.6.2)
-    json (2.20.0)
+    json (2.21.2)
     json-jwt (1.16.6)
       activesupport (>= 4.2)
       aes_key_wrap


### PR DESCRIPTION
Fixes [back-bundle-audit failure](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346629/workflows/fa27aa7b-0901-434e-ade0-326f8de0e893/jobs/798643)

Possibly not strictly needed, since related vulnerability only an issue if our codebase invokes `JSON::ResumableParser`, which it doesn't _directly_, but I have not ruled out another gem that we use invoking this module (hence, bumping anyway). Ref: https://nvd.nist.gov/vuln/detail/CVE-2026-71847

Bumps to a minor version change and likely low risk. The jump to 2.20 was riskier and we had already done that.

# Changelog
## Technical
- [TAN-8456] Bump json gem. Fix for CVE-2026-71847
