### PR TITLE
[TAN-8455] Flaky E2E Fix: language_switch.cy.ts — await builder boot

### DIFF
--- a/front/cypress/e2e/project_description_builder/language_switch.cy.ts
+++ b/front/cypress/e2e/project_description_builder/language_switch.cy.ts
@@ -3,44 +3,64 @@ import { randomString } from '../../support/commands';
 describe('Project description builder language switch', () => {
   let projectId = '';
   let projectSlug = '';
+  const projectTitle = randomString();
 
+  // The platform locale is derived from the authenticated user (utils/locale.ts
+  // prefers the user's locale over the one in the URL), so switching locale
+  // means patching the user and reloading. Once the new locale reaches the
+  // locale stream the app rewrites the URL prefix, so asserting on the prefix
+  // is what tells us the switch has actually been applied.
   const switchLocale = (locale: string) => {
-    cy.apiUpdateCurrentUser({ locale: locale });
+    cy.apiUpdateCurrentUser({ locale });
     cy.reload();
+    cy.location('pathname').should('match', new RegExp(`^/${locale}/`));
+  };
+
+  // ProjectPageBuilderPage renders nothing at all until the tenant locales and
+  // the layout query have resolved, so this container appearing is the builder's
+  // readiness signal — gate on it before touching the toolbox. The admin bundle
+  // is heavy enough that booting it can outlast defaultCommandTimeout on a
+  // contended CI node (and by a wide margin against a local dev server), hence
+  // the explicit budget.
+  const BUILDER_BOOT_TIMEOUT = 60000;
+
+  const visitBuilder = () => {
+    cy.visit(`/admin/project-page-builder/projects/${projectId}`);
+    cy.get('#e2e-project-page-content-builder-page', {
+      timeout: BUILDER_BOOT_TIMEOUT,
+    }).should('be.visible');
   };
 
   before(() => {
     cy.setAdminLoginCookie();
     cy.getAdminAuthUser().then((user) => {
-      const projectTitle = randomString();
-      const projectDescriptionPreview = randomString();
-      const projectDescription = '';
-      const userId = user.body.data.id;
-
       cy.apiCreateProject({
         title: projectTitle,
-        descriptionPreview: projectDescriptionPreview,
-        description: projectDescription,
+        descriptionPreview: randomString(),
+        description: '',
         publicationStatus: 'published',
-        // participationMethod: 'ideation',
-        assigneeId: userId,
+        assigneeId: user.body.data.id,
       }).then((project) => {
         projectSlug = projectTitle;
         projectId = project.body.data.id;
         cy.apiToggleProjectDescriptionBuilder({ projectId });
-        cy.visit(`/admin/project-page-builder/projects/${projectId}`);
       });
     });
   });
 
   beforeEach(() => {
-    switchLocale('en');
+    // Test isolation clears cookies before every test, so the login cookie has
+    // to be restored before anything that reads it — including
+    // apiUpdateCurrentUser, which silently does nothing without it.
     cy.setAdminLoginCookie();
+    // The previous test leaves the user on nl-BE; reset it so each test starts
+    // from a known platform locale.
+    cy.apiUpdateCurrentUser({ locale: 'en' });
   });
 
   after(() => {
-    cy.visit(`/projects/${projectSlug}`);
-    switchLocale('en');
+    cy.setAdminLoginCookie();
+    cy.apiUpdateCurrentUser({ locale: 'en' });
     cy.apiRemoveProject(projectId);
   });
 
@@ -48,6 +68,8 @@ describe('Project description builder language switch', () => {
     cy.intercept('**/content_builder_layouts/project_page/upsert').as(
       'saveProjectDescriptionBuilder'
     );
+
+    visitBuilder();
 
     // EN
     cy.get('#e2e-draggable-text').dragAndDrop('#e2e-project-page-body', {
@@ -58,10 +80,12 @@ describe('Project description builder language switch', () => {
     cy.get('.e2e-text-box').first().click('center');
     cy.get('.ql-editor').click();
     cy.get('.ql-editor').type('Language 1 text.', { force: true });
+    cy.get('.ql-editor').should('contain.text', 'Language 1 text.');
     cy.wait(1000);
     // NL
     cy.get('.e2e-localeswitcher.nl-BE').click();
     cy.get('.ql-editor').clear().type('Language 2 text.', { force: true });
+    cy.get('.ql-editor').should('contain.text', 'Language 2 text.');
     cy.wait(1000);
     cy.get('#e2e-content-builder-topbar-save').click();
     cy.wait('@saveProjectDescriptionBuilder');
@@ -69,9 +93,9 @@ describe('Project description builder language switch', () => {
     // Confirm correct content on live page
     cy.visit(`/projects/${projectSlug}`);
     switchLocale('en');
-    cy.contains('Language 1 text.').should('exist');
+    cy.contains('Language 1 text.').should('be.visible');
     switchLocale('nl-BE');
-    cy.contains('Language 2 text.').should('exist');
+    cy.contains('Language 2 text.').should('be.visible');
   });
 
   it('deletes language specific content correctly', () => {
@@ -79,20 +103,28 @@ describe('Project description builder language switch', () => {
       'saveProjectDescriptionBuilder'
     );
 
-    cy.visit(`/admin/project-page-builder/projects/${projectId}`);
+    visitBuilder();
 
-    // Delete content. The widget renders in the platform locale, so match the
-    // text typed for either language.
-    cy.contains('.e2e-text-box', /Language \d text\./)
-      .wait(1000)
-      .click({ force: true });
+    // The platform locale is reset to 'en' in beforeEach, so the widget renders
+    // the English text.
+    cy.contains('.e2e-text-box', 'Language 1 text.').click({ force: true });
     cy.get('#e2e-delete-button').click({ force: true });
+    cy.contains('.e2e-text-box', 'Language 1 text.').should('not.exist');
 
-    // Confirm correct content on live page
+    // The builder does not autosave, so the deletion has to be persisted before
+    // the live page can say anything about it.
+    cy.get('#e2e-content-builder-topbar-save').click();
+    cy.wait('@saveProjectDescriptionBuilder');
+
+    // Confirm correct content on live page. The project title is asserted first
+    // so the "not.exist" checks run against a rendered page rather than passing
+    // against one that has not painted yet.
     cy.visit(`/projects/${projectSlug}`);
     switchLocale('en');
+    cy.contains(projectTitle).should('be.visible');
     cy.contains('Language 1 text.').should('not.exist');
     switchLocale('nl-BE');
+    cy.contains(projectTitle).should('be.visible');
     cy.contains('Language 2 text.').should('not.exist');
   });
 });


### PR DESCRIPTION
This PR has been generated by Claude using the fix-flaky-e2e skill.

# Changelog

## Technical
- Fixed the flaky `language_switch.cy.ts` E2E spec. It now waits for the project
  page builder to finish booting before interacting with the toolbox, restores the
  login cookie before the per-test locale reset, and saves the layout after
  deleting a widget so the live-page assertions verify something real.

---

Generated by Claude

**Spec:** `front/cypress/e2e/project_description_builder/language_switch.cy.ts`

### Root cause

Three separate defects, all confirmed by running rather than by inspection:

1. **Test isolation vs. the `beforeEach` locale reset.** `testIsolation` defaults to
   `true` (Cypress 15), so cookies are cleared and the page is reset to `about:blank`
   before every test after the first. `apiUpdateCurrentUser` early-returns when the
   `cl2_jwt` cookie is missing, so `switchLocale('en')` in `beforeEach` silently did
   nothing, `cy.reload()` reloaded a blank page, and `setAdminLoginCookie()` ran
   *after* the reload. The tolerant `/Language \d text\./` matcher in the delete test
   was a workaround for this broken reset.

2. **The nightly flake.** The first test relied on the page `before()` visited
   surviving into the test, reloaded it, then immediately queried
   `#e2e-draggable-text`. `ProjectPageBuilderPage` renders `null` until the tenant
   locales and layout query resolve, so a slow boot under CI contention blew the
   15s default timeout — matching the nightly failure exactly
   (`Expected to find element: #e2e-draggable-text, but never found it`).

3. **The delete test asserted nothing.** It deleted a widget but never saved (the
   builder has no autosave), then asserted `should('not.exist')` on the live page
   immediately after a reload — passing by racing a blank page. Adding only a
   positive control, with no other change, turns it red:
   `Expected not to find content: 'Language 1 text.' but continuously found it`.

### Why this addresses the cause rather than suppressing it

- The builder gate is `#e2e-project-page-content-builder-page`, the container that
  renders only once the app's own readiness condition is met — not a sleep. The
  explicit 60s budget covers admin-bundle boot on a contended node.
- The login cookie is restored before anything that reads it, so the locale reset
  actually happens instead of failing silently.
- `switchLocale` asserts the URL locale prefix afterwards. The user's locale wins
  over the URL's in `utils/locale.ts`, and the app rewrites the prefix — so the
  assertion proves the switch was applied.
- The delete is persisted and each `not.exist` is preceded by asserting the project
  title is visible, so absence means absence.
- No bare `cy.wait(<ms>)` was added, no assertions loosened, no retries relied on.
  The two pre-existing `cy.wait(1000)` calls guarding the craftjs debounce are
  untouched.

### Stability evidence

- **Local:** 10/10 green with `retries=0` (Cypress's 2 retries disabled, so these are
  first-attempt passes). The first attempt at this fix scored 2/10 and was discarded —
  a `cy.intercept` + `cy.wait` gate tripped on `cy.wait`'s 5s request timeout.
- **CI:** pipeline [346670](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346670),
  spec ×3 — 3/3 nodes green, 6/6 test records `success`.
- Nightly history: 1 failure in the last 60 runs (2026-07-22), so the trend over the
  next few weeks is the real verdict.