### PR TITLE
[TAN-8381] Add staleness check and relink modes to bin/setup-claude

### DIFF
--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -10,11 +10,32 @@
 #     Claude Code's CLAUDE.md discovery follows file symlinks, so no
 #     committed stub or @import indirection is needed.
 #
+# Modes:
+#   bin/setup-claude            full setup: clone/update the overlay, then
+#                               (re)create the symlinks
+#   bin/setup-claude --relink   (re)create the symlinks from the local overlay
+#                               working tree only — no git operations, so it's
+#                               safe to run from automation (e.g. a session
+#                               hook) without touching the dev's git state
+#   bin/setup-claude --check    staleness diagnostic: exit 1 and say what's
+#                               wrong when the overlay clone is missing or
+#                               behind origin/main, symlinks are missing or
+#                               dangling, or core.hooksPath is unset. Makes no
+#                               changes apart from a throttled `git fetch`
+#                               (at most once per
+#                               SETUP_CLAUDE_CHECK_FETCH_MAX_AGE_MINUTES,
+#                               default 360, tracked via a stamp file in the
+#                               overlay's .git/; skipped entirely with
+#                               SETUP_CLAUDE_CHECK_NO_FETCH=1). Fetch failures
+#                               (offline, auth) are ignored — the check never
+#                               blocks on the network.
+#
 # Requires CITIZENLAB_CLAUDE_GIT_REMOTE (the git remote spec for the private
 # overlay repo — SSH `git@host:...`, HTTPS, or `ssh://...`). It can be set in
 # the host shell directly, or in env_files/back-secret.env — the script
 # extracts just that one variable from the file without sourcing it whole, so
 # the docker-compose env file doesn't have to be bash-source-safe.
+# (--check and --relink work from the existing local clone and don't need it.)
 # Override the default sibling clone location with CITIZENLAB_CLAUDE_DIR.
 
 set -euo pipefail
@@ -50,6 +71,17 @@ relpath() {
 # script. See bin/setup-claude.test.sh.
 [ "${BIN_SETUP_CLAUDE_LIBRARY:-}" = "1" ] && return 0
 
+MODE="setup"
+case "${1:-}" in
+  "") ;;
+  --check)  MODE="check" ;;
+  --relink) MODE="relink" ;;
+  *)
+    echo "Usage: bin/setup-claude [--check|--relink]" >&2
+    exit 2
+    ;;
+esac
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
@@ -65,7 +97,7 @@ if [ -z "${CITIZENLAB_CLAUDE_GIT_REMOTE:-}" ] && [ -f env_files/back-secret.env 
 fi
 
 PRIVATE_REPO="${CITIZENLAB_CLAUDE_GIT_REMOTE:-}"
-if [ -z "$PRIVATE_REPO" ]; then
+if [ "$MODE" = "setup" ] && [ -z "$PRIVATE_REPO" ]; then
   echo "Warning: CITIZENLAB_CLAUDE_GIT_REMOTE is not set." >&2
   echo "Set it in your host shell rc, or add it to env_files/back-secret.env (gitignored) at the repo root." >&2
   exit 1
@@ -74,10 +106,126 @@ fi
 PARENT="$(dirname "$REPO_ROOT")"
 PRIVATE_DIR="${CITIZENLAB_CLAUDE_DIR:-$PARENT/citizenlab-claude}"
 
+# The one definition of "which overlay files get mirrored under .claude/",
+# shared by the mirror loop below and by --check so the two can't drift.
+# Excluded: git internals, the overlay's own README/.gitignore, per-folder
+# README docs, files with special destinations (settings.json,
+# .claude-readme.md), and CLAUDE.md (materialized as top-level symlinks).
+list_private_files() {
+  find "$PRIVATE_DIR" -type f \
+    -not -path '*/.git/*' \
+    -not -name 'README.md' \
+    -not -name '.gitignore' \
+    -not -name 'settings.json' \
+    -not -name '.claude-readme.md' \
+    -not -name 'CLAUDE.md' \
+    -print0
+}
+
+list_private_claude_md() {
+  find "$PRIVATE_DIR" -name 'CLAUDE.md' -not -path '*/.git/*' -print0
+}
+
+if [ "$MODE" = "check" ]; then
+  issues=()
+
+  if [ ! -d "$PRIVATE_DIR" ]; then
+    if [ -z "$PRIVATE_REPO" ]; then
+      # No remote configured and no clone: a dev without overlay access.
+      # Nothing to check and nothing worth nagging about.
+      echo "Claude overlay not configured (no CITIZENLAB_CLAUDE_GIT_REMOTE, no clone at $PRIVATE_DIR) — skipping check."
+      exit 0
+    fi
+    issues+=("private overlay clone is missing at $PRIVATE_DIR")
+  else
+    # Clone freshness: fetch origin/main (throttled via a stamp file so
+    # frequent invocations — e.g. one per Claude session start — hit the
+    # network at most once per max-age window), then compare local main
+    # against it. The stamp records the attempt, not the success, so an
+    # offline machine isn't re-probed on every invocation.
+    stamp="$PRIVATE_DIR/.git/setup-claude-check-fetch-stamp"
+    max_age="${SETUP_CLAUDE_CHECK_FETCH_MAX_AGE_MINUTES:-360}"
+    if [ -z "${SETUP_CLAUDE_CHECK_NO_FETCH:-}" ]; then
+      if [ ! -f "$stamp" ] || [ -n "$(find "$stamp" -mmin +"$max_age" 2>/dev/null)" ]; then
+        touch "$stamp" 2>/dev/null || true
+        git -C "$PRIVATE_DIR" fetch --quiet origin main >/dev/null 2>&1 || true
+      fi
+    fi
+    if git -C "$PRIVATE_DIR" rev-parse -q --verify refs/heads/main >/dev/null 2>&1 \
+       && git -C "$PRIVATE_DIR" rev-parse -q --verify refs/remotes/origin/main >/dev/null 2>&1; then
+      behind="$(git -C "$PRIVATE_DIR" rev-list --count refs/heads/main..refs/remotes/origin/main 2>/dev/null || echo 0)"
+      if [ "$behind" -gt 0 ]; then
+        last="$(git -C "$PRIVATE_DIR" log -1 --format=%cs refs/heads/main 2>/dev/null || echo unknown)"
+        issues+=("overlay main is $behind commit(s) behind origin/main (local main last commit: $last)")
+      fi
+    fi
+
+    # Symlink drift, part 1: overlay files with no resolving symlink at
+    # their expected destination — a file was added to the overlay after
+    # the last setup/relink run. Covers the mirror set, the two
+    # special-destination files, and the top-level CLAUDE.md links (same
+    # parent-dir-must-exist rule as the creation loop below).
+    missing=0
+    missing_example=""
+    note_missing() {
+      missing=$((missing + 1))
+      [ -n "$missing_example" ] || missing_example="$1"
+    }
+    while IFS= read -r -d '' src; do
+      rel="${src#$PRIVATE_DIR/}"
+      { [ -L ".claude/$rel" ] && [ -e ".claude/$rel" ]; } || note_missing ".claude/$rel"
+    done < <(list_private_files)
+    if [ -f "$PRIVATE_DIR/settings.json" ]; then
+      { [ -L .claude/settings.json ] && [ -e .claude/settings.json ]; } || note_missing ".claude/settings.json"
+    fi
+    if [ -f "$PRIVATE_DIR/.claude-readme.md" ]; then
+      { [ -L .claude/README.md ] && [ -e .claude/README.md ]; } || note_missing ".claude/README.md"
+    fi
+    while IFS= read -r -d '' src; do
+      rel="${src#$PRIVATE_DIR/}"
+      parent="$(dirname "$rel")"
+      if [ "$parent" = "." ] || [ -d "$parent" ]; then
+        { [ -L "$rel" ] && [ -e "$rel" ]; } || note_missing "$rel"
+      fi
+    done < <(list_private_claude_md)
+    if [ "$missing" -gt 0 ]; then
+      issues+=("$missing overlay file(s) not materialized as symlinks (e.g. $missing_example)")
+    fi
+
+    # Symlink drift, part 2: dangling symlinks under .claude/ — a file was
+    # deleted from the overlay after the last setup/relink run.
+    dangling_list="$(find .claude -type l ! -exec test -e {} \; -print 2>/dev/null || true)"
+    if [ -n "$dangling_list" ]; then
+      dangling_count="$(printf '%s\n' "$dangling_list" | wc -l | tr -d ' ')"
+      dangling_example="$(printf '%s\n' "$dangling_list" | head -n 1)"
+      issues+=("$dangling_count dangling symlink(s) under .claude/ (e.g. $dangling_example)")
+    fi
+  fi
+
+  if [ -d .githooks ] && [ "$(git config --get core.hooksPath || true)" != ".githooks" ]; then
+    issues+=("git core.hooksPath is not set to .githooks (privacy pre-commit guard inactive)")
+  fi
+
+  if [ "${#issues[@]}" -eq 0 ]; then
+    echo "Claude overlay check: OK"
+    exit 0
+  fi
+  echo "Claude overlay check: STALE"
+  for issue in "${issues[@]}"; do
+    echo "  - $issue"
+  done
+  echo "Run \`make claude-setup\` to refresh."
+  exit 1
+fi
+
 if [ ! -d "$PRIVATE_DIR" ]; then
+  if [ "$MODE" = "relink" ]; then
+    echo "Error: private overlay clone is missing at $PRIVATE_DIR — run \`make claude-setup\` first." >&2
+    exit 1
+  fi
   echo "Cloning private overlay into $PRIVATE_DIR ..."
   git clone "$PRIVATE_REPO" "$PRIVATE_DIR"
-else
+elif [ "$MODE" = "setup" ]; then
   echo "Updating private overlay at $PRIVATE_DIR ..."
   # Skip the pull when the current branch has no upstream — common when a
   # dev is on a fresh feature branch in citizenlab-claude that hasn't been
@@ -120,22 +268,13 @@ find .claude -type l -delete 2>/dev/null || true
 # Mirror every tracked file from the private repo as a per-file symlink at
 # .claude/<same-relative-path>. Per-file (not directory) symlinks because
 # Claude Code's `@import` and skill/command discovery don't follow directory
-# symlinks. Skipped: the private repo's own README/.gitignore, the per-folder
-# README docs, the files with special destinations handled below, and any
-# CLAUDE.md (those are materialized as top-level symlinks, see further down).
+# symlinks. The shared list_private_files() defines the set (see above).
 while IFS= read -r -d '' src; do
   rel="${src#$PRIVATE_DIR/}"
   dst=".claude/$rel"
   mkdir -p "$(dirname "$dst")"
   ln -sfn "$(relpath "$src" "$REPO_ROOT/$(dirname "$dst")")" "$dst"
-done < <(find "$PRIVATE_DIR" -type f \
-  -not -path '*/.git/*' \
-  -not -name 'README.md' \
-  -not -name '.gitignore' \
-  -not -name 'settings.json' \
-  -not -name '.claude-readme.md' \
-  -not -name 'CLAUDE.md' \
-  -print0)
+done < <(list_private_files)
 
 # Remove any empty directories under .claude/ left behind after the CLAUDE.md
 # exclusion (e.g. .claude/back/ / .claude/front/ from the previous design).
@@ -189,7 +328,7 @@ while IFS= read -r -d '' src; do
     fi
     ln -sfn "$(relpath "$src" "$anchor")" "$rel"
   fi
-done < <(find "$PRIVATE_DIR" -name 'CLAUDE.md' -not -path '*/.git/*' -print0)
+done < <(list_private_claude_md)
 
 # Install the privacy guard hooks (versioned at .githooks/)
 if [ -d .githooks ]; then
@@ -200,4 +339,8 @@ if [ -d .githooks ]; then
   fi
 fi
 
-echo "Claude private overlay installed at $PRIVATE_DIR"
+if [ "$MODE" = "relink" ]; then
+  echo "Claude overlay symlinks refreshed from $PRIVATE_DIR"
+else
+  echo "Claude private overlay installed at $PRIVATE_DIR"
+fi

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -234,8 +234,10 @@ SKILL
     echo 'private repo own README' > README.md
     # `-c user.email=...` sets the value just for this one git command,
     # avoiding any reliance on whatever `git config` is set to on the
-    # dev's machine or the CI runner.
-    git -c user.email=t@t -c user.name=t add -A
+    # dev's machine or the CI runner. `-c core.excludesFile=/dev/null`
+    # likewise neutralizes a global gitignore, which may exclude fixture
+    # filenames like `settings.json` and silently drop them.
+    git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
     git -c user.email=t@t -c user.name=t commit -q -m fixtures
     # Push to whatever default branch the local clone landed on (could be
     # `main` or `master` depending on the user's git defaults).
@@ -406,7 +408,7 @@ mkdir -p "$PUBLIC/front"   # restore the area dir we removed in an earlier test
   cd "$FIXTURE_WT"
   git pull -q --ff-only
   rm front/CLAUDE.md
-  git -c user.email=t@t -c user.name=t add -A
+  git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
   git -c user.email=t@t -c user.name=t commit -q -m "drop front"
   git push -q
 )
@@ -492,7 +494,7 @@ behind_sha="$(git -C "$PRIVATE" rev-parse main)"
 (
   cd "$FIXTURE_WT"
   echo "advance" > main-advance.txt
-  git -c user.email=t@t -c user.name=t add -A
+  git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
   git -c user.email=t@t -c user.name=t commit -q -m "advance main"
   git push -q origin main
 )
@@ -500,6 +502,185 @@ ahead_sha="$(git -C "$FIXTURE_WT" rev-parse main)"
 assert_eq "$(git -C "$PRIVATE" rev-parse main)" "$behind_sha" "test setup sanity: PRIVATE main starts behind origin/main"
 run_setup
 assert_eq "$(git -C "$PRIVATE" rev-parse main)" "$ahead_sha" "local main fast-forwarded to origin/main even when HEAD is on a feature branch"
+
+
+# ============================================================================
+# Integration tests: --check and --relink modes
+# ============================================================================
+# These continue from the fake-universe state left by the tests above
+# (PRIVATE exists, HEAD on a feature branch, main == origin/main).
+
+# Assert a string contains a substring — pins the category of a --check
+# issue, not its exact phrasing.
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  case "$haystack" in
+    *"$needle"*) pass "$label" ;;
+    *)
+      fail "$label"
+      echo "    expected to contain: '$needle'" >&2
+      echo "    actual output:       '$haystack'" >&2
+      ;;
+  esac
+}
+
+# Run bin/setup-claude with the given args against the fake universe.
+# Fetch is disabled for determinism; the fetch-path test opts back in.
+run_mode() {
+  (
+    cd "$PUBLIC"
+    CITIZENLAB_CLAUDE_GIT_REMOTE="$REMOTE" \
+    CITIZENLAB_CLAUDE_DIR="$PRIVATE" \
+    SETUP_CLAUDE_CHECK_NO_FETCH=1 \
+      bash "$SCRIPT_TO_TEST" "$@" >/dev/null 2>&1
+  )
+}
+
+# Run `--check`, capturing output in CHECK_OUT and exit status in
+# CHECK_STATUS (`|| CHECK_STATUS=$?` keeps set -e from aborting on the
+# expected failures). Pass "fetch" to enable the throttled-fetch path.
+CHECK_OUT=""
+CHECK_STATUS=0
+run_check_capture() {
+  local no_fetch=1
+  [ "${1:-}" = "fetch" ] && no_fetch=""
+  CHECK_STATUS=0
+  CHECK_OUT="$(
+    cd "$PUBLIC"
+    CITIZENLAB_CLAUDE_GIT_REMOTE="$REMOTE" \
+    CITIZENLAB_CLAUDE_DIR="$PRIVATE" \
+    SETUP_CLAUDE_CHECK_NO_FETCH="$no_fetch" \
+      bash "$SCRIPT_TO_TEST" --check 2>&1
+  )" || CHECK_STATUS=$?
+}
+
+
+# ----------------------------------------------------------------------------
+# Test: freshly-set-up state passes --check.
+# ----------------------------------------------------------------------------
+run_setup
+run_check_capture
+assert_eq "$CHECK_STATUS" "0" "fresh state: --check exits 0"
+assert_contains "$CHECK_OUT" "OK" "fresh state: --check reports OK"
+
+
+# ----------------------------------------------------------------------------
+# Test: missing symlink (file added to the overlay, setup never re-run) is
+# detected and healed by --relink.
+# ----------------------------------------------------------------------------
+rm "$PUBLIC/.claude/hooks/test-hook.sh"
+run_check_capture
+assert_eq "$CHECK_STATUS" "1" "missing symlink: --check exits 1"
+assert_contains "$CHECK_OUT" "not materialized" "missing symlink: --check names the drift"
+run_mode --relink || fail "--relink after missing symlink should succeed"
+assert_symlink_to "$PUBLIC/.claude/hooks/test-hook.sh" "../../../private/hooks/test-hook.sh" "--relink recreates the missing symlink"
+run_check_capture
+assert_eq "$CHECK_STATUS" "0" "after --relink: --check passes again"
+
+
+# ----------------------------------------------------------------------------
+# Test: dangling symlink (file deleted from the overlay) is detected and
+# cleaned up by --relink.
+# ----------------------------------------------------------------------------
+rm "$PRIVATE/commands/test.md"
+run_check_capture
+assert_eq "$CHECK_STATUS" "1" "dangling symlink: --check exits 1"
+assert_contains "$CHECK_OUT" "dangling" "dangling symlink: --check names the drift"
+run_mode --relink || fail "--relink after dangling symlink should succeed"
+assert_path_missing "$PUBLIC/.claude/commands/test.md" "--relink removes the dangling symlink"
+run_check_capture
+assert_eq "$CHECK_STATUS" "0" "after --relink (dangling): --check passes again"
+
+
+# ----------------------------------------------------------------------------
+# Test: unset core.hooksPath is detected and restored by --relink.
+# ----------------------------------------------------------------------------
+git -C "$PUBLIC" config --unset core.hooksPath
+run_check_capture
+assert_eq "$CHECK_STATUS" "1" "unset hooksPath: --check exits 1"
+assert_contains "$CHECK_OUT" "core.hooksPath" "unset hooksPath: --check names the drift"
+run_mode --relink || fail "--relink after unset hooksPath should succeed"
+assert_eq "$(git -C "$PUBLIC" config --get core.hooksPath)" ".githooks" "--relink restores core.hooksPath"
+
+
+# ----------------------------------------------------------------------------
+# Test: local main behind origin/main is detected via the fetch path, the
+# fetch attempt leaves the throttle stamp, and a full setup run clears it.
+# ----------------------------------------------------------------------------
+(
+  cd "$FIXTURE_WT"
+  git checkout -q main
+  echo "advance again" > main-advance-2.txt
+  git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
+  git -c user.email=t@t -c user.name=t commit -q -m "advance main again"
+  git push -q origin main
+)
+rm -f "$PRIVATE/.git/setup-claude-check-fetch-stamp"
+run_check_capture fetch
+assert_eq "$CHECK_STATUS" "1" "behind origin/main: --check exits 1"
+assert_contains "$CHECK_OUT" "behind origin/main" "behind origin/main: --check names the drift"
+if [ -f "$PRIVATE/.git/setup-claude-check-fetch-stamp" ]; then
+  pass "fetch attempt leaves the throttle stamp file"
+else
+  fail "fetch attempt leaves the throttle stamp file"
+fi
+run_setup
+run_check_capture
+assert_eq "$CHECK_STATUS" "0" "after full setup: --check passes again"
+
+
+# ----------------------------------------------------------------------------
+# Test: no remote + no clone (dev without overlay access) exits 0 so the
+# check stays silent for them; remote set + clone missing exits 1; --relink
+# with no clone is a hard error.
+# ----------------------------------------------------------------------------
+NOACCESS_PUBLIC="$TEST_TMP/noaccess-public"
+mkdir -p "$NOACCESS_PUBLIC"
+(
+  cd "$NOACCESS_PUBLIC"
+  git init -q
+  git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+)
+if (
+  cd "$NOACCESS_PUBLIC"
+  CITIZENLAB_CLAUDE_GIT_REMOTE="" \
+  CITIZENLAB_CLAUDE_DIR="$TEST_TMP/nonexistent-private" \
+    bash "$SCRIPT_TO_TEST" --check >/dev/null 2>&1
+); then
+  pass "no access (no remote, no clone): --check exits 0"
+else
+  fail "no access (no remote, no clone): --check exits 0"
+fi
+MISSING_STATUS=0
+MISSING_OUT="$(
+  cd "$NOACCESS_PUBLIC"
+  CITIZENLAB_CLAUDE_GIT_REMOTE="$REMOTE" \
+  CITIZENLAB_CLAUDE_DIR="$TEST_TMP/nonexistent-private" \
+  SETUP_CLAUDE_CHECK_NO_FETCH=1 \
+    bash "$SCRIPT_TO_TEST" --check 2>&1
+)" || MISSING_STATUS=$?
+assert_eq "$MISSING_STATUS" "1" "remote set but clone missing: --check exits 1"
+assert_contains "$MISSING_OUT" "missing at" "remote set but clone missing: --check says the clone is missing"
+if (
+  cd "$NOACCESS_PUBLIC"
+  CITIZENLAB_CLAUDE_GIT_REMOTE="$REMOTE" \
+  CITIZENLAB_CLAUDE_DIR="$TEST_TMP/nonexistent-private" \
+    bash "$SCRIPT_TO_TEST" --relink >/dev/null 2>&1
+); then
+  fail "--relink with missing clone exits non-zero"
+else
+  pass "--relink with missing clone exits non-zero"
+fi
+
+
+# ----------------------------------------------------------------------------
+# Test: an unknown flag is rejected instead of silently running a full setup.
+# ----------------------------------------------------------------------------
+if run_mode --bogus-flag; then
+  fail "unknown flag exits non-zero"
+else
+  pass "unknown flag exits non-zero"
+fi
 
 
 # ============================================================================


### PR DESCRIPTION
# Changelog

## Technical
- `bin/setup-claude --check`: staleness diagnostic for the Claude private overlay. Reports a missing clone, local `main` behind `origin/main` (fetch throttled to once per 6h via a stamp file, offline-safe), overlay files not materialized as symlinks, dangling symlinks, and an unset `core.hooksPath`. Exits 1 with a summary when stale; exits 0 quietly for devs without overlay access.
- `bin/setup-claude --relink`: recreates the symlinks from the local overlay clone with no git operations, so automation can heal symlink drift without touching a dev's git state.

# How to test
- `bin/setup-claude --check` on your machine — should print `Claude overlay check: OK` if you're fresh.
- Symlink drift: `rm .claude/hooks/block-secret-bash.sh` → `--check` exits 1 naming the missing symlink → `bin/setup-claude --relink` → `--check` OK again.
- Behind detection: `git -C ../citizenlab-claude branch -f main origin/main~2` → `--check` reports "N commit(s) behind origin/main". Restore with `git -C ../citizenlab-claude fetch origin main:main`.
- End-to-end (needs the companion overlay PR + `make claude-setup`): rewind main as above, then start a new Claude Code session — Claude should mention the stale overlay in its first sentence and offer to run `make claude-setup`. Symlink drift instead gets silently self-healed at session start.