### PR TITLE
[TAN-8462] Flaky E2E Fix: project_page_voting_multi.cy.ts — port the single-voting race fixes

### DIFF
--- a/front/cypress/e2e/project_page_voting_multi.cy.ts
+++ b/front/cypress/e2e/project_page_voting_multi.cy.ts
@@ -111,16 +111,23 @@ describe('Multiple voting project', () => {
   });
 
   it('can submit the votes', () => {
-    cy.intercept(`**/baskets/**`).as('basketRequest');
-    cy.visit(`/en/projects/${projectSlug}`);
-    cy.wait('@basketRequest');
     cy.dockProjectCtaBar();
+    // The vote count from the previous test proves the basket state has
+    // loaded (a slow project → phase → basket fetch chain), without racing
+    // a network intercept whose request may start later than the 5s
+    // requestTimeout.
+    cy.dataCy('project-cta-bar-top').contains('3 out of 5 votes left');
     cy.get('#e2e-voting-submit-button')
       .should('be.visible')
       .should('not.have.class', 'disabled');
-    cy.wait(1000);
-    cy.get('#e2e-voting-submit-button').find('button').click({ force: true });
-    cy.wait(1000);
+
+    // Wait for the submission to actually persist before the test ends —
+    // the next test needs the basket in 'hasSubmitted' state on the backend.
+    cy.intercept('PATCH', '**/baskets/**').as('submitBasket');
+    cy.get('#e2e-voting-submit-button').find('button').click();
+    cy.wait('@submitBasket')
+      .its('response.statusCode')
+      .should('be.oneOf', [200, 201]);
 
     cy.contains('Vote submitted');
     cy.contains('Congratulations, your vote has been submitted');
@@ -136,13 +143,20 @@ describe('Multiple voting project', () => {
 
   it('can modify and remove your votes', () => {
     cy.dockProjectCtaBar();
-    cy.get('#e2e-modify-votes')
+    // Longer timeout: the modify button renders only once the basket query
+    // (end of the project → phase → basket chain) resolves as submitted.
+    cy.get('#e2e-modify-votes', { timeout: 30000 })
       .should('be.visible')
       .should('contain', 'Modify your submission')
       .click();
-    cy.wait(1000);
 
-    cy.get('#e2e-ideas-container').find('.e2e-vote-minus button').click();
+    // Clicking "Modify your submission" reopens the basket via a mutation,
+    // and the vote buttons stay disabled until it settles — a click in that
+    // window is a silent no-op.
+    cy.get('#e2e-ideas-container')
+      .find('.e2e-vote-minus button')
+      .should('not.have.class', 'disabled')
+      .click();
 
     cy.get('#e2e-ideas-container')
       .find('.e2e-vote-plus button')
@@ -150,7 +164,11 @@ describe('Multiple voting project', () => {
 
     cy.dataCy('project-cta-bar-top').contains('4 out of 5 votes left');
 
-    cy.get('#e2e-ideas-container').find('.e2e-vote-minus button').click();
+    // Same guard: the previous vote mutation may briefly disable the button.
+    cy.get('#e2e-ideas-container')
+      .find('.e2e-vote-minus button')
+      .should('not.have.class', 'disabled')
+      .click();
 
     cy.dataCy('project-cta-bar-top').contains('5 out of 5 votes left');
 


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `project_page_voting_multi.cy.ts`):** the spec still had the pre-fix structure of its single-voting sibling, with the same three races root-caused in #14485/#14506. The submit test gated on `cy.wait('@basketRequest')`, whose 5s *request* timeout races the start of the basket GET; it force-clicked submit and never awaited the submit PATCH, so the modify test could start before the basket persisted as `hasSubmitted` — its `#e2e-modify-votes` lookup then timed out (the Jul 8 nightly failure). The modify test also clicked vote buttons that stay `disabled` while the basket-reopen mutation settles — a silent no-op window.

**Why this fixes rather than suppresses:** the same treatment validated on the single-voting spec — gate on the vote-counter UI state instead of a network-start wait, await the submit PATCH response (200/201) before ending the test, 30s timeout on `#e2e-modify-votes` justified by the fetch-chain depth, and `not.have.class 'disabled'` gates before each vote-button click. Removed: the redundant re-visit, a force-click, and three bare waits.

**Stability evidence:** [pipeline 346658](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346658) — 6 nodes, 24/24 tests green across the spec.

# Changelog

## Technical

- Fixed the flaky multi-voting E2E tests (submit and modify votes).