### PR TITLE
[TAN-8457] Flaky E2E Fix: project_preview_link.cy.ts — await token refresh

### DIFF
--- a/front/cypress/e2e/admin/projects/project_preview_link.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_preview_link.cy.ts
@@ -51,8 +51,14 @@ describe('Admin: edit project', () => {
     cy.visit(`admin/projects/${projectId}`);
     cy.get('#e2e-share-link').click();
     cy.get('#e2e-refresh-link').click();
+    // Wait for the token refresh to actually persist before visiting the
+    // old link — a fixed wait raced the request on slow backends, and the
+    // old token then still granted access.
+    cy.intercept('POST', '**/projects/*/refresh_preview_token').as(
+      'refreshToken'
+    );
     cy.get('#e2e-refresh-link-accept').click();
-    cy.wait(1000);
+    cy.wait('@refreshToken').its('response.statusCode').should('eq', 200);
     cy.logout();
 
     cy.visit(link);


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `admin/projects/project_preview_link.cy.ts`):** the invalid-link test refreshes the preview token, sleeps a fixed 1s, logs out, and visits the old link expecting the not-authorized screen. The Aug 3 nightly failure screenshot shows the draft project page rendering for the logged-out visitor instead — the refresh mutation hadn't persisted within the blind 1s wait, so the old token still granted access. The fixed wait also cuts the other way: the test could false-pass on timing luck if invalidation were actually broken.

**Why this fixes rather than suppresses:** the spec now intercepts `POST **/projects/*/refresh_preview_token` and waits for its 200 response before logging out and visiting the old link (the request fires on click, so only the response needs awaiting). The `cy.wait(1000)` is removed; the assertion is unchanged and now deterministic in both directions.

**Stability evidence:** [pipeline 346645](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346645) — 6 nodes, 18/18 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky project-preview-link E2E test by awaiting the token refresh.