### PR TITLE
[TAN-8444] Don't re-validate an unchanged host, and never block a delete on it

### DIFF
--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -29,9 +29,8 @@ class AppConfiguration < ApplicationRecord
   }
 
   validates :host, presence: true
-  # Only on change, for the same reason as the twin check on `Tenant`: an already-invalid host
-  # must not block saves that have nothing to do with it. This is the one that aborted the
-  # `cl2back:clean_tenant_settings` deploy step, which saves the configuration, not the tenant.
+  # Only on change, for the same reason as the twin check on `Tenant`: an
+  # already-invalid host must not block saves that have nothing to do with it.
   validate :validate_host_format, if: :host_changed?
   validate :validate_locales, on: :update
   validate :validate_singleton, on: :create

--- a/back/app/models/app_configuration.rb
+++ b/back/app/models/app_configuration.rb
@@ -29,7 +29,10 @@ class AppConfiguration < ApplicationRecord
   }
 
   validates :host, presence: true
-  validate :validate_host_format
+  # Only on change, for the same reason as the twin check on `Tenant`: an already-invalid host
+  # must not block saves that have nothing to do with it. This is the one that aborted the
+  # `cl2back:clean_tenant_settings` deploy step, which saves the configuration, not the tenant.
+  validate :validate_host_format, if: :host_changed?
   validate :validate_locales, on: :update
   validate :validate_singleton, on: :create
 

--- a/back/engines/commercial/multi_tenancy/app/models/tenant.rb
+++ b/back/engines/commercial/multi_tenancy/app/models/tenant.rb
@@ -27,7 +27,11 @@ class Tenant < ApplicationRecord
 
   validates :name, :host, presence: true
   validates :host, uniqueness: true, exclusion: { in: %w[schema-migrations public] }
-  validate :valid_host_format
+  # Only on change: the format belongs to the act of setting the host. Re-checking a persisted
+  # one means a single bad row — from a path that bypassed the model, such as the clone's raw
+  # INSERT — blocks every unrelated save, including its own soft-delete and any rake task that
+  # iterates tenants. `host_changed?` is true on create, so new and edited hosts are unaffected.
+  validate :valid_host_format, if: :host_changed?
 
   after_initialize :custom_initialization
   after_create :create_apartment_tenant

--- a/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
+++ b/back/engines/commercial/multi_tenancy/app/services/multi_tenancy/tenant_service.rb
@@ -88,7 +88,10 @@ module MultiTenancy
     # @param [ActiveSupport::Duration,nil] retry_interval
     def delete(tenant, retry_interval: nil)
       tenant_side_fx.before_destroy(tenant)
-      tenant.update!(deleted_at: Time.zone.now)
+      # Deliberately not `update!`: a tenant must not become undeletable because of the state of
+      # the record being deleted. `update_column` writes the one column, skipping validation and
+      # the app configuration sync — which ignores `deleted_at` anyway (see `attributes_delta`).
+      tenant.update_column(:deleted_at, Time.zone.now)
 
       # Users must be removed before the tenant to ensure PII is removed from
       # third-party services.

--- a/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/models/tenant_spec.rb
@@ -9,6 +9,32 @@ RSpec.describe Tenant do
     end
   end
 
+  describe 'host format validation' do
+    it 'rejects an invalid host on create' do
+      expect(build(:tenant, host: 'Uppercase.example.com')).to be_invalid
+    end
+
+    it 'rejects a change to an invalid host' do
+      tenant = create(:tenant, host: 'lowercase.example.com')
+      tenant.host = 'Uppercase.example.com'
+
+      expect(tenant).to be_invalid
+    end
+
+    # A host that got in without passing through the model — the tenant clone service inserts
+    # with raw SQL — used to make the whole record unsavable for good, blocking its own
+    # soft-delete and every rake task that iterates tenants and saves them.
+    it 'does not re-check a persisted host that has not changed' do
+      tenant = create(:tenant, host: 'uppercase.example.com')
+      tenant.update_column(:host, 'Uppercase.example.com')
+      tenant.reload
+
+      tenant.deleted_at = Time.zone.now
+
+      expect(tenant).to be_valid
+    end
+  end
+
   describe '#switch!' do
     let_it_be(:other_tenant) { create(:tenant, name: 'other-tenant') }
 

--- a/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/tenant_service_spec.rb
+++ b/back/engines/commercial/multi_tenancy/spec/services/multi_tenancy/tenant_service_spec.rb
@@ -75,5 +75,17 @@ RSpec.describe MultiTenancy::TenantService do
       service.delete(tenant)
       expect(tenant.deleted_at).not_to be_nil
     end
+
+    # The soft-delete used to go through `update!`, so a record that was already invalid raised
+    # RecordInvalid and nothing was deleted at all. The tenant that surfaced this had an
+    # uppercase host; the name stands in for it here, as that leaves the schema reachable.
+    it 'marks a tenant that fails validation as deleted' do
+      invalid_tenant = create(:tenant, host: 'invalid.example.com')
+      invalid_tenant.update_column(:name, nil)
+      expect(invalid_tenant.reload).to be_invalid
+
+      expect { service.delete(invalid_tenant) }.to have_enqueued_job(MultiTenancy::Tenants::DeleteJob)
+      expect(invalid_tenant.reload.deleted_at).not_to be_nil
+    end
   end
 end

--- a/back/spec/models/app_configuration_spec.rb
+++ b/back/spec/models/app_configuration_spec.rb
@@ -3,6 +3,28 @@
 require 'rails_helper'
 
 RSpec.describe AppConfiguration do
+  describe 'host format validation' do
+    it 'rejects a change to an invalid host' do
+      config = described_class.instance
+      config.host = 'Uppercase.example.com'
+
+      expect(config).to be_invalid
+    end
+
+    # `cl2back:clean_tenant_settings` runs on every deploy and saves the configuration of every
+    # tenant. One host that got in without passing through the model used to abort the whole
+    # task, and with it the deploy.
+    it 'does not re-check a persisted host that has not changed' do
+      config = described_class.instance
+      config.update_column(:host, 'Uppercase.example.com')
+      config.reload
+
+      config.settings['core']['organization_name'] = { 'en' => 'Changed' }
+
+      expect(config).to be_valid
+    end
+  end
+
   describe '.instance' do
     it 'is reset when the tenant is reset' do
       tenant = Tenant.current


### PR DESCRIPTION
A tenant whose host had a capital letter (`Brusselsdemo.govocal.com`, inserted by the clone service's raw SQL) was permanently invalid. Deleting it from Admin HQ 500'd silently, and `cl2back:clean_tenant_settings` later aborted a production deploy.

- `Tenant#valid_host_format` now runs only `if: :host_changed?` — format is a property of *setting* the host, and re-checking a persisted one let a single bad row block every unrelated save, including its own soft-delete.
- `AppConfiguration#validate_host_format` gets the same condition. It duplicates the tenant's rule verbatim, and it's the record `clean_tenant_settings` actually saves — so this, not the change above, is what unblocks the deploy.
- `TenantService#delete` uses `update_column(:deleted_at, …)` instead of `update!`. A tenant should never be undeletable because of the state of the record being deleted.

New/edited hosts are validated exactly as before: `host_changed?` is true on create.

Specs added for all three.

# Changelog
## Technical
- [TAN-8444] Don't re-validate an unchanged host, and never block a delete on it
