### PR TITLE
[TAN-8461] Flaky E2E Fix: idea_new_page.cy.ts — gate submit on enabled state, await creation

### DIFF
--- a/front/cypress/e2e/idea_new_page.cy.ts
+++ b/front/cypress/e2e/idea_new_page.cy.ts
@@ -86,7 +86,19 @@ describe('Idea submission form', () => {
 
     cy.dataCy('e2e-next-page').should('be.visible').click();
     cy.dataCy('e2e-next-page').should('be.visible').click();
+
+    // Submit stays disabled until the page's last question has scrolled
+    // into view (IntersectionObserver in PageControlButtons), and a click
+    // on the disabled button is a silent no-op — scroll and wait for the
+    // enabled state, then await the idea creation before moving on.
+    cy.intercept('POST', '**/phases/*/inputs').as('submitIdea');
+    cy.get('[data-question-id]').last().scrollIntoView();
+    cy.dataCy('e2e-submit-form')
+      .should('be.visible')
+      .should('not.have.class', 'disabled');
     cy.dataCy('e2e-submit-form').click();
+    cy.wait('@submitIdea').its('response.statusCode').should('be.oneOf', [200, 201]);
+
     cy.dataCy('e2e-after-submission').should('exist').click();
     cy.contains(ideaTitle).should('exist');
   });


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `idea_new_page.cy.ts`, short-description test):** two layers, both visible in the Jul 29 nightly failure. (1) The test clicked `e2e-submit-form` blind — the idea form uses the same `PageControlButtons` as the community-monitor survey (#14476): submit stays disabled until the page's last question has scrolled into view, and a click on the disabled button is a silent no-op. Attempt 1's screenshot shows the test stranded on the details page after the click, with no submission made. (2) The idea-creation POST was never awaited, so the post-submission assertions raced it (the final attempt's actual error: the idea title never found).

**Why this fixes rather than suppresses:** the submit step now scrolls the last question into view, requires the button to not be `disabled` (the pattern proven in #14476), clicks, and waits for `POST **/phases/*/inputs` to return 200/201 before asserting the after-submission state — the same intercept the spec's location test already uses. Assertions are unchanged.

**Stability evidence:** [pipeline 346652](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346652) — 6 nodes, 48/48 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky idea-submission E2E test (disabled-submit race and unawaited creation).