### PR TITLE
TAN-8463-departments-final-touches

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1614,6 +1614,18 @@
           "allowed": { "type": "boolean", "default": false },
           "enabled": { "type": "boolean", "default": false }
         }
+      },
+
+      "configurable_dropdown": {
+        "type": "object",
+        "title": "Configurable dropdown",
+        "description": "Allows grouping several navigation bar items together under a single dropdown menu.",
+        "additionalProperties": false,
+        "required": ["allowed", "enabled"],
+        "properties": {
+          "allowed": { "type": "boolean", "default": false },
+          "enabled": { "type": "boolean", "default": false }
+        }
       }
     },
   "dependencies": {

--- a/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
+++ b/back/engines/commercial/multi_tenancy/db/seeds/tenants.rb
@@ -441,6 +441,10 @@ module MultiTenancy
             parallel_participation: {
               enabled: true,
               allowed: true
+            },
+            configurable_dropdown: {
+              enabled: true,
+              allowed: true
             }
           })
         )

--- a/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/core/create_tenant.rake
@@ -367,6 +367,10 @@ namespace :cl2_back do
         parallel_participation: {
           enabled: true,
           allowed: true
+        },
+        configurable_dropdown: {
+          enabled: true,
+          allowed: true
         }
       }
     )

--- a/front/app/api/app_configuration/types.ts
+++ b/front/app/api/app_configuration/types.ts
@@ -208,6 +208,7 @@ export interface IAppConfigurationSettings {
   project_static_pages?: AppConfigurationFeature;
   parallel_participation?: AppConfigurationFeature;
   html_block_in_content_builder?: AppConfigurationFeature;
+  configurable_dropdown?: AppConfigurationFeature;
 }
 
 export type TAppConfigurationSettingCore = keyof IAppConfigurationSettingsCore;

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/CustomPages/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Widgets/CustomPages/index.tsx
@@ -1,18 +1,56 @@
 import React from 'react';
 
-import { Box, Spinner, Title } from '@citizenlab/cl2-component-library';
+import { Box, Shimmer, Title, colors } from '@citizenlab/cl2-component-library';
+import { Multiloc } from 'typings';
 
 import useCustomPages from 'api/custom_pages/useCustomPages';
 
+import useLocalize from 'hooks/useLocalize';
+
 import EmptyState from '../_shared/EmptyState';
 
+import { CARD_ICON_SIZE } from './constants';
 import CustomPageCard from './CustomPageCard';
 import GridContainer, { Grid } from './GridContainer';
 import messages from './messages';
 import Settings from './Settings';
-import useLocalize from 'hooks/useLocalize';
-import { Multiloc } from 'typings';
 import { CustomPageItem } from './typings';
+
+type SkeletonProps = {
+  title: string;
+  customPages: CustomPageItem[];
+};
+
+const Skeleton = ({ title, customPages }: SkeletonProps) => (
+  <GridContainer>
+    <Title variant="h2" mt="0px" color="tenantText">
+      {title}
+    </Title>
+    <Grid>
+      {customPages.map((item) => (
+        <Box
+          key={item.id}
+          display="flex"
+          alignItems="center"
+          gap="16px"
+          p="20px"
+          border={`1px solid ${colors.coolGrey300}`}
+          borderRadius="12px"
+        >
+          {(item.icon || item.image?.imageUrl) && (
+            <Shimmer
+              flex="0 0 auto"
+              w={`${CARD_ICON_SIZE}px`}
+              h={`${CARD_ICON_SIZE}px`}
+              borderRadius="4px"
+            />
+          )}
+          <Shimmer w="60%" h="16px" borderRadius="16px" />
+        </Box>
+      ))}
+    </Grid>
+  </GridContainer>
+);
 
 type CustomPagesProps = {
   titleMultiloc?: Multiloc;
@@ -40,12 +78,14 @@ const CustomPages = ({ titleMultiloc, customPages }: CustomPagesProps) => {
     ];
   });
 
+  // Nothing selected in the settings panel: no fetch result can change that, so
+  // there is nothing to show a skeleton for.
+  if (customPages.length === 0) {
+    return <EmptyState title={title} explanation={messages.noData} />;
+  }
+
   if (isInitialLoading) {
-    return (
-      <Box w="100%" display="flex" justifyContent="center" py="24px">
-        <Spinner />
-      </Box>
-    );
+    return <Skeleton title={title} customPages={customPages} />;
   }
 
   if (selectedPages.length === 0) {

--- a/front/app/containers/Admin/pagesAndMenu/containers/NewMenuItemModal/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/NewMenuItemModal/index.tsx
@@ -7,7 +7,10 @@ import { INavbarDropdownChild, INavbarItem } from 'api/navbar/types';
 import useAddNavbarItem from 'api/navbar/useAddNavbarItem';
 import useUpsertNavbarDropdown from 'api/navbar/useUpsertNavbarDropdown';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import Modal from 'components/UI/Modal';
+import UpsellTooltip from 'components/UpsellTooltip';
 
 import { useIntl } from 'utils/cl-intl';
 import { IItemNotInNavbar } from 'utils/navbar';
@@ -35,6 +38,11 @@ const NewMenuItemModal = ({ opened, onClose, editItem }: Props) => {
   const [activeTab, setActiveTab] = React.useState<'single' | 'dropdown'>(
     isEditing ? 'dropdown' : 'single'
   );
+
+  // Dropdowns that predate the feature stay editable, so only block reaching
+  // the tab when adding a new item.
+  const dropdownEnabled = useFeatureFlag({ name: 'configurable_dropdown' });
+  const dropdownBlocked = !dropdownEnabled && !isEditing;
 
   const handleClose = () => {
     setActiveTab(isEditing ? 'dropdown' : 'single');
@@ -74,16 +82,24 @@ const NewMenuItemModal = ({ opened, onClose, editItem }: Props) => {
           >
             {formatMessage(messages.singleItem)}
           </Button>
-          <Button
-            flex="1"
-            buttonStyle={activeTab === 'dropdown' ? 'admin-dark' : 'secondary'}
-            onClick={() => setActiveTab('dropdown')}
-            className="intercom-admin-pages-menu-dropdown-tab"
-            data-cy="e2e-new-menu-item-dropdown-tab"
-            borderRadius="0 4px 4px 0"
-          >
-            {formatMessage(messages.dropdown)}
-          </Button>
+          {/* The tooltip wraps its child in a span, and that span is what the
+              row lays out — hence the width here rather than flex on the
+              button, which would apply inside the span and do nothing. */}
+          <UpsellTooltip disabled={!dropdownBlocked} width="50%">
+            <Button
+              width="100%"
+              buttonStyle={
+                activeTab === 'dropdown' ? 'admin-dark' : 'secondary'
+              }
+              onClick={() => setActiveTab('dropdown')}
+              disabled={dropdownBlocked}
+              className="intercom-admin-pages-menu-dropdown-tab"
+              data-cy="e2e-new-menu-item-dropdown-tab"
+              borderRadius="0 4px 4px 0"
+            >
+              {formatMessage(messages.dropdown)}
+            </Button>
+          </UpsellTooltip>
         </Box>
 
         {activeTab === 'single' ? (

--- a/front/app/containers/Admin/pagesAndMenu/containers/NewMenuItemModal/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/NewMenuItemModal/index.tsx
@@ -39,8 +39,6 @@ const NewMenuItemModal = ({ opened, onClose, editItem }: Props) => {
     isEditing ? 'dropdown' : 'single'
   );
 
-  // Dropdowns that predate the feature stay editable, so only block reaching
-  // the tab when adding a new item.
   const dropdownEnabled = useFeatureFlag({ name: 'configurable_dropdown' });
   const dropdownBlocked = !dropdownEnabled && !isEditing;
 
@@ -82,9 +80,6 @@ const NewMenuItemModal = ({ opened, onClose, editItem }: Props) => {
           >
             {formatMessage(messages.singleItem)}
           </Button>
-          {/* The tooltip wraps its child in a span, and that span is what the
-              row lays out — hence the width here rather than flex on the
-              button, which would apply inside the span and do nothing. */}
           <UpsellTooltip disabled={!dropdownBlocked} width="50%">
             <Button
               width="100%"

--- a/front/app/containers/Admin/projects/all/Tabs.tsx
+++ b/front/app/containers/Admin/projects/all/Tabs.tsx
@@ -12,6 +12,8 @@ import { HighestRole } from 'api/users/types';
 
 import useFeatureFlag from 'hooks/useFeatureFlag';
 
+import NewLabel from 'components/UI/NewLabel';
+
 import { trackEventByName } from 'utils/analytics';
 import { MessageDescriptor, useIntl } from 'utils/cl-intl';
 import { removeSearchParams } from 'utils/cl-router/removeSearchParams';
@@ -75,6 +77,9 @@ const ROLES_THAT_CAN_SEE_FOLDERS: HighestRole[] = [
   'project_folder_moderator',
 ];
 
+// Spaces shipped in August 2026. Stop flagging the tab as new six months on.
+const SPACES_NEW_LABEL_EXPIRY = new Date('2027-02-10');
+
 const Tabs = () => {
   const searchParams = useSearch({
     from: '/$locale/admin/projects/',
@@ -94,6 +99,7 @@ const Tabs = () => {
     <Box
       as="nav"
       display="flex"
+      alignItems="center"
       w="100%"
       mt="12px"
       className="intercom-product-tour-project-page-tabs"
@@ -129,17 +135,25 @@ const Tabs = () => {
         />
       )}
       {ROLES_THAT_CAN_SEE_SPACES.includes(highest_role) && spacesEnabled && (
-        <Tab
-          message={messages.spaces}
-          icon="spaces"
-          active={tab === 'spaces'}
-          dataCy="projects-overview-spaces-tab"
-          onClick={() => {
-            removeSearchParams([...PROJECT_PARAMS, ...FOLDER_PARAMS]);
-            updateSearchParams({ tab: 'spaces' });
-            trackEventByName(tracks.setTab, { tab: 'spaces' });
-          }}
-        />
+        <>
+          <Tab
+            message={messages.spaces}
+            icon="spaces"
+            active={tab === 'spaces'}
+            dataCy="projects-overview-spaces-tab"
+            onClick={() => {
+              removeSearchParams([...PROJECT_PARAMS, ...FOLDER_PARAMS]);
+              updateSearchParams({ tab: 'spaces' });
+              trackEventByName(tracks.setTab, { tab: 'spaces' });
+            }}
+          />
+          <NewLabel
+            expiryDate={SPACES_NEW_LABEL_EXPIRY}
+            ml="-12px"
+            mt="-8px"
+            mr="20px"
+          />
+        </>
       )}
       <Tab
         message={messages.calendar}


### PR DESCRIPTION
# Changelog
## Added
- "New" label to spaces tab
- Custom pages homepage widget - now loads with skeleton instead of a loader for better UX
- Upsell trigger added for customizable dropdown feature

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
