### PR TITLE
Fix unsanitized locale param

### DIFF
--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -104,11 +104,15 @@ class ProjectsFinderAdminService
   end
 
   def self.sort_alphabetically(scope, params)
-    locale = params[:locale] || 'en'
+    # whitelist of the locale
+    configured_locales = AppConfiguration.instance.settings('core', 'locales')
+    locale = configured_locales.include?(params[:locale]) ? params[:locale] : 'en'
     direction = params[:sort] == 'alphabetically_desc' ? 'DESC' : 'ASC'
+    # quote method is used to prevent SQL injection
+    quoted_locale = scope.connection.quote(locale)
 
     scope.order(
-      Arel.sql("projects.title_multiloc->>'#{locale}' #{direction}, projects.created_at ASC, projects.id ASC")
+      Arel.sql("projects.title_multiloc->>#{quoted_locale} #{direction}, projects.created_at ASC, projects.id ASC")
     )
   end
 

--- a/back/app/services/projects_finder_admin_service.rb
+++ b/back/app/services/projects_finder_admin_service.rb
@@ -104,7 +104,7 @@ class ProjectsFinderAdminService
   end
 
   def self.sort_alphabetically(scope, params)
-    # whitelist of the locale
+    # Filter locale param against configured locales to prevent SQL injection
     configured_locales = AppConfiguration.instance.settings('core', 'locales')
     locale = configured_locales.include?(params[:locale]) ? params[:locale] : 'en'
     direction = params[:sort] == 'alphabetically_desc' ? 'DESC' : 'ASC'

--- a/back/spec/services/projects_finder_admin_service_spec.rb
+++ b/back/spec/services/projects_finder_admin_service_spec.rb
@@ -344,6 +344,83 @@ describe ProjectsFinderAdminService do
       result = described_class.sort_alphabetically(Project.all, { locale: 'en', sort: 'alphabetically_asc' })
       expect(result.pluck(:id)).to eq([p1.id, p2.id, p3.id])
     end
+
+    it 'sorts projects in reverse alphabetical order' do
+      result = described_class.sort_alphabetically(Project.all, { locale: 'en', sort: 'alphabetically_desc' })
+      expect(result.pluck(:id)).to eq([p3.id, p2.id, p1.id])
+    end
+
+    it 'falls back to en when the locale is not configured on the tenant' do
+      expect(AppConfiguration.instance.settings('core', 'locales')).not_to include('zz')
+
+      result = described_class.sort_alphabetically(Project.all, { locale: 'zz', sort: 'alphabetically_asc' })
+
+      expect(result.pluck(:id)).to eq([p1.id, p2.id, p3.id])
+    end
+
+    it 'still sorts on a configured non-default locale' do
+      # The whitelist must not break locales the tenant legitimately uses.
+      locale = (AppConfiguration.instance.settings('core', 'locales') - ['en']).first
+      # Deliberately ordered the other way round in en, so sorting on the other
+      # locale is what produces the expectation below.
+      other1 = create(:project, title_multiloc: { 'en' => 'Zeta', locale => 'Aap' })
+      other2 = create(:project, title_multiloc: { 'en' => 'Alpha B', locale => 'Zebra' })
+
+      result = described_class.sort_alphabetically(
+        Project.where(id: [other1.id, other2.id]),
+        { locale: locale, sort: 'alphabetically_asc' }
+      )
+
+      expect(result.pluck(:id)).to eq([other1.id, other2.id])
+    end
+
+    # The ORDER BY is built with Arel.sql, which opts out of ActiveRecord's
+    # protection against raw SQL in `order`, and params[:locale] reaches it
+    # straight from the query string. These cover the sanitising.
+    context 'when params[:locale] carries a SQL injection payload' do
+      # Interpolated verbatim, this closes the string literal and appends its
+      # own ordering; the trailing -- swallows the rest of the clause.
+      let(:reordering_payload) { "zz' , projects.title_multiloc->>'en' DESC --" }
+
+      it 'does not let the payload take over the ORDER BY' do
+        result = described_class.sort_alphabetically(
+          Project.all, { locale: reordering_payload, sort: 'alphabetically_asc' }
+        )
+
+        expect(result.pluck(:id)).to eq([p1.id, p2.id, p3.id])
+        # The order the payload would have produced.
+        expect(result.pluck(:id)).not_to eq([p3.id, p2.id, p1.id])
+      end
+
+      it 'does not emit the payload into the generated SQL' do
+        sql = described_class.sort_alphabetically(
+          Project.all, { locale: reordering_payload, sort: 'alphabetically_asc' }
+        ).to_sql
+
+        expect(sql).not_to include('DESC --')
+        expect(sql).to include("->>'en'")
+      end
+
+      it 'does not break on a locale containing a single quote' do
+        # Interpolated verbatim, this leaves an unterminated string literal and
+        # the query fails to parse.
+        expect do
+          described_class.sort_alphabetically(
+            Project.all, { locale: "en'", sort: 'alphabetically_asc' }
+          ).load
+        end.not_to raise_error
+      end
+
+      it 'does not let the payload reach the query planner' do
+        # Syntactically valid, so it gets past the parser; it only fails once
+        # the planner resolves identifiers. Treated as a literal it is inert.
+        expect do
+          described_class.sort_alphabetically(
+            Project.all, { locale: "zz' , projects.no_such_column --" }
+          ).load
+        end.not_to raise_error
+      end
+    end
   end
 
   describe 'self.sort_by_participation' do


### PR DESCRIPTION
🎩 What? Why?
There was a vulnerability in sort_alphabetically method of ProjectsListedScopeService, which used a raw params[:locale] in a sql query.
The value of params[:locale] is now checked regarding the app locales values, or fallback to 'en'.
The SQL request performed with `Arel.sql` now uses a quoted literal instead of interpolation. 
Code added with the help of Claude.
Also looked with Claude the other places where `Arel.sql` is used to check if there was any other case of problematic interpolation, and found none.
 
The related issue is 
https://app.notion.com/p/govocal/Authenticated-SQL-injection-via-unsanitised-locale-sort-param-escalating-to-RCE-through-ERB-rendere-3b69663b7b26816299b7cb8188749280

✅ Tasks
[X] add tests

# Changelog
## Fixed
- unsanitized params[:locale] in sort_alphabetically method of ProjectsListedScopeService. 

