### PR TITLE
[TAN-8413] Improve XSS sanitisation for titles and bodies content

### DIFF
--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -40,6 +40,10 @@ class Comment < ApplicationRecord
   include AnonymousParticipation
   include LocationTrackableParticipation
 
+  # SanitizationService features allowed in the body. Single source of truth so that anything
+  # re-sanitizing a comment body (e.g. machine translations) can match these exactly.
+  BODY_SANITIZE_FEATURES = %i[mention].freeze
+
   acts_as_nested_set dependent: :destroy, counter_cache: :children_count
 
   belongs_to :idea
@@ -99,7 +103,7 @@ class Comment < ApplicationRecord
 
   def sanitize_body_multiloc
     service = SanitizationService.new
-    self.body_multiloc = service.sanitize_multiloc body_multiloc, %i[mention]
+    self.body_multiloc = service.sanitize_multiloc body_multiloc, BODY_SANITIZE_FEATURES
     self.body_multiloc = service.remove_multiloc_empty_trailing_tags body_multiloc
     self.body_multiloc = service.linkify_multiloc body_multiloc
   end

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -102,10 +102,7 @@ class Comment < ApplicationRecord
   end
 
   def sanitize_body_multiloc
-    service = SanitizationService.new
-    self.body_multiloc = service.sanitize_multiloc body_multiloc, BODY_SANITIZE_FEATURES
-    self.body_multiloc = service.remove_multiloc_empty_trailing_tags body_multiloc
-    self.body_multiloc = service.linkify_multiloc body_multiloc
+    self.body_multiloc = SanitizationService.new.sanitize_body_multiloc(body_multiloc, BODY_SANITIZE_FEATURES)
   end
 
   def remove_notifications

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -40,8 +40,8 @@ class Comment < ApplicationRecord
   include AnonymousParticipation
   include LocationTrackableParticipation
 
-  # SanitizationService features allowed in the body, shared with anything re-sanitizing a stored
-  # comment body (e.g. machine translations).
+  # `SanitizationService` features allowed in the body, shared with anything that re-sanitizes a
+  # stored body (e.g. machine translations).
   BODY_SANITIZE_FEATURES = %i[mention].freeze
 
   acts_as_nested_set dependent: :destroy, counter_cache: :children_count

--- a/back/app/models/comment.rb
+++ b/back/app/models/comment.rb
@@ -40,8 +40,8 @@ class Comment < ApplicationRecord
   include AnonymousParticipation
   include LocationTrackableParticipation
 
-  # SanitizationService features allowed in the body. Single source of truth so that anything
-  # re-sanitizing a comment body (e.g. machine translations) can match these exactly.
+  # SanitizationService features allowed in the body, shared with anything re-sanitizing a stored
+  # comment body (e.g. machine translations).
   BODY_SANITIZE_FEATURES = %i[mention].freeze
 
   acts_as_nested_set dependent: :destroy, counter_cache: :children_count

--- a/back/app/models/default_input_topic.rb
+++ b/back/app/models/default_input_topic.rb
@@ -31,6 +31,8 @@ class DefaultInputTopic < ApplicationRecord
   validates :description_multiloc, multiloc: { presence: false }
   validate :max_depth_validation
 
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
+
   # Returns "Parent > Child" format for subtopics
   def full_title_multiloc
     return title_multiloc if parent.blank?
@@ -42,6 +44,12 @@ class DefaultInputTopic < ApplicationRecord
   end
 
   private
+
+  # These titles are copied verbatim into `InputTopic` when a project is created, so strip here
+  # too: a payload must not sit waiting in the template set.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
+  end
 
   def max_depth_validation
     return if parent.blank?

--- a/back/app/models/default_input_topic.rb
+++ b/back/app/models/default_input_topic.rb
@@ -45,7 +45,6 @@ class DefaultInputTopic < ApplicationRecord
 
   private
 
-  # Copied into `InputTopic` on project creation, so a payload here would reach every new project.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/default_input_topic.rb
+++ b/back/app/models/default_input_topic.rb
@@ -45,8 +45,7 @@ class DefaultInputTopic < ApplicationRecord
 
   private
 
-  # These titles are copied verbatim into `InputTopic` when a project is created, so strip here
-  # too: a payload must not sit waiting in the template set.
+  # Copied into `InputTopic` on project creation, so a payload here would reach every new project.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/event.rb
+++ b/back/app/models/event.rb
@@ -58,6 +58,7 @@ class Event < ApplicationRecord
   validate :validate_start_at_before_end_at
 
   before_validation :sanitize_description_multiloc
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
   before_validation :strip_title
 
   scope :with_project_publication_statuses, lambda { |statuses|
@@ -80,6 +81,11 @@ class Event < ApplicationRecord
     return unless start_at.present? && end_at.present? && start_at > end_at
 
     errors.add(:start_at, :after_end_at, message: 'is after end_at')
+  end
+
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end
 
   def strip_title

--- a/back/app/models/global_topic.rb
+++ b/back/app/models/global_topic.rb
@@ -51,7 +51,6 @@ class GlobalTopic < ApplicationRecord
 
   private
 
-  # Kept in step with `InputTopic`, whose title is rendered as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/global_topic.rb
+++ b/back/app/models/global_topic.rb
@@ -38,6 +38,7 @@ class GlobalTopic < ApplicationRecord
   validates :description_multiloc, multiloc: { presence: false }
   validates :include_in_onboarding, inclusion: { in: [true, false] }
 
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
   before_validation :strip_title
 
   scope :order_new, ->(direction = :desc) { order(created_at: direction, id: direction) }
@@ -50,8 +51,14 @@ class GlobalTopic < ApplicationRecord
 
   private
 
+  # No confirmed HTML render path for this title today, but it is admin-editable and shares its
+  # shape with `InputTopic`, whose title is rendered as raw HTML. Keep the rule uniform.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
+  end
+
   def strip_title
-    return unless description_multiloc&.any?
+    return unless title_multiloc&.any?
 
     title_multiloc.each do |key, value|
       title_multiloc[key] = value.strip

--- a/back/app/models/global_topic.rb
+++ b/back/app/models/global_topic.rb
@@ -51,8 +51,7 @@ class GlobalTopic < ApplicationRecord
 
   private
 
-  # No confirmed HTML render path for this title today, but it is admin-editable and shares its
-  # shape with `InputTopic`, whose title is rendered as raw HTML. Keep the rule uniform.
+  # Kept in step with `InputTopic`, whose title is rendered as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -526,7 +526,7 @@ class Idea < ApplicationRecord
     end
   end
 
-  # Titles are plain text, but Common Ground statements render one as raw HTML.
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -79,6 +79,10 @@ class Idea < ApplicationRecord
   # re-sanitizing an idea body (e.g. machine translations) can match these exactly.
   BODY_SANITIZE_FEATURES = %i[title alignment list decoration link image video].freeze
 
+  # Strip/decode passes allowed before `sanitize_title_multiloc` gives up and stores the
+  # escaped form. Each pass peels one layer of entity encoding; real titles settle in 1-3.
+  TITLE_SANITIZE_PASSES = 5
+
   attr_accessor :request # Non persisted attribute to store request to be used by EveryoneTrackingService
 
   slug from: proc { |idea| idea&.participation_method_on_creation&.generate_slug(idea) }
@@ -107,7 +111,7 @@ class Idea < ApplicationRecord
   has_many_text_images from: :body_multiloc
 
   before_validation :sanitize_body_multiloc, if: :body_multiloc
-  before_validation :sanitize_title_multiloc, if: :title_multiloc
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
 
   # Must appear before before_destroy
   before_save :convert_wkt_geo_custom_field_values_to_geojson
@@ -530,10 +534,28 @@ class Idea < ApplicationRecord
   # Titles are plain text but reach HTML render paths (e.g. supportHtml in Common Ground),
   # so strip all markup. Runs for drafts too, since draft content is rendered to admins.
   def sanitize_title_multiloc
-    full_sanitizer = ActionView::Base.full_sanitizer
     title_multiloc.each do |key, value|
-      title_multiloc[key] = full_sanitizer.sanitize(value) if value
+      title_multiloc[key] = strip_title_markup(value) if value
     end
+  end
+
+  # `full_sanitizer` re-serializes the text nodes it keeps, so on its own it entity-encodes
+  # every `&`, `<` and `>` that survives - turning "Fish & chips" into "Fish &amp; chips".
+  # Decoding after each pass keeps plain text intact; repeating until the value settles stops
+  # an encoded payload (`&lt;script&gt;`) from surviving by hiding one decode behind another.
+  def strip_title_markup(value)
+    full_sanitizer = ActionView::Base.full_sanitizer
+
+    TITLE_SANITIZE_PASSES.times do
+      decoded = CGI.unescapeHTML(full_sanitizer.sanitize(value))
+      return decoded if decoded == value
+
+      value = decoded
+    end
+
+    # Only reachable for pathologically nested encodings. Fall back to the escaped form,
+    # which is inert wherever a title is rendered.
+    full_sanitizer.sanitize(value)
   end
 
   def set_submitted_at

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -75,8 +75,8 @@ class Idea < ApplicationRecord
   PUBLICATION_STATUSES = %w[draft submitted published].freeze
   SUBMISSION_STATUSES = %w[submitted published].freeze
 
-  # SanitizationService features allowed in the body, shared with anything re-sanitizing a stored
-  # idea body (e.g. machine translations).
+  # `SanitizationService` features allowed in the body, shared with anything that re-sanitizes a
+  # stored body (e.g. machine translations).
   BODY_SANITIZE_FEATURES = %i[title alignment list decoration link image video].freeze
 
   attr_accessor :request # Non persisted attribute to store request to be used by EveryoneTrackingService
@@ -107,8 +107,8 @@ class Idea < ApplicationRecord
   has_many_text_images from: :body_multiloc
 
   before_validation :sanitize_body_multiloc, if: :body_multiloc
-  # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
-  # `ApplicationRecord` and would otherwise build the slug from the raw title.
+  # `prepend: true` puts this before `Sluggable#generate_slug` (registered on `ApplicationRecord`),
+  # which would otherwise build the slug from the raw title.
   before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
 
   # Must appear before before_destroy
@@ -526,8 +526,7 @@ class Idea < ApplicationRecord
     end
   end
 
-  # Titles are plain text but reach HTML render paths (e.g. supportHtml in Common Ground),
-  # so strip all markup. Runs for drafts too, since draft content is rendered to admins.
+  # Titles are plain text, but Common Ground statements render one as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -423,10 +423,7 @@ class Idea < ApplicationRecord
   end
 
   def sanitize_body_multiloc
-    service = SanitizationService.new
-    self.body_multiloc = service.sanitize_multiloc(body_multiloc, BODY_SANITIZE_FEATURES)
-    self.body_multiloc = service.remove_multiloc_empty_trailing_tags(body_multiloc)
-    self.body_multiloc = service.linkify_multiloc(body_multiloc)
+    self.body_multiloc = SanitizationService.new.sanitize_body_multiloc(body_multiloc, BODY_SANITIZE_FEATURES)
   end
 
   def fix_comments_count_on_projects

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -103,6 +103,7 @@ class Idea < ApplicationRecord
   has_many_text_images from: :body_multiloc
 
   before_validation :sanitize_body_multiloc, if: :body_multiloc
+  before_validation :sanitize_title_multiloc, if: :title_multiloc
 
   # Must appear before before_destroy
   before_save :convert_wkt_geo_custom_field_values_to_geojson
@@ -522,6 +523,15 @@ class Idea < ApplicationRecord
 
     title_multiloc.each do |key, value|
       title_multiloc[key] = value.strip
+    end
+  end
+
+  # Titles are plain text but reach HTML render paths (e.g. supportHtml in Common Ground),
+  # so strip all markup. Runs for drafts too, since draft content is rendered to admins.
+  def sanitize_title_multiloc
+    full_sanitizer = ActionView::Base.full_sanitizer
+    title_multiloc.each do |key, value|
+      title_multiloc[key] = full_sanitizer.sanitize(value) if value
     end
   end
 

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -79,10 +79,6 @@ class Idea < ApplicationRecord
   # re-sanitizing an idea body (e.g. machine translations) can match these exactly.
   BODY_SANITIZE_FEATURES = %i[title alignment list decoration link image video].freeze
 
-  # Strip/decode passes allowed before `sanitize_title_multiloc` gives up and stores the
-  # escaped form. Each pass peels one layer of entity encoding; real titles settle in 1-3.
-  TITLE_SANITIZE_PASSES = 5
-
   attr_accessor :request # Non persisted attribute to store request to be used by EveryoneTrackingService
 
   slug from: proc { |idea| idea&.participation_method_on_creation&.generate_slug(idea) }
@@ -534,28 +530,10 @@ class Idea < ApplicationRecord
   # Titles are plain text but reach HTML render paths (e.g. supportHtml in Common Ground),
   # so strip all markup. Runs for drafts too, since draft content is rendered to admins.
   def sanitize_title_multiloc
+    service = SanitizationService.new
     title_multiloc.each do |key, value|
-      title_multiloc[key] = strip_title_markup(value) if value
+      title_multiloc[key] = service.strip_to_plain_text(value) if value
     end
-  end
-
-  # `full_sanitizer` re-serializes the text nodes it keeps, so on its own it entity-encodes
-  # every `&`, `<` and `>` that survives - turning "Fish & chips" into "Fish &amp; chips".
-  # Decoding after each pass keeps plain text intact; repeating until the value settles stops
-  # an encoded payload (`&lt;script&gt;`) from surviving by hiding one decode behind another.
-  def strip_title_markup(value)
-    full_sanitizer = ActionView::Base.full_sanitizer
-
-    TITLE_SANITIZE_PASSES.times do
-      decoded = CGI.unescapeHTML(full_sanitizer.sanitize(value))
-      return decoded if decoded == value
-
-      value = decoded
-    end
-
-    # Only reachable for pathologically nested encodings. Fall back to the escaped form,
-    # which is inert wherever a title is rendered.
-    full_sanitizer.sanitize(value)
   end
 
   def set_submitted_at

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -102,6 +102,8 @@ class Idea < ApplicationRecord
 
   has_many_text_images from: :body_multiloc
 
+  before_validation :sanitize_body_multiloc, if: :body_multiloc
+
   # Must appear before before_destroy
   before_save :convert_wkt_geo_custom_field_values_to_geojson
   after_update :fix_comments_count_on_projects
@@ -171,7 +173,6 @@ class Idea < ApplicationRecord
     validates :idea_status, presence: true
     validates :project, presence: true
     before_validation :assign_defaults
-    before_validation :sanitize_body_multiloc, if: :body_multiloc
   end
 
   pg_search_scope :search_by_all,

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -527,10 +527,7 @@ class Idea < ApplicationRecord
   # Titles are plain text but reach HTML render paths (e.g. supportHtml in Common Ground),
   # so strip all markup. Runs for drafts too, since draft content is rendered to admins.
   def sanitize_title_multiloc
-    service = SanitizationService.new
-    title_multiloc.each do |key, value|
-      title_multiloc[key] = service.strip_to_plain_text(value) if value
-    end
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end
 
   def set_submitted_at

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -75,8 +75,8 @@ class Idea < ApplicationRecord
   PUBLICATION_STATUSES = %w[draft submitted published].freeze
   SUBMISSION_STATUSES = %w[submitted published].freeze
 
-  # SanitizationService features allowed in the body. Single source of truth so that anything
-  # re-sanitizing an idea body (e.g. machine translations) can match these exactly.
+  # SanitizationService features allowed in the body, shared with anything re-sanitizing a stored
+  # idea body (e.g. machine translations).
   BODY_SANITIZE_FEATURES = %i[title alignment list decoration link image video].freeze
 
   attr_accessor :request # Non persisted attribute to store request to be used by EveryoneTrackingService

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -107,7 +107,9 @@ class Idea < ApplicationRecord
   has_many_text_images from: :body_multiloc
 
   before_validation :sanitize_body_multiloc, if: :body_multiloc
-  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
+  # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
+  # `ApplicationRecord` and would otherwise build the slug from the raw title.
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
 
   # Must appear before before_destroy
   before_save :convert_wkt_geo_custom_field_values_to_geojson

--- a/back/app/models/idea.rb
+++ b/back/app/models/idea.rb
@@ -75,6 +75,10 @@ class Idea < ApplicationRecord
   PUBLICATION_STATUSES = %w[draft submitted published].freeze
   SUBMISSION_STATUSES = %w[submitted published].freeze
 
+  # SanitizationService features allowed in the body. Single source of truth so that anything
+  # re-sanitizing an idea body (e.g. machine translations) can match these exactly.
+  BODY_SANITIZE_FEATURES = %i[title alignment list decoration link image video].freeze
+
   attr_accessor :request # Non persisted attribute to store request to be used by EveryoneTrackingService
 
   slug from: proc { |idea| idea&.participation_method_on_creation&.generate_slug(idea) }
@@ -420,10 +424,7 @@ class Idea < ApplicationRecord
 
   def sanitize_body_multiloc
     service = SanitizationService.new
-    self.body_multiloc = service.sanitize_multiloc(
-      body_multiloc,
-      %i[title alignment list decoration link image video]
-    )
+    self.body_multiloc = service.sanitize_multiloc(body_multiloc, BODY_SANITIZE_FEATURES)
     self.body_multiloc = service.remove_multiloc_empty_trailing_tags(body_multiloc)
     self.body_multiloc = service.linkify_multiloc(body_multiloc)
   end

--- a/back/app/models/input_topic.rb
+++ b/back/app/models/input_topic.rb
@@ -44,6 +44,8 @@ class InputTopic < ApplicationRecord
   validate :max_depth_validation
   validate :icon_only_for_root_topics
 
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
+
   scope :order_ideas_count, lambda { |ideas, direction: :asc|
     topics_counts = IdeasCountService.counts(ideas, ['input_topic_id'])['input_topic_id']
     sorted_ids = ids.sort_by do |id|
@@ -64,6 +66,12 @@ class InputTopic < ApplicationRecord
   end
 
   private
+
+  # Titles are plain text but reach an HTML render path - the ideas feed sidebar renders a topic
+  # title as raw HTML - so strip all markup.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
+  end
 
   def max_depth_validation
     return if parent.blank?

--- a/back/app/models/input_topic.rb
+++ b/back/app/models/input_topic.rb
@@ -67,8 +67,7 @@ class InputTopic < ApplicationRecord
 
   private
 
-  # Titles are plain text but reach an HTML render path - the ideas feed sidebar renders a topic
-  # title as raw HTML - so strip all markup.
+  # Titles are plain text, but the ideas feed sidebar renders a topic title as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/input_topic.rb
+++ b/back/app/models/input_topic.rb
@@ -67,7 +67,7 @@ class InputTopic < ApplicationRecord
 
   private
 
-  # Titles are plain text, but the ideas feed sidebar renders a topic title as raw HTML.
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -437,8 +437,7 @@ class Phase < ApplicationRecord
     @previous_phase_end_at_updated = true
   end
 
-  # Titles are plain text, but a changed title reaches an HTML render path: the admin management
-  # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+  # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -102,6 +102,7 @@ class Phase < ApplicationRecord
 
   before_validation :sanitize_description_multiloc
   before_validation :sanitize_draft_description_multiloc
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
   before_validation :strip_title
   before_validation :set_participation_method_defaults, on: :create
   before_validation :set_participation_method_defaults_on_method_change, on: :update
@@ -434,6 +435,12 @@ class Phase < ApplicationRecord
 
     previous_phase.update!(end_at: start_at)
     @previous_phase_end_at_updated = true
+  end
+
+  # Titles are plain text, but a changed title reaches an HTML render path: the admin management
+  # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end
 
   def strip_title

--- a/back/app/models/phase.rb
+++ b/back/app/models/phase.rb
@@ -437,7 +437,7 @@ class Phase < ApplicationRecord
     @previous_phase_end_at_updated = true
   end
 
-  # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -88,8 +88,8 @@ class Project < ApplicationRecord
   before_validation :sanitize_description_multiloc, if: :description_multiloc
   before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
   before_validation :set_visible_to, on: :create
-  # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
-  # `ApplicationRecord` and would otherwise build the slug from the raw title.
+  # `prepend: true` puts this before `Sluggable#generate_slug` (registered on `ApplicationRecord`),
+  # which would otherwise build the slug from the raw title.
   before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
   before_validation :strip_title
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
@@ -356,8 +356,7 @@ class Project < ApplicationRecord
     self.visible_to ||= 'public'
   end
 
-  # Titles are plain text, but a changed title reaches an HTML render path: the admin management
-  # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+  # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -356,7 +356,7 @@ class Project < ApplicationRecord
     self.visible_to ||= 'public'
   end
 
-  # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
   def sanitize_title_multiloc
     self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -47,7 +47,9 @@ class Project < ApplicationRecord
 
   VISIBLE_TOS = %w[public groups admins].freeze
 
-  slug from: proc { |project| project.title_multiloc&.values&.find(&:present?) }
+  # `Sluggable` registers on `ApplicationRecord`, so this runs before `sanitize_title_multiloc` and
+  # sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
+  slug from: proc { |project| SanitizationService.new.strip_to_plain_text(project.title_multiloc&.values&.find(&:present?)) }
 
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
@@ -88,6 +90,7 @@ class Project < ApplicationRecord
   before_validation :sanitize_description_multiloc, if: :description_multiloc
   before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
   before_validation :set_visible_to, on: :create
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
   before_validation :strip_title
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify
@@ -351,6 +354,12 @@ class Project < ApplicationRecord
 
   def set_visible_to
     self.visible_to ||= 'public'
+  end
+
+  # Titles are plain text, but a changed title reaches an HTML render path: the admin management
+  # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end
 
   def strip_title

--- a/back/app/models/project.rb
+++ b/back/app/models/project.rb
@@ -47,9 +47,7 @@ class Project < ApplicationRecord
 
   VISIBLE_TOS = %w[public groups admins].freeze
 
-  # `Sluggable` registers on `ApplicationRecord`, so this runs before `sanitize_title_multiloc` and
-  # sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
-  slug from: proc { |project| SanitizationService.new.strip_to_plain_text(project.title_multiloc&.values&.find(&:present?)) }
+  slug from: proc { |project| project.title_multiloc&.values&.find(&:present?) }
 
   mount_base64_uploader :header_bg, ProjectHeaderBgUploader
 
@@ -90,7 +88,9 @@ class Project < ApplicationRecord
   before_validation :sanitize_description_multiloc, if: :description_multiloc
   before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
   before_validation :set_visible_to, on: :create
-  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
+  # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
+  # `ApplicationRecord` and would otherwise build the slug from the raw title.
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
   before_validation :strip_title
   before_destroy :remove_notifications # Must occur before has_many :notifications (see https://github.com/rails/rails/issues/5205)
   has_many :notifications, dependent: :nullify

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -31,7 +31,9 @@ module ProjectFolders
     include Files::FileAttachable
     include PgSearch::Model
 
-    slug from: proc { |folder| folder.title_multiloc&.values&.find(&:present?) }
+    # `Sluggable` registers on `ApplicationRecord`, so this runs before `sanitize_title_multiloc`
+    # and sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
+    slug from: proc { |folder| SanitizationService.new.strip_to_plain_text(folder.title_multiloc&.values&.find(&:present?)) }
 
     belongs_to :space, optional: true
 
@@ -53,6 +55,7 @@ module ProjectFolders
 
     before_validation :sanitize_description_multiloc, if: :description_multiloc
     before_validation :sanitize_description_preview_multiloc, if: :description_preview_multiloc
+    before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
     before_validation :strip_title
     before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
 
@@ -112,6 +115,12 @@ module ProjectFolders
         %i[decoration link]
       )
       self.description_preview_multiloc = service.remove_multiloc_empty_trailing_tags description_preview_multiloc
+    end
+
+    # Titles are plain text, but a changed title reaches an HTML render path: the admin management
+    # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+    def sanitize_title_multiloc
+      self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
     end
 
     def strip_title

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -53,8 +53,8 @@ module ProjectFolders
 
     before_validation :sanitize_description_multiloc, if: :description_multiloc
     before_validation :sanitize_description_preview_multiloc, if: :description_preview_multiloc
-    # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
-    # `ApplicationRecord` and would otherwise build the slug from the raw title.
+    # `prepend: true` puts this before `Sluggable#generate_slug` (registered on `ApplicationRecord`),
+    # which would otherwise build the slug from the raw title.
     before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
     before_validation :strip_title
     before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
@@ -117,8 +117,7 @@ module ProjectFolders
       self.description_preview_multiloc = service.remove_multiloc_empty_trailing_tags description_preview_multiloc
     end
 
-    # Titles are plain text, but a changed title reaches an HTML render path: the admin management
-    # feed renders each changed multiloc attribute as raw HTML. So strip all markup.
+    # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
     def sanitize_title_multiloc
       self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
     end

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -117,7 +117,7 @@ module ProjectFolders
       self.description_preview_multiloc = service.remove_multiloc_empty_trailing_tags description_preview_multiloc
     end
 
-    # Titles are plain text, but the admin management feed renders a changed title as raw HTML.
+    # Titles are plain text: strip markup so nothing downstream can render it as HTML.
     def sanitize_title_multiloc
       self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
     end

--- a/back/app/models/project_folders/folder.rb
+++ b/back/app/models/project_folders/folder.rb
@@ -31,9 +31,7 @@ module ProjectFolders
     include Files::FileAttachable
     include PgSearch::Model
 
-    # `Sluggable` registers on `ApplicationRecord`, so this runs before `sanitize_title_multiloc`
-    # and sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
-    slug from: proc { |folder| SanitizationService.new.strip_to_plain_text(folder.title_multiloc&.values&.find(&:present?)) }
+    slug from: proc { |folder| folder.title_multiloc&.values&.find(&:present?) }
 
     belongs_to :space, optional: true
 
@@ -55,7 +53,9 @@ module ProjectFolders
 
     before_validation :sanitize_description_multiloc, if: :description_multiloc
     before_validation :sanitize_description_preview_multiloc, if: :description_preview_multiloc
-    before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }
+    # `prepend: true` so this runs before `Sluggable`'s `generate_slug`, which is registered on
+    # `ApplicationRecord` and would otherwise build the slug from the raw title.
+    before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
     before_validation :strip_title
     before_validation :set_admin_publication, unless: proc { Current.loading_tenant_template }
 

--- a/back/app/models/static_page.rb
+++ b/back/app/models/static_page.rb
@@ -71,6 +71,9 @@ class StaticPage < ApplicationRecord
   accepts_nested_attributes_for :nav_bar_item
 
   before_validation :set_code, on: :create
+  # `prepend: true` puts this before `Sluggable#generate_slug` (registered on `ApplicationRecord`),
+  # which would otherwise build the slug from the raw title.
+  before_validation :sanitize_title_multiloc, if: -> { title_multiloc && title_multiloc_changed? }, prepend: true
   before_validation :strip_title
   before_validation :sanitize_top_info_section_multiloc
   before_validation :sanitize_bottom_info_section_multiloc
@@ -200,6 +203,11 @@ class StaticPage < ApplicationRecord
 
   def set_code
     self.code ||= 'custom'
+  end
+
+  # Titles are plain text: strip markup so nothing downstream can render it as HTML.
+  def sanitize_title_multiloc
+    self.title_multiloc = SanitizationService.new.strip_multiloc_to_plain_text(title_multiloc)
   end
 
   def strip_title

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -497,9 +497,8 @@ class User < ApplicationRecord
     self.bio_multiloc = service.linkify_multiloc(bio_multiloc)
   end
 
-  # Names are plain text. A bare `full_sanitizer` pass entity-encodes what it keeps ("O'Brien" ->
-  # "O&#39;Brien") and leaves a payload hiding behind its own encoding intact, so use the shared
-  # plain-text pipeline instead.
+  # Not a bare `full_sanitizer` pass: that entity-encodes what it keeps ("O'Brien" -> "O&#39;Brien")
+  # and leaves a payload hiding behind its own encoding intact.
   def sanitize_first_name
     self.first_name = SanitizationService.new.strip_to_plain_text(first_name)
   end

--- a/back/app/models/user.rb
+++ b/back/app/models/user.rb
@@ -497,12 +497,15 @@ class User < ApplicationRecord
     self.bio_multiloc = service.linkify_multiloc(bio_multiloc)
   end
 
+  # Names are plain text. A bare `full_sanitizer` pass entity-encodes what it keeps ("O'Brien" ->
+  # "O&#39;Brien") and leaves a payload hiding behind its own encoding intact, so use the shared
+  # plain-text pipeline instead.
   def sanitize_first_name
-    self.first_name = ActionView::Base.full_sanitizer.sanitize(first_name)
+    self.first_name = SanitizationService.new.strip_to_plain_text(first_name)
   end
 
   def sanitize_last_name
-    self.last_name = ActionView::Base.full_sanitizer.sanitize(last_name)
+    self.last_name = SanitizationService.new.strip_to_plain_text(last_name)
   end
 
   def email_or_new_email_changed?

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -102,6 +102,8 @@ class SanitizationService
   # decode after each pass, and repeat until the value settles - otherwise a payload survives by
   # hiding behind its own encoding (`&lt;script&gt;`).
   def strip_to_plain_text(text)
+    return nil if text.nil?
+
     full_sanitizer = ActionView::Base.full_sanitizer
 
     PLAIN_TEXT_PASSES.times do
@@ -114,6 +116,12 @@ class SanitizationService
     # More layers of encoding than we have passes (`&amp;amp;amp;amp;amp;lt;script&gt;`). Return
     # the escaped form, which renders as literal text rather than markup.
     full_sanitizer.sanitize(text)
+  end
+
+  # The pipeline for a plain-text multiloc field, i.e. a title. Shared so that every model whose
+  # title reaches an HTML render path strips it by the same rule.
+  def strip_multiloc_to_plain_text(multiloc)
+    multiloc.transform_values { |text| strip_to_plain_text(text) }
   end
 
   def html_with_content?(text_or_html)

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -152,7 +152,7 @@ class SanitizationService
 
     def initialize(features = [])
       super()
-      features_w_default = features.push(:default)
+      features_w_default = features + [:default]
       @tags = features_w_default.flat_map { |f| EDITOR_FEATURES[f][:tags] }.uniq
       @attributes = features_w_default.flat_map { |f| EDITOR_FEATURES[f][:attributes] }.uniq
     end

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -91,6 +91,9 @@ class SanitizationService
   # @param html [String] Body HTML to process.
   # @param features [Array<Symbol>] A list of allowed features.
   # @return [String] The processed body HTML.
+  # A `nil` value comes back as `''` rather than `nil`, because `remove_empty_trailing_tags`
+  # serializes an empty document. That is long-standing behaviour the models relied on before
+  # this pipeline was extracted, so it is preserved deliberately - do not add a nil guard.
   def sanitize_body(html, features)
     html = sanitize(html, features)
     html = remove_empty_trailing_tags(html)
@@ -98,7 +101,7 @@ class SanitizationService
   end
 
   def sanitize_body_multiloc(multiloc, features)
-    multiloc.transform_values { |html| html ? sanitize_body(html, features) : html }
+    multiloc.transform_values { |html| sanitize_body(html, features) }
   end
 
   # Reduces text to plain text: no markup, and no entity encoding of the text that survives.

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -6,8 +6,7 @@ class SanitizationService
 
   EDITOR_STRUCTURE_TAGS = %w[div p h2 h3 ol ul].freeze
 
-  # Strip/decode passes allowed before `strip_to_plain_text` gives up and returns the escaped
-  # form. Each pass peels one layer of entity encoding; real text settles in 1-3.
+  # Each `strip_to_plain_text` pass peels one layer of entity encoding; real text settles in 1-3.
   PLAIN_TEXT_PASSES = 5
 
   SANITIZER = Rails::Html::SafeListSanitizer.new
@@ -80,20 +79,13 @@ class SanitizationService
     Rinku.auto_link(html, :all, 'target="_blank" rel="noreferrer noopener nofollow"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
   end
 
-  # The full pipeline applied to a user-authored rich-text body: sanitize, drop empty trailing
-  # tags, then linkify. The order matters and is part of the contract - sanitizing *before*
-  # linkifying is what forces an anchor's href to agree with its visible text, so an allowlist
-  # that omits `:link` still ends up with links, just never spoofed ones.
+  # The pipeline `Idea` and `Comment` apply to their bodies, shared so that anything reprocessing
+  # a stored body (machine translations, the stored-XSS purge) applies the same rules.
   #
-  # Single source of truth for `Idea`/`Comment` body handling, so anything reprocessing a stored
-  # body (machine translations, the stored-XSS purge) applies the same rules rather than its own.
+  # Sanitizing before linkifying is load-bearing: it drops the author's anchors and rebuilds them
+  # from the visible text, so an href can never disagree with its label.
   #
-  # @param html [String] Body HTML to process.
-  # @param features [Array<Symbol>] A list of allowed features.
-  # @return [String] The processed body HTML.
-  # A `nil` value comes back as `''` rather than `nil`, because `remove_empty_trailing_tags`
-  # serializes an empty document. That is long-standing behaviour the models relied on before
-  # this pipeline was extracted, so it is preserved deliberately - do not add a nil guard.
+  # A nil value comes back as '' rather than nil. Long-standing behaviour - do not add a guard.
   def sanitize_body(html, features)
     html = sanitize(html, features)
     html = remove_empty_trailing_tags(html)
@@ -106,13 +98,9 @@ class SanitizationService
 
   # Reduces text to plain text: no markup, and no entity encoding of the text that survives.
   #
-  # `full_sanitizer` re-serializes the text nodes it keeps, so on its own it entity-encodes
-  # every `&`, `<` and `>` - turning "Fish & chips" into "Fish &amp; chips". Decoding after
-  # each pass keeps plain text intact; repeating until the value settles stops an encoded
-  # payload (`&lt;script&gt;`) from surviving by hiding one decode behind another.
-  #
-  # @param text [String] Text that may contain markup.
-  # @return [String] The text with all markup removed.
+  # `full_sanitizer` alone entity-encodes what it keeps ("Fish & chips" -> "Fish &amp; chips"), so
+  # decode after each pass, and repeat until the value settles - otherwise a payload survives by
+  # hiding behind its own encoding (`&lt;script&gt;`).
   def strip_to_plain_text(text)
     full_sanitizer = ActionView::Base.full_sanitizer
 
@@ -123,8 +111,8 @@ class SanitizationService
       text = decoded
     end
 
-    # Only reachable for pathologically nested encodings. Fall back to the escaped form,
-    # which is inert wherever it is rendered.
+    # More layers of encoding than we have passes (`&amp;amp;amp;amp;amp;lt;script&gt;`). Return
+    # the escaped form, which renders as literal text rather than markup.
     full_sanitizer.sanitize(text)
   end
 

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -6,6 +6,10 @@ class SanitizationService
 
   EDITOR_STRUCTURE_TAGS = %w[div p h2 h3 ol ul].freeze
 
+  # Strip/decode passes allowed before `strip_to_plain_text` gives up and returns the escaped
+  # form. Each pass peels one layer of entity encoding; real text settles in 1-3.
+  PLAIN_TEXT_PASSES = 5
+
   SANITIZER = Rails::Html::SafeListSanitizer.new
 
   private_constant :SANITIZER
@@ -74,6 +78,30 @@ class SanitizationService
   # @return [String] The text with it's content being transformed into links.
   def linkify(html)
     Rinku.auto_link(html, :all, 'target="_blank" rel="noreferrer noopener nofollow"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
+  end
+
+  # Reduces text to plain text: no markup, and no entity encoding of the text that survives.
+  #
+  # `full_sanitizer` re-serializes the text nodes it keeps, so on its own it entity-encodes
+  # every `&`, `<` and `>` - turning "Fish & chips" into "Fish &amp; chips". Decoding after
+  # each pass keeps plain text intact; repeating until the value settles stops an encoded
+  # payload (`&lt;script&gt;`) from surviving by hiding one decode behind another.
+  #
+  # @param text [String] Text that may contain markup.
+  # @return [String] The text with all markup removed.
+  def strip_to_plain_text(text)
+    full_sanitizer = ActionView::Base.full_sanitizer
+
+    PLAIN_TEXT_PASSES.times do
+      decoded = CGI.unescapeHTML(full_sanitizer.sanitize(text))
+      return decoded if decoded == text
+
+      text = decoded
+    end
+
+    # Only reachable for pathologically nested encodings. Fall back to the escaped form,
+    # which is inert wherever it is rendered.
+    full_sanitizer.sanitize(text)
   end
 
   def html_with_content?(text_or_html)

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -80,6 +80,27 @@ class SanitizationService
     Rinku.auto_link(html, :all, 'target="_blank" rel="noreferrer noopener nofollow"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
   end
 
+  # The full pipeline applied to a user-authored rich-text body: sanitize, drop empty trailing
+  # tags, then linkify. The order matters and is part of the contract - sanitizing *before*
+  # linkifying is what forces an anchor's href to agree with its visible text, so an allowlist
+  # that omits `:link` still ends up with links, just never spoofed ones.
+  #
+  # Single source of truth for `Idea`/`Comment` body handling, so anything reprocessing a stored
+  # body (machine translations, the stored-XSS purge) applies the same rules rather than its own.
+  #
+  # @param html [String] Body HTML to process.
+  # @param features [Array<Symbol>] A list of allowed features.
+  # @return [String] The processed body HTML.
+  def sanitize_body(html, features)
+    html = sanitize(html, features)
+    html = remove_empty_trailing_tags(html)
+    linkify(html)
+  end
+
+  def sanitize_body_multiloc(multiloc, features)
+    multiloc.transform_values { |html| html ? sanitize_body(html, features) : html }
+  end
+
   # Reduces text to plain text: no markup, and no entity encoding of the text that survives.
   #
   # `full_sanitizer` re-serializes the text nodes it keeps, so on its own it entity-encodes

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -14,7 +14,7 @@ class SanitizationService
   private_constant :SANITIZER
 
   # Sanitizes a string from malicious and unwanted input.
-  # @param sanitize [String] string input to be sanitized
+  # @param text [String] string input to be sanitized
   # @param features [Array<Symbol>] A list of allowed features
   # See {IframeScrubber, EDITOR_FEATURES} for the list of allowed tags and attributes.
   def sanitize(text, features)
@@ -79,15 +79,14 @@ class SanitizationService
     Rinku.auto_link(html, :all, 'target="_blank" rel="noreferrer noopener nofollow"', nil, Rinku::AUTOLINK_SHORT_DOMAINS)
   end
 
-  # The pipeline `Idea` and `Comment` apply to their bodies, shared so that anything reprocessing
-  # a stored body (machine translations, the stored-XSS purge) applies the same rules.
+  # The pipeline `Idea` and `Comment` apply to their bodies, shared with anything reprocessing a
+  # stored body (e.g. machine translations).
   #
-  # Sanitizing before linkifying is load-bearing, but what it buys depends on `features`. Where
-  # `:link` is absent (`Comment`), the author's anchors are dropped and rebuilt from the visible
-  # text, so an href cannot disagree with its label. Where `:link` is present (`Idea`), anchors
-  # survive as written: the href is scheme-scrubbed, but it need not match the text it labels.
+  # Sanitizing runs before linkifying, so where `features` omits `:link` (`Comment`) the author's
+  # anchors are dropped and rebuilt from the visible text, and an href cannot disagree with its
+  # label. Where `:link` is present (`Idea`) anchors survive as written, scheme-scrubbed only.
   #
-  # A nil value comes back as '' rather than nil. Long-standing behaviour - do not add a guard.
+  # A nil value comes back as '', not nil. Long-standing behaviour - do not add a guard.
   def sanitize_body(html, features)
     html = sanitize(html, features)
     html = remove_empty_trailing_tags(html)
@@ -98,10 +97,10 @@ class SanitizationService
     multiloc.transform_values { |html| sanitize_body(html, features) }
   end
 
-  # Reduces text to plain text: no markup, and no entity encoding of the text that survives.
+  # Reduces text to plain text: no markup, and no entity encoding of what survives.
   #
   # `full_sanitizer` alone entity-encodes what it keeps ("Fish & chips" -> "Fish &amp; chips"), so
-  # decode after each pass, and repeat until the value settles - otherwise a payload survives by
+  # decode after each pass and repeat until the value settles - otherwise a payload survives by
   # hiding behind its own encoding (`&lt;script&gt;`).
   def strip_to_plain_text(text)
     return nil if text.nil?
@@ -115,13 +114,11 @@ class SanitizationService
       text = decoded
     end
 
-    # More layers of encoding than we have passes (`&amp;amp;amp;amp;amp;lt;script&gt;`). Return
-    # the escaped form, which renders as literal text rather than markup.
+    # More encoding layers than passes: return the escaped form, which renders as literal text.
     full_sanitizer.sanitize(text)
   end
 
-  # The pipeline for a plain-text multiloc field, i.e. a title. Shared so that every model whose
-  # title reaches an HTML render path strips it by the same rule.
+  # `strip_to_plain_text` across a multiloc - the rule every title-bearing model shares.
   def strip_multiloc_to_plain_text(multiloc)
     multiloc.transform_values { |text| strip_to_plain_text(text) }
   end

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -82,8 +82,10 @@ class SanitizationService
   # The pipeline `Idea` and `Comment` apply to their bodies, shared so that anything reprocessing
   # a stored body (machine translations, the stored-XSS purge) applies the same rules.
   #
-  # Sanitizing before linkifying is load-bearing: it drops the author's anchors and rebuilds them
-  # from the visible text, so an href can never disagree with its label.
+  # Sanitizing before linkifying is load-bearing, but what it buys depends on `features`. Where
+  # `:link` is absent (`Comment`), the author's anchors are dropped and rebuilt from the visible
+  # text, so an href cannot disagree with its label. Where `:link` is present (`Idea`), anchors
+  # survive as written: the href is scheme-scrubbed, but it need not match the text it labels.
   #
   # A nil value comes back as '' rather than nil. Long-standing behaviour - do not add a guard.
   def sanitize_body(html, features)

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -30,9 +30,13 @@ module MachineTranslations
     # more permissive than the text it came from, without a second set of rules that could drift.
     before_validation :sanitize_translation, if: :translation
 
-    # [translatable_type, attribute_name] -> the source field's pipeline. Anything not listed is
-    # treated as plain text. Lambdas defer autoloading `Idea`/`Comment` until the callback runs.
+    PLAIN_TEXT_PIPELINE = ->(text) { SanitizationService.new.strip_to_plain_text(text) }
+
+    # [translatable_type, attribute_name] -> the source field's pipeline. Every translatable field
+    # is listed, so that a field's rule is always a decision someone made rather than a default.
+    # Lambdas defer autoloading `Idea`/`Comment` until the callback runs.
     SOURCE_SANITIZE_PIPELINES = {
+      %w[Idea title_multiloc] => PLAIN_TEXT_PIPELINE,
       %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
       %w[Comment body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }
     }.freeze
@@ -41,12 +45,19 @@ module MachineTranslations
 
     def sanitize_translation
       pipeline = SOURCE_SANITIZE_PIPELINES[[translatable_type, attribute_name.to_s]]
-      self.translation =
-        if pipeline
-          pipeline.call(translation)
-        else
-          SanitizationService.new.strip_to_plain_text(translation)
-        end
+
+      # Fall back closed: plain text is the most restrictive rule available, so an unlisted field
+      # can only lose formatting, never gain markup. Report it rather than swallow it - reaching
+      # here means a field became translatable without anyone choosing its rule, and if that field
+      # holds HTML the translation is being silently flattened.
+      if pipeline.nil?
+        ErrorReporter.report_msg(
+          'Machine translation of a field with no sanitize pipeline; falling back to plain text.',
+          extra: { translatable_type: translatable_type, attribute_name: attribute_name }
+        )
+      end
+
+      self.translation = (pipeline || PLAIN_TEXT_PIPELINE).call(translation)
     end
   end
 end

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -34,25 +34,15 @@ module MachineTranslations
     # Maps [translatable_type, attribute_name] to the source field's sanitization pipeline.
     # Anything not listed is treated as plain text and fully stripped.
     #
-    # These mirror `Idea#sanitize_body_multiloc` and `Comment#sanitize_body_multiloc`. The
-    # linkify step matters: both models sanitize *before* linkifying, so their stored bodies
-    # legitimately contain Rinku anchors that the allowlist alone would strip back out. It also
-    # rewrites any anchor the provider returned to point at its own visible text, which is what
-    # stops a translation from carrying a link whose destination and label disagree.
+    # `SanitizationService#sanitize_body` is the same pipeline `Idea` and `Comment` run on write.
+    # Its linkify step matters here: both models sanitize *before* linkifying, so their stored
+    # bodies legitimately contain Rinku anchors that an allowlist alone would strip back out.
     #
     # Wrapping in lambdas defers autoloading `Idea`/`Comment` until the callback runs.
     SOURCE_SANITIZE_PIPELINES = {
-      %w[Idea body_multiloc] => ->(html) { sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
-      %w[Comment body_multiloc] => ->(html) { sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }
+      %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
+      %w[Comment body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }
     }.freeze
-
-    def self.sanitize_body(html, features)
-      service = SanitizationService.new
-      html = service.sanitize(html, features)
-      html = service.remove_empty_trailing_tags(html)
-      service.linkify(html)
-    end
-    private_class_method :sanitize_body
 
     private
 

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -26,26 +26,43 @@ module MachineTranslations
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
 
     # The translation is external-provider HTML rendered raw on the front end, so sanitize it
-    # here as defence-in-depth. The allowlist is derived from the source field's own rules so a
-    # translation is never more permissive than the text it was translated from.
+    # here as defence-in-depth. Rather than reproduce a set of rules that could drift, run the
+    # translation through the source field's own pipeline: a translation is then never more
+    # permissive than the text it was translated from, and never loses markup the source keeps.
     before_validation :sanitize_translation, if: :translation
 
-    # Maps [translatable_type, attribute_name] to the source field's SanitizationService features.
-    # Anything not listed (titles, unknown attributes) is treated as plain text and fully stripped.
-    SOURCE_SANITIZE_FEATURES = {
-      %w[Idea body_multiloc] => -> { Idea::BODY_SANITIZE_FEATURES },
-      %w[Comment body_multiloc] => -> { Comment::BODY_SANITIZE_FEATURES }
+    # Maps [translatable_type, attribute_name] to the source field's sanitization pipeline.
+    # Anything not listed is treated as plain text and fully stripped.
+    #
+    # These mirror `Idea#sanitize_body_multiloc` and `Comment#sanitize_body_multiloc`. The
+    # linkify step matters: both models sanitize *before* linkifying, so their stored bodies
+    # legitimately contain Rinku anchors that the allowlist alone would strip back out. It also
+    # rewrites any anchor the provider returned to point at its own visible text, which is what
+    # stops a translation from carrying a link whose destination and label disagree.
+    #
+    # Wrapping in lambdas defers autoloading `Idea`/`Comment` until the callback runs.
+    SOURCE_SANITIZE_PIPELINES = {
+      %w[Idea body_multiloc] => ->(html) { sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
+      %w[Comment body_multiloc] => ->(html) { sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }
     }.freeze
+
+    def self.sanitize_body(html, features)
+      service = SanitizationService.new
+      html = service.sanitize(html, features)
+      html = service.remove_empty_trailing_tags(html)
+      service.linkify(html)
+    end
+    private_class_method :sanitize_body
 
     private
 
     def sanitize_translation
-      features_proc = SOURCE_SANITIZE_FEATURES[[translatable_type, attribute_name.to_s]]
+      pipeline = SOURCE_SANITIZE_PIPELINES[[translatable_type, attribute_name.to_s]]
       self.translation =
-        if features_proc
-          SanitizationService.new.sanitize(translation, features_proc.call)
+        if pipeline
+          pipeline.call(translation)
         else
-          ActionView::Base.full_sanitizer.sanitize(translation)
+          SanitizationService.new.strip_to_plain_text(translation)
         end
     end
   end

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -25,16 +25,15 @@ module MachineTranslations
     validates :translatable, :attribute_name, :translation, presence: true
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
 
-    # The translation is external-provider HTML rendered raw on the front end, so sanitize it here
-    # as defence-in-depth. Running the source field's own pipeline keeps a translation from being
-    # more permissive than the text it came from, without a second set of rules that could drift.
+    # Provider HTML, rendered raw on the front end. Running the source field's own pipeline keeps a
+    # translation from being more permissive than the text it was translated from.
     before_validation :sanitize_translation, if: :translation
 
     PLAIN_TEXT_PIPELINE = ->(text) { SanitizationService.new.strip_to_plain_text(text) }
 
-    # [translatable_type, attribute_name] -> the source field's pipeline. Every translatable field
-    # is listed, so that a field's rule is always a decision someone made rather than a default.
-    # Lambdas defer autoloading `Idea`/`Comment` until the callback runs.
+    # [translatable_type, attribute_name] -> the source field's pipeline. Every translatable field is
+    # listed, so a field's rule is always a choice rather than a default. Lambdas defer autoloading
+    # `Idea`/`Comment` until the callback runs.
     SOURCE_SANITIZE_PIPELINES = {
       %w[Idea title_multiloc] => PLAIN_TEXT_PIPELINE,
       %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
@@ -46,10 +45,8 @@ module MachineTranslations
     def sanitize_translation
       pipeline = SOURCE_SANITIZE_PIPELINES[[translatable_type, attribute_name.to_s]]
 
-      # Fall back closed: plain text is the most restrictive rule available, so an unlisted field
-      # can only lose formatting, never gain markup. Report it rather than swallow it - reaching
-      # here means a field became translatable without anyone choosing its rule, and if that field
-      # holds HTML the translation is being silently flattened.
+      # Fall back closed - plain text can only lose formatting, never permit markup - but report it:
+      # reaching here means a field became translatable without anyone choosing its rule.
       if pipeline.nil?
         ErrorReporter.report_msg(
           'Machine translation of a field with no sanitize pipeline; falling back to plain text.',

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -24,5 +24,29 @@ module MachineTranslations
 
     validates :translatable, :attribute_name, :translation, presence: true
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
+
+    # The translation is external-provider HTML rendered raw on the front end, so sanitize it
+    # here as defence-in-depth. The allowlist is derived from the source field's own rules so a
+    # translation is never more permissive than the text it was translated from.
+    before_validation :sanitize_translation, if: :translation
+
+    # Maps [translatable_type, attribute_name] to the source field's SanitizationService features.
+    # Anything not listed (titles, unknown attributes) is treated as plain text and fully stripped.
+    SOURCE_SANITIZE_FEATURES = {
+      %w[Idea body_multiloc] => -> { Idea::BODY_SANITIZE_FEATURES },
+      %w[Comment body_multiloc] => -> { Comment::BODY_SANITIZE_FEATURES }
+    }.freeze
+
+    private
+
+    def sanitize_translation
+      features_proc = SOURCE_SANITIZE_FEATURES[[translatable_type, attribute_name.to_s]]
+      self.translation =
+        if features_proc
+          SanitizationService.new.sanitize(translation, features_proc.call)
+        else
+          ActionView::Base.full_sanitizer.sanitize(translation)
+        end
+    end
   end
 end

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -25,20 +25,13 @@ module MachineTranslations
     validates :translatable, :attribute_name, :translation, presence: true
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
 
-    # The translation is external-provider HTML rendered raw on the front end, so sanitize it
-    # here as defence-in-depth. Rather than reproduce a set of rules that could drift, run the
-    # translation through the source field's own pipeline: a translation is then never more
-    # permissive than the text it was translated from, and never loses markup the source keeps.
+    # The translation is external-provider HTML rendered raw on the front end, so sanitize it here
+    # as defence-in-depth. Running the source field's own pipeline keeps a translation from being
+    # more permissive than the text it came from, without a second set of rules that could drift.
     before_validation :sanitize_translation, if: :translation
 
-    # Maps [translatable_type, attribute_name] to the source field's sanitization pipeline.
-    # Anything not listed is treated as plain text and fully stripped.
-    #
-    # `SanitizationService#sanitize_body` is the same pipeline `Idea` and `Comment` run on write.
-    # Its linkify step matters here: both models sanitize *before* linkifying, so their stored
-    # bodies legitimately contain Rinku anchors that an allowlist alone would strip back out.
-    #
-    # Wrapping in lambdas defers autoloading `Idea`/`Comment` until the callback runs.
+    # [translatable_type, attribute_name] -> the source field's pipeline. Anything not listed is
+    # treated as plain text. Lambdas defer autoloading `Idea`/`Comment` until the callback runs.
     SOURCE_SANITIZE_PIPELINES = {
       %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
       %w[Comment body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -39,6 +39,30 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to include('href="https://example.com"')
     end
 
+    # A field nobody wired up must not silently pick up the most permissive rule by accident.
+    context 'a field with no pipeline of its own' do
+      before { allow(ErrorReporter).to receive(:report_msg) }
+
+      it 'falls back to plain text' do
+        mt = create(:machine_translation, attribute_name: 'unwired_multiloc', translation: '<p>hi</p><img src=x onerror=alert(1)>')
+        expect(mt.translation).to eq 'hi'
+      end
+
+      it 'reports the missing pipeline' do
+        create(:machine_translation, attribute_name: 'unwired_multiloc')
+        expect(ErrorReporter).to have_received(:report_msg).with(
+          a_string_including('no sanitize pipeline'),
+          extra: hash_including(attribute_name: 'unwired_multiloc')
+        )
+      end
+    end
+
+    it 'does not report a pipeline for a field that has one' do
+      allow(ErrorReporter).to receive(:report_msg)
+      create(:machine_translation, attribute_name: 'title_multiloc')
+      expect(ErrorReporter).not_to have_received(:report_msg)
+    end
+
     it 'rewrites a spoofed anchor in a comment body translation to its visible text' do
       comment = create(:comment)
       mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -30,8 +30,8 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to include('href="https://good.example"')
     end
 
-    # A comment body allows mentions only, but `Comment#sanitize_body_multiloc` linkifies after
-    # sanitizing - so its stored bodies do contain anchors, and a translation of one must keep them.
+    # A comment body allows mentions only, but is linkified after sanitizing - so stored bodies do
+    # contain anchors, and a translation of one must keep them.
     it 'keeps linkified URLs in a comment body translation' do
       comment = create(:comment)
       mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -6,18 +6,17 @@ describe MachineTranslations::MachineTranslation do
   describe 'translation sanitization on save' do
     it 'strips event-handler attributes from an idea body translation' do
       mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<p>hi</p><img src=x onerror=alert(1)>')
-      expect(mt.translation).not_to include('onerror')
+      expect(mt.translation).to eq '<p>hi</p><img src="x">'
     end
 
     it 'strips script tags from an idea body translation' do
       mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<p>hi</p><script>alert(1)</script>')
-      expect(mt.translation).not_to include('<script>')
+      expect(mt.translation).to eq '<p>hi</p>alert(1)'
     end
 
     it 'strips all HTML from a title translation' do
       mt = create(:machine_translation, attribute_name: 'title_multiloc', translation: '<img src=x onerror=alert(1)>hi')
-      expect(mt.translation).not_to include('onerror')
-      expect(mt.translation).not_to include('<img')
+      expect(mt.translation).to eq 'hi'
     end
 
     it 'leaves ampersands in a title translation as plain text' do
@@ -25,9 +24,10 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to eq 'Poisson & frites'
     end
 
+    # The href survives untouched; only `rel` is rewritten, by the sanitiser's nofollow scrub.
     it 'keeps links in an idea body translation (idea body allowlist)' do
       mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<a href="https://good.example">x</a>')
-      expect(mt.translation).to include('href="https://good.example"')
+      expect(mt.translation).to eq '<a href="https://good.example" rel="nofollow">x</a>'
     end
 
     # A comment body allows mentions only, but linkify runs after sanitize - so stored bodies do
@@ -36,7 +36,9 @@ describe MachineTranslations::MachineTranslation do
       comment = create(:comment)
       mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
         translation: '<p>Voir <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a> ici</p>')
-      expect(mt.translation).to include('href="https://example.com"')
+      expect(mt.translation).to eq(
+        '<p>Voir <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a> ici</p>'
+      )
     end
 
     context 'a field with no pipeline of its own' do
@@ -66,9 +68,9 @@ describe MachineTranslations::MachineTranslation do
       comment = create(:comment)
       mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
         translation: '<p>hi</p><a href="https://evil.example">https://google.example</a><img src=y onerror=alert(1)>')
-      expect(mt.translation).not_to include('onerror')
-      expect(mt.translation).not_to include('evil.example')
-      expect(mt.translation).to include('href="https://google.example"')
+      expect(mt.translation).to eq(
+        '<p>hi</p><a href="https://google.example" target="_blank" rel="noreferrer noopener nofollow">https://google.example</a>'
+      )
     end
   end
 end

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe MachineTranslations::MachineTranslation do
+  describe 'translation sanitization on save' do
+    it 'strips event-handler attributes from an idea body translation' do
+      mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<p>hi</p><img src=x onerror=alert(1)>')
+      expect(mt.translation).not_to include('onerror')
+    end
+
+    it 'strips script tags from an idea body translation' do
+      mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<p>hi</p><script>alert(1)</script>')
+      expect(mt.translation).not_to include('<script>')
+    end
+
+    it 'strips all HTML from a title translation' do
+      mt = create(:machine_translation, attribute_name: 'title_multiloc', translation: '<img src=x onerror=alert(1)>hi')
+      expect(mt.translation).not_to include('onerror')
+      expect(mt.translation).not_to include('<img')
+    end
+
+    # The two cases below prove the allowlist is derived from the source field: an idea body
+    # permits links, a comment body (mention-only) does not.
+    it 'keeps links in an idea body translation (idea body allowlist)' do
+      mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<a href="https://good.example">x</a>')
+      expect(mt.translation).to include('href="https://good.example"')
+    end
+
+    it 'strips links from a comment body translation (comment mention-only allowlist)' do
+      comment = create(:comment)
+      mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
+        translation: '<p>hi</p><a href="https://evil.example">x</a><img src=y onerror=alert(1)>')
+      expect(mt.translation).not_to include('onerror')
+      expect(mt.translation).not_to include('<a ')
+    end
+  end
+end

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -20,19 +20,32 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).not_to include('<img')
     end
 
-    # The two cases below prove the allowlist is derived from the source field: an idea body
-    # permits links, a comment body (mention-only) does not.
+    it 'leaves ampersands in a title translation as plain text' do
+      mt = create(:machine_translation, attribute_name: 'title_multiloc', translation: 'Poisson & frites')
+      expect(mt.translation).to eq 'Poisson & frites'
+    end
+
     it 'keeps links in an idea body translation (idea body allowlist)' do
       mt = create(:machine_translation, attribute_name: 'body_multiloc', translation: '<a href="https://good.example">x</a>')
       expect(mt.translation).to include('href="https://good.example"')
     end
 
-    it 'strips links from a comment body translation (comment mention-only allowlist)' do
+    # A comment body allows mentions only, but `Comment#sanitize_body_multiloc` linkifies after
+    # sanitizing - so its stored bodies do contain anchors, and a translation of one must keep them.
+    it 'keeps linkified URLs in a comment body translation' do
       comment = create(:comment)
       mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
-        translation: '<p>hi</p><a href="https://evil.example">x</a><img src=y onerror=alert(1)>')
+        translation: '<p>Voir <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a> ici</p>')
+      expect(mt.translation).to include('href="https://example.com"')
+    end
+
+    it 'rewrites a spoofed anchor in a comment body translation to its visible text' do
+      comment = create(:comment)
+      mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
+        translation: '<p>hi</p><a href="https://evil.example">https://google.example</a><img src=y onerror=alert(1)>')
       expect(mt.translation).not_to include('onerror')
-      expect(mt.translation).not_to include('<a ')
+      expect(mt.translation).not_to include('evil.example')
+      expect(mt.translation).to include('href="https://google.example"')
     end
   end
 end

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -30,7 +30,7 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to include('href="https://good.example"')
     end
 
-    # A comment body allows mentions only, but is linkified after sanitizing - so stored bodies do
+    # A comment body allows mentions only, but linkify runs after sanitize - so stored bodies do
     # contain anchors, and a translation of one must keep them.
     it 'keeps linkified URLs in a comment body translation' do
       comment = create(:comment)
@@ -39,7 +39,6 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to include('href="https://example.com"')
     end
 
-    # A field nobody wired up must not silently pick up the most permissive rule by accident.
     context 'a field with no pipeline of its own' do
       before { allow(ErrorReporter).to receive(:report_msg) }
 

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -305,8 +305,13 @@ module ParticipationMethod
       fields
     end
 
+    # `Sluggable` registers `generate_slug` on `ApplicationRecord`, so it runs before `Idea`'s own
+    # `sanitize_title_multiloc` and sees the raw title. Strip here rather than reorder the
+    # callbacks, which would affect every sluggable model - otherwise `<b>Bold</b> idea` is stored
+    # with title "Bold idea" but slug "b-bold-b-idea".
     def generate_slug(input)
       title = MultilocService.new.t(input.title_multiloc, input.author&.locale).presence
+      title = SanitizationService.new.strip_to_plain_text(title) if title
       SlugService.new.generate_slug input, title
     end
 

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -305,10 +305,8 @@ module ParticipationMethod
       fields
     end
 
-    # `Sluggable` registers `generate_slug` on `ApplicationRecord`, so it runs before `Idea`'s own
-    # `sanitize_title_multiloc` and sees the raw title. Strip here rather than reorder the
-    # callbacks, which would affect every sluggable model - otherwise `<b>Bold</b> idea` is stored
-    # with title "Bold idea" but slug "b-bold-b-idea".
+    # `Sluggable` registers on `ApplicationRecord`, so this runs before `Idea#sanitize_title_multiloc`
+    # and sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
     def generate_slug(input)
       title = MultilocService.new.t(input.title_multiloc, input.author&.locale).presence
       title = SanitizationService.new.strip_to_plain_text(title) if title

--- a/back/lib/participation_method/ideation.rb
+++ b/back/lib/participation_method/ideation.rb
@@ -305,11 +305,8 @@ module ParticipationMethod
       fields
     end
 
-    # `Sluggable` registers on `ApplicationRecord`, so this runs before `Idea#sanitize_title_multiloc`
-    # and sees the raw title. Strip here rather than reorder callbacks for every sluggable model.
     def generate_slug(input)
       title = MultilocService.new.t(input.title_multiloc, input.author&.locale).presence
-      title = SanitizationService.new.strip_to_plain_text(title) if title
       SlugService.new.generate_slug input, title
     end
 

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 # Re-sanitises stored content carrying an XSS payload saved before sanitisation was added. Draft
-# idea bodies were never sanitised; idea titles and machine translations were never HTML-sanitised
-# at all. Sanitising on write does not touch rows already in the database, so this cleans the
-# stored values in place, using each field's whole write-path pipeline:
+# idea bodies were never sanitised; titles and machine translations were never HTML-sanitised at
+# all. Sanitising on write does not touch rows already in the database, so this cleans the stored
+# values in place, using each field's whole write-path pipeline:
 #
 #     Idea#body_multiloc              -> SanitizationService#sanitize_body_multiloc, Idea features
 #     Comment#body_multiloc           -> SanitizationService#sanitize_body_multiloc, Comment features
-#     MachineTranslation#translation  -> the field's own derived rule (title full-strip vs body)
+#     MachineTranslation#translation  -> the source field's own pipeline, whichever that is
 #     #title_multiloc, on each of `title_models`
 #                                     -> SanitizationService#strip_multiloc_to_plain_text
 #
@@ -25,22 +25,21 @@
 #     rake 'single_use:purge_stored_xss[execute]'          # write, all tenants
 #     rake 'single_use:purge_stored_xss[execute,foo.com]'  # write, one tenant
 namespace :single_use do
-  desc "Re-sanitise stored idea/comment/translation content carrying XSS payloads. Dry run unless passed 'execute'."
+  desc "Re-sanitise stored title/body/translation content carrying XSS payloads. Dry run unless passed 'execute'."
   task :purge_stored_xss, %i[execute host] => [:environment] do |_t, args|
     service = SanitizationService.new
 
-    # Pre-filter over a text-typed SQL expression (a jsonb cast or a text column). A row with no
-    # `<` has no tag to strip and no `&` has no entity to decode, so nothing this excludes can be
-    # changed below. Keep it this wide: matching executable keywords instead misses `<iframe src>`,
-    # `<form>`, `<object>`, `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
+    # Pre-filter over a text-typed SQL expression (a jsonb cast or a text column). No `<` means no
+    # tag to strip and no `&` means no entity to decode, so nothing this excludes could change.
+    # Keep it this wide: matching executable keywords instead would miss `<iframe src>`, `<form>`,
+    # `<object>`, `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
     rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
     strip_multiloc = service.method(:strip_multiloc_to_plain_text)
 
-    # Titles are plain text everywhere, but several render as raw HTML: the admin management feed
-    # renders any changed `title_multiloc`, and the ideas feed sidebar renders a topic title. So a
-    # moderator-editable title is a stored XSS carrier too. Every model that sanitises its title on
-    # write belongs here, whether or not a sink for it is known today.
+    # Titles are plain text, but the admin management feed renders any changed `title_multiloc` as
+    # raw HTML and the ideas feed sidebar renders a topic title, so they carry payloads too. Every
+    # model that sanitises its title on write belongs here.
     title_models = [Idea, Project, Phase, ProjectFolders::Folder, InputTopic, GlobalTopic, DefaultInputTopic].freeze
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
@@ -59,8 +58,8 @@ namespace :single_use do
         affected << { host: tenant.host, model: model_label, attribute: attribute.to_s }
         record.update_columns(attribute => new_value) if script.execute?
       rescue StandardError => e
-        # `TenantScript` only rescues per tenant, and this task sweeps ten scopes per tenant. One
-        # unreadable row must not cost the nine sweeps that follow it.
+        # `TenantScript` only rescues per tenant, so without this one bad row would cost the tenant
+        # every sweep still to come.
         script.reporter.add_error(
           "#{e.class}: #{e.message}",
           context: { tenant: tenant.host, model: model_label, id: record.id, attribute: attribute.to_s }
@@ -104,8 +103,8 @@ namespace :single_use do
         Comment.where(rewritable.call('body_multiloc::text')), :body_multiloc,
         ->(value) { service.sanitize_body_multiloc(value, Comment::BODY_SANITIZE_FEATURES) }, 'Comment'
       )
-      # Machine translations pick their rule from the record's own translatable_type and
-      # attribute_name, so they reuse the model's sanitiser rather than the value-only helper.
+      # A translation's rule depends on its own translatable_type and attribute_name, so reuse the
+      # model's sanitiser rather than a value-only helper.
       MachineTranslations::MachineTranslation.where(rewritable.call('translation')).find_each do |mt|
         old_value = mt.translation
         mt.send(:sanitize_translation)

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# Re-sanitises stored content that carries an XSS payload saved before the sanitisation fixes on
-# this branch. Draft idea bodies were never sanitised; idea titles and machine translations were
-# never HTML-sanitised at all. Sanitising on write does not touch rows already in the database, so
-# this cleans the stored values in place, using the same rules each field now applies on write:
+# Re-sanitises stored content carrying an XSS payload saved before sanitisation was added. Draft
+# idea bodies were never sanitised; idea titles and machine translations were never HTML-sanitised
+# at all. Sanitising on write does not touch rows already in the database, so this cleans the
+# stored values in place, using each field's whole write-path pipeline:
 #
 #     Idea#body_multiloc              -> SanitizationService#sanitize_body_multiloc, Idea features
 #     Idea#title_multiloc             -> SanitizationService#strip_to_plain_text
@@ -13,12 +13,8 @@
 # `custom_field_values` is intentionally out of scope: those answers render as escaped text on the
 # front end (not an HTML sink), so they cannot execute and do not need purging.
 #
-# Each field runs its *whole* write-path pipeline, linkify included. That is load-bearing for
-# comments: their allowlist has no `a` tag, so sanitising alone would strip the Rinku anchors a
-# stored comment body legitimately contains, silently destroying links while removing a payload.
-# A cheap SQL pre-filter narrows the work to rows that could possibly change at all, and a row is
-# written only when processing actually changes it — so clean content is left untouched and
-# re-runs are no-ops. Writes use `update_columns` to avoid re-running unrelated validations on
+# A row is written only when processing actually changes it, so clean content is left untouched
+# and re-runs are no-ops. Writes use `update_columns` to avoid re-running unrelated validations on
 # legacy rows.
 #
 # `TenantScript` owns the dry run, the tenant loop and the report. Deleted tenants stay out; every
@@ -33,11 +29,9 @@ namespace :single_use do
     service = SanitizationService.new
 
     # Pre-filter over a text-typed SQL expression (a jsonb cast or a text column). A row with no
-    # `<` has no tag to strip, and one with no `&` has no entity to decode, so no row this
-    # excludes can be changed by any of the sanitisers below. Anything narrower (matching only
-    # `<script`, `on*=` and friends) silently skips whole payload classes the write path strips -
-    # `<iframe src>`, `<form>`, `<object>`, `<style>`, `<base>`, and schemes hidden behind an
-    # entity such as `javas&#99;ript:`.
+    # `<` has no tag to strip and no `&` has no entity to decode, so nothing this excludes can be
+    # changed below. Keep it this wide: matching executable keywords instead misses `<iframe src>`,
+    # `<form>`, `<object>`, `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
     rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
     strip_multiloc = lambda do |multiloc|
@@ -96,9 +90,8 @@ namespace :single_use do
         Comment.where(rewritable.call('body_multiloc::text')), :body_multiloc,
         ->(value) { service.sanitize_body_multiloc(value, Comment::BODY_SANITIZE_FEATURES) }, 'Comment'
       )
-      # Machine translations need the record's own translatable_type/attribute_name to pick the
-      # right rule, so they reuse the model's private sanitiser in place rather than the value-only
-      # `purge` helper above.
+      # Machine translations pick their rule from the record's own translatable_type and
+      # attribute_name, so they reuse the model's sanitiser rather than the value-only helper.
       MachineTranslations::MachineTranslation.where(rewritable.call('translation')).find_each do |mt|
         old_value = mt.translation
         mt.send(:sanitize_translation)

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -6,9 +6,10 @@
 # stored values in place, using each field's whole write-path pipeline:
 #
 #     Idea#body_multiloc              -> SanitizationService#sanitize_body_multiloc, Idea features
-#     Idea#title_multiloc             -> SanitizationService#strip_to_plain_text
 #     Comment#body_multiloc           -> SanitizationService#sanitize_body_multiloc, Comment features
 #     MachineTranslation#translation  -> the field's own derived rule (title full-strip vs body)
+#     #title_multiloc, on Idea, Project, Phase and Folder
+#                                     -> SanitizationService#strip_multiloc_to_plain_text
 #
 # `custom_field_values` is intentionally out of scope: those answers render as escaped text on the
 # front end (not an HTML sink), so they cannot execute and do not need purging.
@@ -34,9 +35,7 @@ namespace :single_use do
     # `<form>`, `<object>`, `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
     rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
-    strip_multiloc = lambda do |multiloc|
-      multiloc.transform_values { |value| value ? service.strip_to_plain_text(value) : value }
-    end
+    strip_multiloc = service.method(:strip_multiloc_to_plain_text)
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
 
@@ -71,7 +70,7 @@ namespace :single_use do
     TenantScript.run(
       'purge_stored_xss',
       args: args,
-      description: 'purging stored XSS payloads from idea, comment and translation content',
+      description: 'purging stored XSS payloads from idea, comment, title and translation content',
       tenants: Tenant.not_deleted,
       summary: summary
     ) do |tenant, script|
@@ -80,11 +79,15 @@ namespace :single_use do
         Idea.where(rewritable.call('body_multiloc::text')), :body_multiloc,
         ->(value) { service.sanitize_body_multiloc(value, Idea::BODY_SANITIZE_FEATURES) }, 'Idea'
       )
-      purge.call(
-        tenant, script,
-        Idea.where(rewritable.call('title_multiloc::text')), :title_multiloc,
-        strip_multiloc, 'Idea'
-      )
+      # Titles are plain text everywhere, but the admin management feed renders a changed
+      # `title_multiloc` as raw HTML - so a moderator-editable title is a stored XSS carrier too.
+      [Idea, Project, Phase, ProjectFolders::Folder].each do |model|
+        purge.call(
+          tenant, script,
+          model.where(rewritable.call('title_multiloc::text')), :title_multiloc,
+          strip_multiloc, model.name
+        )
+      end
       purge.call(
         tenant, script,
         Comment.where(rewritable.call('body_multiloc::text')), :body_multiloc,

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+# Re-sanitises stored content that carries an XSS payload saved before the sanitisation fixes on
+# this branch. Draft idea bodies were never sanitised; idea titles and machine translations were
+# never HTML-sanitised at all. Sanitising on write does not touch rows already in the database, so
+# this cleans the stored values in place, using the same rules each field now applies on write:
+#
+#     Idea#body_multiloc              -> SanitizationService, Idea::BODY_SANITIZE_FEATURES
+#     Idea#title_multiloc             -> ActionView full_sanitizer (plain text, all tags stripped)
+#     Comment#body_multiloc           -> SanitizationService, Comment::BODY_SANITIZE_FEATURES
+#     MachineTranslation#translation  -> the field's own derived rule (title full-strip vs body)
+#
+# `custom_field_values` is intentionally out of scope: those answers render as escaped text on the
+# front end (not an HTML sink), so they cannot execute and do not need purging.
+#
+# Only the *sanitise* step is applied, not the models' linkify/trailing-tag passes: those rewrite
+# legitimate content (e.g. turning a bare URL into a link) and would produce a diff on clean rows.
+# A cheap SQL pre-filter narrows the work to rows whose text carries an executable pattern (an on*
+# handler, <script, javascript:/vbscript:, data:text/html), and a row is written only when
+# sanitising actually changes it — so clean content is left untouched and re-runs are no-ops.
+# Writes use `update_columns` to avoid re-running unrelated validations on legacy rows.
+#
+# `TenantScript` owns the dry run, the tenant loop and the report. Deleted tenants stay out; every
+# other tenant can still serve content, so all of them are in scope.
+#
+#     rake single_use:purge_stored_xss                     # dry run, all tenants
+#     rake 'single_use:purge_stored_xss[execute]'          # write, all tenants
+#     rake 'single_use:purge_stored_xss[execute,foo.com]'  # write, one tenant
+namespace :single_use do
+  desc "Re-sanitise stored idea/comment/translation content carrying XSS payloads. Dry run unless passed 'execute'."
+  task :purge_stored_xss, %i[execute host] => [:environment] do |_t, args|
+    service = SanitizationService.new
+    full_sanitizer = ActionView::Base.full_sanitizer
+
+    # Executable-payload pre-filter over a text-typed SQL expression (a jsonb cast or a text column).
+    suspicious = lambda do |col|
+      "(#{col} ~* 'on\\w+\\s*=' OR #{col} ILIKE '%<script%' OR " \
+        "#{col} ILIKE '%javascript:%' OR #{col} ILIKE '%vbscript:%' OR #{col} ILIKE '%data:text/html%')"
+    end
+
+    sanitize_multiloc = lambda do |multiloc, features|
+      service.sanitize_multiloc(multiloc, features)
+    end
+
+    strip_multiloc = lambda do |multiloc|
+      multiloc.transform_values { |value| value ? full_sanitizer.sanitize(value) : value }
+    end
+
+    affected = [] # rows for the summary: { host:, model:, attribute: }
+
+    # Re-sanitises one attribute across a scope, reporting and writing only real changes.
+    purge = lambda do |tenant, script, scope, attribute, sanitizer, model_label|
+      scope.find_each do |record|
+        old_value = record.public_send(attribute)
+        new_value = sanitizer.call(old_value)
+        next if new_value == old_value
+
+        script.reporter.add_change(
+          old_value, new_value,
+          context: { tenant: tenant.host, model: model_label, id: record.id, attribute: attribute.to_s }
+        )
+        affected << { host: tenant.host, model: model_label, attribute: attribute.to_s }
+        record.update_columns(attribute => new_value) if script.execute?
+      end
+    end
+
+    summary = lambda do |_script|
+      next if affected.empty?
+
+      puts "\n   🧹 Purged rows by tenant:"
+      affected.group_by { |row| row[:host] }.each do |host, rows|
+        puts "\n      #{host}"
+        rows.group_by { |row| [row[:model], row[:attribute]] }.each do |(model, attribute), group|
+          puts "         #{model}##{attribute}: #{group.size}"
+        end
+      end
+    end
+
+    TenantScript.run(
+      'purge_stored_xss',
+      args: args,
+      description: 'purging stored XSS payloads from idea, comment and translation content',
+      tenants: Tenant.not_deleted,
+      summary: summary
+    ) do |tenant, script|
+      purge.call(
+        tenant, script,
+        Idea.where(suspicious.call('body_multiloc::text')), :body_multiloc,
+        ->(value) { sanitize_multiloc.call(value, Idea::BODY_SANITIZE_FEATURES) }, 'Idea'
+      )
+      purge.call(
+        tenant, script,
+        Idea.where(suspicious.call('title_multiloc::text')), :title_multiloc,
+        strip_multiloc, 'Idea'
+      )
+      purge.call(
+        tenant, script,
+        Comment.where(suspicious.call('body_multiloc::text')), :body_multiloc,
+        ->(value) { sanitize_multiloc.call(value, Comment::BODY_SANITIZE_FEATURES) }, 'Comment'
+      )
+      # Machine translations need the record's own translatable_type/attribute_name to pick the
+      # right rule, so they reuse the model's private sanitiser in place rather than the value-only
+      # `purge` helper above.
+      MachineTranslations::MachineTranslation.where(suspicious.call('translation')).find_each do |mt|
+        old_value = mt.translation
+        mt.send(:sanitize_translation)
+        new_value = mt.translation
+        next if new_value == old_value
+
+        script.reporter.add_change(
+          old_value, new_value,
+          context: { tenant: tenant.host, model: 'MachineTranslation', id: mt.id, attribute: 'translation' }
+        )
+        affected << { host: tenant.host, model: 'MachineTranslation', attribute: 'translation' }
+        mt.update_columns(translation: new_value) if script.execute?
+      end
+    end
+  end
+end

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -40,7 +40,9 @@ namespace :single_use do
     strip_multiloc = service.method(:strip_multiloc_to_plain_text)
 
     # Every model that sanitises its `title_multiloc` on write belongs here.
-    title_models = [Idea, Project, Phase, ProjectFolders::Folder, InputTopic, GlobalTopic, DefaultInputTopic].freeze
+    title_models = [
+      Idea, Project, Phase, ProjectFolders::Folder, InputTopic, GlobalTopic, DefaultInputTopic, Event, StaticPage
+    ].freeze
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
 

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -39,9 +39,7 @@ namespace :single_use do
 
     strip_multiloc = service.method(:strip_multiloc_to_plain_text)
 
-    # Titles are plain text, but the admin management feed renders any changed `title_multiloc` as
-    # raw HTML and the ideas feed sidebar renders a topic title, so they carry payloads too. Every
-    # model that sanitises its title on write belongs here.
+    # Every model that sanitises its `title_multiloc` on write belongs here.
     title_models = [Idea, Project, Phase, ProjectFolders::Folder, InputTopic, GlobalTopic, DefaultInputTopic].freeze
 
     affected = [] # rows for the summary: { host:, model:, attribute: }

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -8,7 +8,7 @@
 #     Idea#body_multiloc              -> SanitizationService#sanitize_body_multiloc, Idea features
 #     Comment#body_multiloc           -> SanitizationService#sanitize_body_multiloc, Comment features
 #     MachineTranslation#translation  -> the field's own derived rule (title full-strip vs body)
-#     #title_multiloc, on Idea, Project, Phase and Folder
+#     #title_multiloc, on each of `title_models`
 #                                     -> SanitizationService#strip_multiloc_to_plain_text
 #
 # `custom_field_values` is intentionally out of scope: those answers render as escaped text on the
@@ -36,6 +36,12 @@ namespace :single_use do
     rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
     strip_multiloc = service.method(:strip_multiloc_to_plain_text)
+
+    # Titles are plain text everywhere, but several render as raw HTML: the admin management feed
+    # renders any changed `title_multiloc`, and the ideas feed sidebar renders a topic title. So a
+    # moderator-editable title is a stored XSS carrier too. Every model that sanitises its title on
+    # write belongs here, whether or not a sink for it is known today.
+    title_models = [Idea, Project, Phase, ProjectFolders::Folder, InputTopic, GlobalTopic, DefaultInputTopic].freeze
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
 
@@ -79,9 +85,7 @@ namespace :single_use do
         Idea.where(rewritable.call('body_multiloc::text')), :body_multiloc,
         ->(value) { service.sanitize_body_multiloc(value, Idea::BODY_SANITIZE_FEATURES) }, 'Idea'
       )
-      # Titles are plain text everywhere, but the admin management feed renders a changed
-      # `title_multiloc` as raw HTML - so a moderator-editable title is a stored XSS carrier too.
-      [Idea, Project, Phase, ProjectFolders::Folder].each do |model|
+      title_models.each do |model|
         purge.call(
           tenant, script,
           model.where(rewritable.call('title_multiloc::text')), :title_multiloc,

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -5,20 +5,21 @@
 # never HTML-sanitised at all. Sanitising on write does not touch rows already in the database, so
 # this cleans the stored values in place, using the same rules each field now applies on write:
 #
-#     Idea#body_multiloc              -> SanitizationService, Idea::BODY_SANITIZE_FEATURES
-#     Idea#title_multiloc             -> ActionView full_sanitizer (plain text, all tags stripped)
-#     Comment#body_multiloc           -> SanitizationService, Comment::BODY_SANITIZE_FEATURES
+#     Idea#body_multiloc              -> SanitizationService#sanitize_body_multiloc, Idea features
+#     Idea#title_multiloc             -> SanitizationService#strip_to_plain_text
+#     Comment#body_multiloc           -> SanitizationService#sanitize_body_multiloc, Comment features
 #     MachineTranslation#translation  -> the field's own derived rule (title full-strip vs body)
 #
 # `custom_field_values` is intentionally out of scope: those answers render as escaped text on the
 # front end (not an HTML sink), so they cannot execute and do not need purging.
 #
-# Only the *sanitise* step is applied, not the models' linkify/trailing-tag passes: those rewrite
-# legitimate content (e.g. turning a bare URL into a link) and would produce a diff on clean rows.
-# A cheap SQL pre-filter narrows the work to rows whose text carries an executable pattern (an on*
-# handler, <script, javascript:/vbscript:, data:text/html), and a row is written only when
-# sanitising actually changes it — so clean content is left untouched and re-runs are no-ops.
-# Writes use `update_columns` to avoid re-running unrelated validations on legacy rows.
+# Each field runs its *whole* write-path pipeline, linkify included. That is load-bearing for
+# comments: their allowlist has no `a` tag, so sanitising alone would strip the Rinku anchors a
+# stored comment body legitimately contains, silently destroying links while removing a payload.
+# A cheap SQL pre-filter narrows the work to rows that could possibly change at all, and a row is
+# written only when processing actually changes it — so clean content is left untouched and
+# re-runs are no-ops. Writes use `update_columns` to avoid re-running unrelated validations on
+# legacy rows.
 #
 # `TenantScript` owns the dry run, the tenant loop and the report. Deleted tenants stay out; every
 # other tenant can still serve content, so all of them are in scope.
@@ -30,20 +31,17 @@ namespace :single_use do
   desc "Re-sanitise stored idea/comment/translation content carrying XSS payloads. Dry run unless passed 'execute'."
   task :purge_stored_xss, %i[execute host] => [:environment] do |_t, args|
     service = SanitizationService.new
-    full_sanitizer = ActionView::Base.full_sanitizer
 
-    # Executable-payload pre-filter over a text-typed SQL expression (a jsonb cast or a text column).
-    suspicious = lambda do |col|
-      "(#{col} ~* 'on\\w+\\s*=' OR #{col} ILIKE '%<script%' OR " \
-        "#{col} ILIKE '%javascript:%' OR #{col} ILIKE '%vbscript:%' OR #{col} ILIKE '%data:text/html%')"
-    end
-
-    sanitize_multiloc = lambda do |multiloc, features|
-      service.sanitize_multiloc(multiloc, features)
-    end
+    # Pre-filter over a text-typed SQL expression (a jsonb cast or a text column). A row with no
+    # `<` has no tag to strip, and one with no `&` has no entity to decode, so no row this
+    # excludes can be changed by any of the sanitisers below. Anything narrower (matching only
+    # `<script`, `on*=` and friends) silently skips whole payload classes the write path strips -
+    # `<iframe src>`, `<form>`, `<object>`, `<style>`, `<base>`, and schemes hidden behind an
+    # entity such as `javas&#99;ript:`.
+    rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
     strip_multiloc = lambda do |multiloc|
-      multiloc.transform_values { |value| value ? full_sanitizer.sanitize(value) : value }
+      multiloc.transform_values { |value| value ? service.strip_to_plain_text(value) : value }
     end
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
@@ -85,23 +83,23 @@ namespace :single_use do
     ) do |tenant, script|
       purge.call(
         tenant, script,
-        Idea.where(suspicious.call('body_multiloc::text')), :body_multiloc,
-        ->(value) { sanitize_multiloc.call(value, Idea::BODY_SANITIZE_FEATURES) }, 'Idea'
+        Idea.where(rewritable.call('body_multiloc::text')), :body_multiloc,
+        ->(value) { service.sanitize_body_multiloc(value, Idea::BODY_SANITIZE_FEATURES) }, 'Idea'
       )
       purge.call(
         tenant, script,
-        Idea.where(suspicious.call('title_multiloc::text')), :title_multiloc,
+        Idea.where(rewritable.call('title_multiloc::text')), :title_multiloc,
         strip_multiloc, 'Idea'
       )
       purge.call(
         tenant, script,
-        Comment.where(suspicious.call('body_multiloc::text')), :body_multiloc,
-        ->(value) { sanitize_multiloc.call(value, Comment::BODY_SANITIZE_FEATURES) }, 'Comment'
+        Comment.where(rewritable.call('body_multiloc::text')), :body_multiloc,
+        ->(value) { service.sanitize_body_multiloc(value, Comment::BODY_SANITIZE_FEATURES) }, 'Comment'
       )
       # Machine translations need the record's own translatable_type/attribute_name to pick the
       # right rule, so they reuse the model's private sanitiser in place rather than the value-only
       # `purge` helper above.
-      MachineTranslations::MachineTranslation.where(suspicious.call('translation')).find_each do |mt|
+      MachineTranslations::MachineTranslation.where(rewritable.call('translation')).find_each do |mt|
         old_value = mt.translation
         mt.send(:sanitize_translation)
         new_value = mt.translation

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -30,9 +30,11 @@ namespace :single_use do
     service = SanitizationService.new
 
     # Pre-filter over a text-typed SQL expression (a jsonb cast or a text column). No `<` means no
-    # tag to strip and no `&` means no entity to decode, so nothing this excludes could change.
-    # Keep it this wide: matching executable keywords instead would miss `<iframe src>`, `<form>`,
-    # `<object>`, `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
+    # tag to strip and no `&` means no entity to decode, so nothing this excludes can carry a
+    # payload. It does exclude rows the write path would merely normalise (a bare URL to linkify, a
+    # stray `>` to re-escape) - deliberate: this task removes payloads, it does not reformat clean
+    # history. Keep it this wide: keyword matching would miss `<iframe src>`, `<form>`, `<object>`,
+    # `<style>` and schemes hidden behind an entity like `javas&#99;ript:`.
     rewritable = ->(col) { "(#{col} LIKE '%<%' OR #{col} LIKE '%&%')" }
 
     strip_multiloc = service.method(:strip_multiloc_to_plain_text)

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -58,6 +58,13 @@ namespace :single_use do
         )
         affected << { host: tenant.host, model: model_label, attribute: attribute.to_s }
         record.update_columns(attribute => new_value) if script.execute?
+      rescue StandardError => e
+        # `TenantScript` only rescues per tenant, and this task sweeps ten scopes per tenant. One
+        # unreadable row must not cost the nine sweeps that follow it.
+        script.reporter.add_error(
+          "#{e.class}: #{e.message}",
+          context: { tenant: tenant.host, model: model_label, id: record.id, attribute: attribute.to_s }
+        )
       end
     end
 
@@ -111,6 +118,11 @@ namespace :single_use do
         )
         affected << { host: tenant.host, model: 'MachineTranslation', attribute: 'translation' }
         mt.update_columns(translation: new_value) if script.execute?
+      rescue StandardError => e
+        script.reporter.add_error(
+          "#{e.class}: #{e.message}",
+          context: { tenant: tenant.host, model: 'MachineTranslation', id: mt.id, attribute: 'translation' }
+        )
       end
     end
   end

--- a/back/spec/acceptance/ideas/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_create_spec.rb
@@ -336,6 +336,20 @@ resource 'Ideas' do
             expect(blocked_error[:blocked_words].pluck(:attribute).uniq).to include('title_multiloc', 'body_multiloc')
           end
         end
+
+        describe 'stored XSS regression: draft bodies are sanitized on write' do
+          let(:publication_status) { 'draft' }
+          let(:body_multiloc) do
+            { 'en' => '<p>poc</p><img onload="alert(document.cookie)" data-cl2-text-image-text-reference="0a808204-4e40-4fe4-9733-0fd88581e2ae">' }
+          end
+
+          example_request 'strips event-handler attributes from the stored draft body' do
+            assert_status 201
+            idea = Idea.find(response_data[:id])
+            expect(idea.publication_status).to eq 'draft'
+            expect(idea.body_multiloc['en']).not_to include('onload')
+          end
+        end
       end
 
       context 'when admin' do

--- a/back/spec/acceptance/ideas/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_create_spec.rb
@@ -347,7 +347,9 @@ resource 'Ideas' do
             assert_status 201
             idea = Idea.find(response_data[:id])
             expect(idea.publication_status).to eq 'draft'
-            expect(idea.body_multiloc['en']).not_to include('onload')
+            expect(idea.body_multiloc['en']).to eq(
+              '<p>poc</p><img data-cl2-text-image-text-reference="0a808204-4e40-4fe4-9733-0fd88581e2ae">'
+            )
           end
         end
       end

--- a/back/spec/models/default_input_topic_spec.rb
+++ b/back/spec/models/default_input_topic_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DefaultInputTopic do
+  describe 'Default factory' do
+    it 'is valid' do
+      expect(build(:default_input_topic)).to be_valid
+    end
+  end
+
+  describe 'title sanitizer' do
+    it 'strips HTML tags from the title' do
+      topic = create(:default_input_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
+      expect(topic.title_multiloc['en']).to eq 'bold topic'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      topic = create(:default_input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(topic.title_multiloc['en']).not_to include('onerror')
+      expect(topic.title_multiloc['en']).not_to include('<img')
+    end
+
+    # Default topics are copied into a project's input topics on creation, so a payload stored
+    # here would be reintroduced with every new project.
+    it 'does not carry a payload into the input topics copied from it' do
+      create(:default_input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      project = create(:project)
+      project.set_default_input_topics!
+
+      titles = project.input_topics.map { |topic| topic.title_multiloc['en'] }
+      expect(titles).to be_present
+      expect(titles.join).not_to include('onerror')
+    end
+  end
+end

--- a/back/spec/models/default_input_topic_spec.rb
+++ b/back/spec/models/default_input_topic_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe DefaultInputTopic do
   it_behaves_like 'a sanitized title_multiloc', factory: :default_input_topic
 
   describe 'title sanitizer' do
-    # Default topics are copied into a project's input topics on creation, so a payload stored
-    # here would be reintroduced with every new project.
     it 'does not carry a payload into the input topics copied from it' do
       create(:default_input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
       project = create(:project)

--- a/back/spec/models/default_input_topic_spec.rb
+++ b/back/spec/models/default_input_topic_spec.rb
@@ -9,18 +9,9 @@ RSpec.describe DefaultInputTopic do
     end
   end
 
+  it_behaves_like 'a sanitized title_multiloc', factory: :default_input_topic
+
   describe 'title sanitizer' do
-    it 'strips HTML tags from the title' do
-      topic = create(:default_input_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
-      expect(topic.title_multiloc['en']).to eq 'bold topic'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      topic = create(:default_input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(topic.title_multiloc['en']).not_to include('onerror')
-      expect(topic.title_multiloc['en']).not_to include('<img')
-    end
-
     # Default topics are copied into a project's input topics on creation, so a payload stored
     # here would be reintroduced with every new project.
     it 'does not carry a payload into the input topics copied from it' do

--- a/back/spec/models/default_input_topic_spec.rb
+++ b/back/spec/models/default_input_topic_spec.rb
@@ -17,9 +17,7 @@ RSpec.describe DefaultInputTopic do
       project = create(:project)
       project.set_default_input_topics!
 
-      titles = project.input_topics.map { |topic| topic.title_multiloc['en'] }
-      expect(titles).to be_present
-      expect(titles.join).not_to include('onerror')
+      expect(project.input_topics.map { |topic| topic.title_multiloc['en'] }).to eq ['hi']
     end
   end
 end

--- a/back/spec/models/event_spec.rb
+++ b/back/spec/models/event_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe Event do
     end
   end
 
+  it_behaves_like 'a sanitized title_multiloc', factory: :event
+
   describe 'associations' do
     subject(:event) { build(:event) }
 

--- a/back/spec/models/folder_spec.rb
+++ b/back/spec/models/folder_spec.rb
@@ -36,6 +36,29 @@ RSpec.describe ProjectFolders::Folder do
       folder.update!(title_multiloc: { 'en' => 'my folder', 'nl-BE' => 'mijn map', 'fr-BE' => 'mon dossier' })
       expect(folder.slug).to eq 'my-folder'
     end
+
+    it 'generates a slug from the sanitized title, not the raw one' do
+      folder.update!(title_multiloc: { 'en' => '<b>Bold</b> folder' })
+      expect(folder.slug).to eq 'bold-folder'
+    end
+  end
+
+  describe '#sanitize_title_multiloc' do
+    it 'strips HTML tags from the title' do
+      folder = create(:project_folder, title_multiloc: { 'en' => '<b>bold</b> folder' })
+      expect(folder.title_multiloc['en']).to eq 'bold folder'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      folder = create(:project_folder, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(folder.title_multiloc['en']).not_to include('onerror')
+      expect(folder.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'leaves ampersands as plain text' do
+      folder = create(:project_folder, title_multiloc: { 'en' => 'Fish & chips' })
+      expect(folder.title_multiloc['en']).to eq 'Fish & chips'
+    end
   end
 
   describe '#sanitize_description_multiloc' do

--- a/back/spec/models/folder_spec.rb
+++ b/back/spec/models/folder_spec.rb
@@ -43,23 +43,7 @@ RSpec.describe ProjectFolders::Folder do
     end
   end
 
-  describe '#sanitize_title_multiloc' do
-    it 'strips HTML tags from the title' do
-      folder = create(:project_folder, title_multiloc: { 'en' => '<b>bold</b> folder' })
-      expect(folder.title_multiloc['en']).to eq 'bold folder'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      folder = create(:project_folder, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(folder.title_multiloc['en']).not_to include('onerror')
-      expect(folder.title_multiloc['en']).not_to include('<img')
-    end
-
-    it 'leaves ampersands as plain text' do
-      folder = create(:project_folder, title_multiloc: { 'en' => 'Fish & chips' })
-      expect(folder.title_multiloc['en']).to eq 'Fish & chips'
-    end
-  end
+  it_behaves_like 'a sanitized title_multiloc', factory: :project_folder
 
   describe '#sanitize_description_multiloc' do
     it 'sanitizes script tags in the description' do

--- a/back/spec/models/global_topic_spec.rb
+++ b/back/spec/models/global_topic_spec.rb
@@ -11,23 +11,9 @@ RSpec.describe GlobalTopic do
 
   it { is_expected.to validate_presence_of(:title_multiloc) }
 
+  it_behaves_like 'a sanitized title_multiloc', factory: :global_topic
+
   describe 'title sanitizer' do
-    it 'strips HTML tags from the title' do
-      topic = create(:global_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
-      expect(topic.title_multiloc['en']).to eq 'bold topic'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      topic = create(:global_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(topic.title_multiloc['en']).not_to include('onerror')
-      expect(topic.title_multiloc['en']).not_to include('<img')
-    end
-
-    it 'leaves ampersands as plain text' do
-      topic = create(:global_topic, title_multiloc: { 'en' => 'Fish & chips' })
-      expect(topic.title_multiloc['en']).to eq 'Fish & chips'
-    end
-
     # The guard used to test description_multiloc, so a topic with no description kept its
     # untrimmed title.
     it 'trims whitespace even when the description is empty' do

--- a/back/spec/models/global_topic_spec.rb
+++ b/back/spec/models/global_topic_spec.rb
@@ -10,4 +10,29 @@ RSpec.describe GlobalTopic do
   end
 
   it { is_expected.to validate_presence_of(:title_multiloc) }
+
+  describe 'title sanitizer' do
+    it 'strips HTML tags from the title' do
+      topic = create(:global_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
+      expect(topic.title_multiloc['en']).to eq 'bold topic'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      topic = create(:global_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(topic.title_multiloc['en']).not_to include('onerror')
+      expect(topic.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'leaves ampersands as plain text' do
+      topic = create(:global_topic, title_multiloc: { 'en' => 'Fish & chips' })
+      expect(topic.title_multiloc['en']).to eq 'Fish & chips'
+    end
+
+    # The guard used to test description_multiloc, so a topic with no description kept its
+    # untrimmed title.
+    it 'trims whitespace even when the description is empty' do
+      topic = create(:global_topic, title_multiloc: { 'en' => '  spacious  ' }, description_multiloc: {})
+      expect(topic.title_multiloc['en']).to eq 'spacious'
+    end
+  end
 end

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -457,6 +457,18 @@ RSpec.describe Idea do
       expect(idea.slug).to be_present
     end
 
+    it 'generates a slug from the sanitized title, not the raw one' do
+      idea = create(:idea, slug: nil, title_multiloc: { 'en' => '<b>Bold</b> idea' })
+      expect(idea.title_multiloc['en']).to eq 'Bold idea'
+      expect(idea.slug).to eq 'bold-idea'
+    end
+
+    it 'does not leak a stripped payload into the slug' do
+      idea = create(:idea, slug: nil, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(idea.slug).not_to include('onerror')
+      expect(idea.slug).not_to include('img')
+    end
+
     it 'generates a slug when there is no current phase' do
       now = Time.now
       project = create(:project)

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -699,6 +699,39 @@ RSpec.describe Idea do
       idea = create(:idea, publication_status: 'draft', title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
       expect(idea.title_multiloc['en']).not_to include('onerror')
     end
+
+    it 'leaves ampersands and comparison operators as plain text' do
+      idea = create(:idea, title_multiloc: { 'en' => 'Fish & chips: budget > 100 < 200' })
+      expect(idea.title_multiloc['en']).to eq 'Fish & chips: budget > 100 < 200'
+    end
+
+    it 'strips markup without entity-encoding the text that survives' do
+      idea = create(:idea, title_multiloc: { 'en' => '<b>Fish</b> & chips' })
+      expect(idea.title_multiloc['en']).to eq 'Fish & chips'
+    end
+
+    it 'neutralises a payload hidden behind entity encoding' do
+      idea = create(:idea, title_multiloc: { 'en' => '&lt;img src=x onerror=alert(1)&gt;hi' })
+      expect(idea.title_multiloc['en']).not_to include('onerror')
+      expect(idea.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'is idempotent across repeated saves' do
+      idea = create(:idea, title_multiloc: { 'en' => 'Fish & chips' })
+      expect { idea.save! }.not_to change { idea.reload.title_multiloc['en'] }
+    end
+
+    it 'is not rewritten by a save that does not touch the title' do
+      idea = create(:idea)
+      # Bypass the callbacks to mimic a row stored before titles were sanitized.
+      idea.update_columns(title_multiloc: { 'en' => 'Fish & chips' })
+      idea.reload
+
+      idea.update!(budget: 123)
+
+      expect(idea.reload.title_multiloc['en']).to eq 'Fish & chips'
+      expect(idea.title_multiloc_previously_changed?).to be false
+    end
   end
 
   describe 'anonymous participation' do

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -651,6 +651,31 @@ RSpec.describe Idea do
       })
       expect(idea.body_multiloc).to eq({ 'en' => '<iframe class="ql-video" frameborder="0" allowfullscreen="true" src="https://www.youtube.com/embed/Bu2wNKlVRzE?showinfo=0" height="242.5" width="485" data-blot-formatter-unclickable-bound="true"></iframe>' })
     end
+
+    it 'sanitizes script tags in a draft body' do
+      idea = create(:idea, publication_status: 'draft', body_multiloc: {
+        'en' => '<p>Test</p><script>This should be removed!</script>'
+      })
+      expect(idea.body_multiloc['en']).not_to include('<script>')
+    end
+
+    it 'strips event-handler attributes from a draft body' do
+      ti_service = instance_double(TextImageService).as_null_object
+      allow(TextImageService).to receive(:new).and_return(ti_service)
+
+      idea = create(:idea, publication_status: 'draft', body_multiloc: { 'en' => '... <img src=x onerror=alert(1)>' })
+      expect(idea.body_multiloc['en']).not_to include('onerror')
+    end
+
+    it 'strips onload from a draft body that carries a text-image reference (reported payload shape)' do
+      ti_service = instance_double(TextImageService).as_null_object
+      allow(TextImageService).to receive(:new).and_return(ti_service)
+
+      idea = create(:idea, publication_status: 'draft', body_multiloc: {
+        'en' => '<p>poc</p><img onload="alert(document.cookie)" data-cl2-text-image-text-reference="0a808204-4e40-4fe4-9733-0fd88581e2ae">'
+      })
+      expect(idea.body_multiloc['en']).not_to include('onload')
+    end
   end
 
   describe 'title' do

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Idea do
 
   it_behaves_like 'claimable_participation'
   it_behaves_like 'location_trackable_participation'
+  it_behaves_like 'a sanitized title_multiloc', factory: :idea
 
   describe 'title validation' do
     it 'requires title_multiloc when title_multiloc_required? is true' do
@@ -696,36 +697,9 @@ RSpec.describe Idea do
       expect(idea.title_multiloc['en']).to eq 'my fantastic idea'
     end
 
-    it 'strips HTML tags from the title' do
-      idea = create(:idea, title_multiloc: { 'en' => '<b>bold</b> idea' })
-      expect(idea.title_multiloc['en']).to eq 'bold idea'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      idea = create(:idea, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(idea.title_multiloc['en']).not_to include('<img')
-      expect(idea.title_multiloc['en']).not_to include('onerror')
-    end
-
     it 'strips HTML from a draft title (stored XSS regression)' do
       idea = create(:idea, publication_status: 'draft', title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
       expect(idea.title_multiloc['en']).not_to include('onerror')
-    end
-
-    it 'leaves ampersands and comparison operators as plain text' do
-      idea = create(:idea, title_multiloc: { 'en' => 'Fish & chips: budget > 100 < 200' })
-      expect(idea.title_multiloc['en']).to eq 'Fish & chips: budget > 100 < 200'
-    end
-
-    it 'strips markup without entity-encoding the text that survives' do
-      idea = create(:idea, title_multiloc: { 'en' => '<b>Fish</b> & chips' })
-      expect(idea.title_multiloc['en']).to eq 'Fish & chips'
-    end
-
-    it 'neutralises a payload hidden behind entity encoding' do
-      idea = create(:idea, title_multiloc: { 'en' => '&lt;img src=x onerror=alert(1)&gt;hi' })
-      expect(idea.title_multiloc['en']).not_to include('onerror')
-      expect(idea.title_multiloc['en']).not_to include('<img')
     end
 
     it 'is idempotent across repeated saves' do

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -683,6 +683,22 @@ RSpec.describe Idea do
       idea = create(:idea, title_multiloc: { 'en' => ' my fantastic idea  ' })
       expect(idea.title_multiloc['en']).to eq 'my fantastic idea'
     end
+
+    it 'strips HTML tags from the title' do
+      idea = create(:idea, title_multiloc: { 'en' => '<b>bold</b> idea' })
+      expect(idea.title_multiloc['en']).to eq 'bold idea'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      idea = create(:idea, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(idea.title_multiloc['en']).not_to include('<img')
+      expect(idea.title_multiloc['en']).not_to include('onerror')
+    end
+
+    it 'strips HTML from a draft title (stored XSS regression)' do
+      idea = create(:idea, publication_status: 'draft', title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(idea.title_multiloc['en']).not_to include('onerror')
+    end
   end
 
   describe 'anonymous participation' do

--- a/back/spec/models/idea_spec.rb
+++ b/back/spec/models/idea_spec.rb
@@ -466,8 +466,7 @@ RSpec.describe Idea do
 
     it 'does not leak a stripped payload into the slug' do
       idea = create(:idea, slug: nil, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(idea.slug).not_to include('onerror')
-      expect(idea.slug).not_to include('img')
+      expect(idea.slug).to eq 'hi'
     end
 
     it 'generates a slug when there is no current phase' do
@@ -669,7 +668,7 @@ RSpec.describe Idea do
       idea = create(:idea, publication_status: 'draft', body_multiloc: {
         'en' => '<p>Test</p><script>This should be removed!</script>'
       })
-      expect(idea.body_multiloc['en']).not_to include('<script>')
+      expect(idea.body_multiloc['en']).to eq '<p>Test</p>This should be removed!'
     end
 
     it 'strips event-handler attributes from a draft body' do
@@ -677,9 +676,10 @@ RSpec.describe Idea do
       allow(TextImageService).to receive(:new).and_return(ti_service)
 
       idea = create(:idea, publication_status: 'draft', body_multiloc: { 'en' => '... <img src=x onerror=alert(1)>' })
-      expect(idea.body_multiloc['en']).not_to include('onerror')
+      expect(idea.body_multiloc['en']).to eq '... <img src="x">'
     end
 
+    # The handler goes; the text-image reference stays, since the image itself is real content.
     it 'strips onload from a draft body that carries a text-image reference (reported payload shape)' do
       ti_service = instance_double(TextImageService).as_null_object
       allow(TextImageService).to receive(:new).and_return(ti_service)
@@ -687,7 +687,9 @@ RSpec.describe Idea do
       idea = create(:idea, publication_status: 'draft', body_multiloc: {
         'en' => '<p>poc</p><img onload="alert(document.cookie)" data-cl2-text-image-text-reference="0a808204-4e40-4fe4-9733-0fd88581e2ae">'
       })
-      expect(idea.body_multiloc['en']).not_to include('onload')
+      expect(idea.body_multiloc['en']).to eq(
+        '<p>poc</p><img data-cl2-text-image-text-reference="0a808204-4e40-4fe4-9733-0fd88581e2ae">'
+      )
     end
   end
 
@@ -699,7 +701,7 @@ RSpec.describe Idea do
 
     it 'strips HTML from a draft title (stored XSS regression)' do
       idea = create(:idea, publication_status: 'draft', title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(idea.title_multiloc['en']).not_to include('onerror')
+      expect(idea.title_multiloc['en']).to eq 'hi'
     end
 
     it 'is idempotent across repeated saves' do

--- a/back/spec/models/input_topic_spec.rb
+++ b/back/spec/models/input_topic_spec.rb
@@ -11,6 +11,24 @@ RSpec.describe InputTopic do
 
   it { is_expected.to validate_presence_of(:title_multiloc) }
 
+  describe 'title sanitizer' do
+    it 'strips HTML tags from the title' do
+      topic = create(:input_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
+      expect(topic.title_multiloc['en']).to eq 'bold topic'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      topic = create(:input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(topic.title_multiloc['en']).not_to include('onerror')
+      expect(topic.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'leaves ampersands as plain text' do
+      topic = create(:input_topic, title_multiloc: { 'en' => 'Fish & chips' })
+      expect(topic.title_multiloc['en']).to eq 'Fish & chips'
+    end
+  end
+
   describe 'order_ideas_count' do
     # topic 0: ideas 1, 3, 6 (3)
     # topic 1: / (0)

--- a/back/spec/models/input_topic_spec.rb
+++ b/back/spec/models/input_topic_spec.rb
@@ -11,23 +11,7 @@ RSpec.describe InputTopic do
 
   it { is_expected.to validate_presence_of(:title_multiloc) }
 
-  describe 'title sanitizer' do
-    it 'strips HTML tags from the title' do
-      topic = create(:input_topic, title_multiloc: { 'en' => '<b>bold</b> topic' })
-      expect(topic.title_multiloc['en']).to eq 'bold topic'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      topic = create(:input_topic, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(topic.title_multiloc['en']).not_to include('onerror')
-      expect(topic.title_multiloc['en']).not_to include('<img')
-    end
-
-    it 'leaves ampersands as plain text' do
-      topic = create(:input_topic, title_multiloc: { 'en' => 'Fish & chips' })
-      expect(topic.title_multiloc['en']).to eq 'Fish & chips'
-    end
-  end
+  it_behaves_like 'a sanitized title_multiloc', factory: :input_topic
 
   describe 'order_ideas_count' do
     # topic 0: ideas 1, 3, 6 (3)

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -39,23 +39,7 @@ RSpec.describe Phase do
     end
   end
 
-  describe 'title sanitizer' do
-    it 'strips HTML tags from the title' do
-      phase = create(:phase, title_multiloc: { 'en' => '<b>bold</b> phase' })
-      expect(phase.title_multiloc['en']).to eq 'bold phase'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      phase = create(:phase, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(phase.title_multiloc['en']).not_to include('onerror')
-      expect(phase.title_multiloc['en']).not_to include('<img')
-    end
-
-    it 'leaves ampersands as plain text' do
-      phase = create(:phase, title_multiloc: { 'en' => 'Fish & chips' })
-      expect(phase.title_multiloc['en']).to eq 'Fish & chips'
-    end
-  end
+  it_behaves_like 'a sanitized title_multiloc', factory: :phase
 
   describe 'timing model validation' do
     it 'fails when the duration is less than 1 day' do

--- a/back/spec/models/phase_spec.rb
+++ b/back/spec/models/phase_spec.rb
@@ -39,6 +39,24 @@ RSpec.describe Phase do
     end
   end
 
+  describe 'title sanitizer' do
+    it 'strips HTML tags from the title' do
+      phase = create(:phase, title_multiloc: { 'en' => '<b>bold</b> phase' })
+      expect(phase.title_multiloc['en']).to eq 'bold phase'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      phase = create(:phase, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(phase.title_multiloc['en']).not_to include('onerror')
+      expect(phase.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'leaves ampersands as plain text' do
+      phase = create(:phase, title_multiloc: { 'en' => 'Fish & chips' })
+      expect(phase.title_multiloc['en']).to eq 'Fish & chips'
+    end
+  end
+
   describe 'timing model validation' do
     it 'fails when the duration is less than 1 day' do
       phase = build(:phase)

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -136,23 +136,9 @@ RSpec.describe Project do
     end
   end
 
+  it_behaves_like 'a sanitized title_multiloc', factory: :project
+
   describe 'title sanitizer' do
-    it 'strips HTML tags from the title' do
-      project = create(:project, title_multiloc: { 'en' => '<b>bold</b> project' })
-      expect(project.title_multiloc['en']).to eq 'bold project'
-    end
-
-    it 'strips script/event-handler payloads from the title' do
-      project = create(:project, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
-      expect(project.title_multiloc['en']).not_to include('onerror')
-      expect(project.title_multiloc['en']).not_to include('<img')
-    end
-
-    it 'leaves ampersands as plain text' do
-      project = create(:project, title_multiloc: { 'en' => 'Fish & chips' })
-      expect(project.title_multiloc['en']).to eq 'Fish & chips'
-    end
-
     it 'is not rewritten by a save that does not touch the title' do
       project = create(:project)
       # Bypass the callbacks to mimic a row stored before titles were sanitized.

--- a/back/spec/models/project_spec.rb
+++ b/back/spec/models/project_spec.rb
@@ -136,6 +136,35 @@ RSpec.describe Project do
     end
   end
 
+  describe 'title sanitizer' do
+    it 'strips HTML tags from the title' do
+      project = create(:project, title_multiloc: { 'en' => '<b>bold</b> project' })
+      expect(project.title_multiloc['en']).to eq 'bold project'
+    end
+
+    it 'strips script/event-handler payloads from the title' do
+      project = create(:project, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+      expect(project.title_multiloc['en']).not_to include('onerror')
+      expect(project.title_multiloc['en']).not_to include('<img')
+    end
+
+    it 'leaves ampersands as plain text' do
+      project = create(:project, title_multiloc: { 'en' => 'Fish & chips' })
+      expect(project.title_multiloc['en']).to eq 'Fish & chips'
+    end
+
+    it 'is not rewritten by a save that does not touch the title' do
+      project = create(:project)
+      # Bypass the callbacks to mimic a row stored before titles were sanitized.
+      project.update_columns(title_multiloc: { 'en' => 'Fish & chips' })
+      project.reload
+
+      project.update!(description_multiloc: { 'en' => '<p>updated</p>' })
+
+      expect(project.reload.title_multiloc['en']).to eq 'Fish & chips'
+    end
+  end
+
   describe 'destroy' do
     it 'can be realised' do
       project = create(:project_xl)
@@ -171,6 +200,11 @@ RSpec.describe Project do
     it 'generates a slug based on the first non-empty locale' do
       project.update!(title_multiloc: { 'en' => 'my project', 'nl-BE' => 'mijn project', 'fr-BE' => 'mon projet' })
       expect(project.slug).to eq 'my-project'
+    end
+
+    it 'generates a slug from the sanitized title, not the raw one' do
+      project.update!(title_multiloc: { 'en' => '<b>Bold</b> project' })
+      expect(project.slug).to eq 'bold-project'
     end
   end
 

--- a/back/spec/models/static_page_spec.rb
+++ b/back/spec/models/static_page_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe StaticPage do
     end
   end
 
+  it_behaves_like 'a sanitized title_multiloc', factory: :static_page
+
   describe 'validations' do
     it { is_expected.to validate_presence_of(:title_multiloc) }
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1380,8 +1380,7 @@ RSpec.describe User do
       user = described_class.new
       user.first_name = '&lt;img src=x onerror=alert(1)&gt;Bob'
       user.validate
-      expect(user.first_name).not_to include('onerror')
-      expect(user.first_name).not_to include('<img')
+      expect(user.first_name).to eq 'Bob'
     end
 
     it 'is invalid when it contains @' do

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1369,6 +1369,21 @@ RSpec.describe User do
       expect(user.first_name).to eq 'Terry'
     end
 
+    it 'does not entity-encode punctuation in a valid name' do
+      user = described_class.new
+      user.first_name = "Ann-Sofie O'Brien"
+      user.validate
+      expect(user.first_name).to eq "Ann-Sofie O'Brien"
+    end
+
+    it 'neutralises a payload hidden behind entity encoding' do
+      user = described_class.new
+      user.first_name = '&lt;img src=x onerror=alert(1)&gt;Bob'
+      user.validate
+      expect(user.first_name).not_to include('onerror')
+      expect(user.first_name).not_to include('<img')
+    end
+
     it 'is invalid when it contains @' do
       user = build(:user, first_name: 'foo@example.com')
       expect(user).not_to be_valid

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -451,12 +451,15 @@ describe SanitizationService do
   end
 
   describe 'sanitize_body_multiloc' do
+    # One input exercising all three steps: the script tag is sanitized away, the bare URL is
+    # linkified, and the empty trailing `<p>` is dropped.
     it 'runs the sanitize, trailing-tag and linkify steps' do
       output = service.sanitize_body_multiloc(
         { 'en' => '<p>See https://example.com</p><script>alert(1)</script><p></p>' }, %i[mention]
       )
-      expect(output['en']).to include('href="https://example.com"')
-      expect(output['en']).not_to include('<script>')
+      expect(output['en']).to eq(
+        '<p>See <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a></p>alert(1)'
+      )
     end
 
     # Public API responses distinguish '' from nil, so this must not drift.
@@ -481,9 +484,7 @@ describe SanitizationService do
     end
 
     it 'neutralises a payload hidden behind entity encoding' do
-      output = service.strip_to_plain_text('&lt;img src=x onerror=alert(1)&gt;hi')
-      expect(output).not_to include('onerror')
-      expect(output).not_to include('<img')
+      expect(service.strip_to_plain_text('&lt;img src=x onerror=alert(1)&gt;hi')).to eq 'hi'
     end
 
     it 'returns nil for nil, like sanitize does' do

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -486,9 +486,22 @@ describe SanitizationService do
       expect(output).not_to include('<img')
     end
 
+    it 'returns nil for nil, like sanitize does' do
+      expect(service.strip_to_plain_text(nil)).to be_nil
+    end
+
     it 'leaves no parsable tag even for deeply nested encodings' do
       output = service.strip_to_plain_text('&amp;amp;amp;amp;amp;lt;script&amp;amp;amp;amp;amp;gt;')
       expect(output).not_to match(/<[a-zA-Z]/)
+    end
+  end
+
+  describe 'strip_multiloc_to_plain_text' do
+    it 'strips every locale and keeps a nil value nil' do
+      output = service.strip_multiloc_to_plain_text(
+        { 'en' => '<b>Fish</b> & chips', 'fr-BE' => '<img src=x onerror=alert(1)>frites', 'nl-NL' => nil }
+      )
+      expect(output).to eq({ 'en' => 'Fish & chips', 'fr-BE' => 'frites', 'nl-NL' => nil })
     end
   end
 end

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -14,6 +14,12 @@ describe SanitizationService do
       expect(service.sanitize(input, features)).to eq input
     end
 
+    it 'does not mutate the passed features array and accepts a frozen one' do
+      features = %i[link image].freeze
+      expect { service.sanitize('<a href="https://example.com">x</a>', features) }.not_to raise_error
+      expect(features).to eq %i[link image]
+    end
+
     it 'allows titles to pass through when title feature is enabled' do
       input = <<~HTML
         <h2>title</h2>

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -449,4 +449,30 @@ describe SanitizationService do
       expect(output).to eq '<p><a href="mailto:hello@citizenlab.co" target="_blank" rel="noreferrer noopener nofollow">hello@citizenlab.co</a></p>'
     end
   end
+
+  describe 'strip_to_plain_text' do
+    it 'removes markup' do
+      expect(service.strip_to_plain_text('<b>Bold</b> idea')).to eq 'Bold idea'
+    end
+
+    it 'does not entity-encode the text that survives' do
+      expect(service.strip_to_plain_text('Fish & chips: budget > 100 < 200')).to eq 'Fish & chips: budget > 100 < 200'
+    end
+
+    it 'is idempotent' do
+      once = service.strip_to_plain_text('<b>Fish</b> & chips')
+      expect(service.strip_to_plain_text(once)).to eq once
+    end
+
+    it 'neutralises a payload hidden behind entity encoding' do
+      output = service.strip_to_plain_text('&lt;img src=x onerror=alert(1)&gt;hi')
+      expect(output).not_to include('onerror')
+      expect(output).not_to include('<img')
+    end
+
+    it 'leaves no parsable tag even for deeply nested encodings' do
+      output = service.strip_to_plain_text('&amp;amp;amp;amp;amp;lt;script&amp;amp;amp;amp;amp;gt;')
+      expect(output).not_to match(/<[a-zA-Z]/)
+    end
+  end
 end

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -234,6 +234,57 @@ describe SanitizationService do
       features = %i[title alignment list decoration link video]
       expect(service.sanitize(input, features)).not_to include "<iframe src=\"javascript:javascript:alert('ThisPlatformWasHacked!');\"></iframe>"
     end
+
+    describe 'URL scheme allowlist' do
+      it 'drops javascript: hrefs on links but keeps the text' do
+        input = '<a href="javascript:alert(1)">click</a>'
+        output = service.sanitize(input, [:link])
+        expect(output).not_to include('javascript:')
+        expect(output).to include('click')
+      end
+
+      it 'drops data: hrefs on links' do
+        input = '<a href="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==">click</a>'
+        output = service.sanitize(input, [:link])
+        expect(output).not_to include('data:text/html')
+      end
+
+      it 'keeps http, https, mailto and relative hrefs on links' do
+        ['https://example.com', 'http://example.com', 'mailto:a@b.com', '/relative', '#frag'].each do |href|
+          output = service.sanitize(%(<a href="#{href}">x</a>), [:link])
+          expect(output).to include(%(href="#{href}"))
+        end
+      end
+
+      it 'drops javascript: src on images' do
+        input = '<img src="javascript:alert(1)">'
+        expect(service.sanitize(input, [:image])).not_to include('javascript:')
+      end
+
+      it 'keeps data:image base64 src on images' do
+        input = '<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7">'
+        expect(service.sanitize(input, [:image])).to include('data:image/gif;base64')
+      end
+    end
+
+    describe 'CSS scrubbing of the style attribute' do
+      it 'drops javascript: URLs inside style' do
+        input = '<img src="/x.png" style="background:url(javascript:alert(1))">'
+        expect(service.sanitize(input, [:image])).not_to include('javascript:')
+      end
+
+      it 'drops CSS expression() inside style' do
+        input = '<img src="/x.png" style="width:expression(alert(1))">'
+        expect(service.sanitize(input, [:image])).not_to include('expression(')
+      end
+
+      it 'drops position/offset properties usable for clickjacking overlays' do
+        input = '<img src="/x.png" style="position:fixed;top:0;left:0;width:100vw;height:100vh">'
+        output = service.sanitize(input, [:image])
+        expect(output).not_to include('position:')
+        expect(output).not_to include('top:')
+      end
+    end
   end
 
   describe 'remove_empty_trailing_tags' do

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -450,6 +450,23 @@ describe SanitizationService do
     end
   end
 
+  describe 'sanitize_body_multiloc' do
+    it 'runs the sanitize, trailing-tag and linkify steps' do
+      output = service.sanitize_body_multiloc(
+        { 'en' => '<p>See https://example.com</p><script>alert(1)</script><p></p>' }, %i[mention]
+      )
+      expect(output['en']).to include('href="https://example.com"')
+      expect(output['en']).not_to include('<script>')
+    end
+
+    # Long-standing behaviour from before the pipeline was extracted: a nil locale value comes
+    # back as ''. Public API responses distinguish the two, so this must not drift to nil.
+    it 'turns a nil locale value into an empty string, not nil' do
+      output = service.sanitize_body_multiloc({ 'en' => '<p>hi</p>', 'nl-NL' => nil }, %i[mention])
+      expect(output).to eq({ 'en' => '<p>hi</p>', 'nl-NL' => '' })
+    end
+  end
+
   describe 'strip_to_plain_text' do
     it 'removes markup' do
       expect(service.strip_to_plain_text('<b>Bold</b> idea')).to eq 'Bold idea'

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -459,8 +459,7 @@ describe SanitizationService do
       expect(output['en']).not_to include('<script>')
     end
 
-    # Long-standing behaviour from before the pipeline was extracted: a nil locale value comes
-    # back as ''. Public API responses distinguish the two, so this must not drift to nil.
+    # Public API responses distinguish '' from nil, so this must not drift.
     it 'turns a nil locale value into an empty string, not nil' do
       output = service.sanitize_body_multiloc({ 'en' => '<p>hi</p>', 'nl-NL' => nil }, %i[mention])
       expect(output).to eq({ 'en' => '<p>hi</p>', 'nl-NL' => '' })

--- a/back/spec/support/shared_examples/sanitized_title_multiloc.rb
+++ b/back/spec/support/shared_examples/sanitized_title_multiloc.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-# Shared examples for a model whose `title_multiloc` is stripped to plain text on write, because
-# a title is plain text that nonetheless reaches HTML render paths.
+# Shared examples for a model whose `title_multiloc` is stripped to plain text on write.
 #
 # The stripping rule itself is specced in spec/services/sanitization_service_spec.rb; these
 # examples only assert that the model is wired to it.

--- a/back/spec/support/shared_examples/sanitized_title_multiloc.rb
+++ b/back/spec/support/shared_examples/sanitized_title_multiloc.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Shared examples for a model whose `title_multiloc` is stripped to plain text on write, because
+# a title is plain text that nonetheless reaches HTML render paths.
+#
+# The stripping rule itself is specced in spec/services/sanitization_service_spec.rb; these
+# examples only assert that the model is wired to it.
+#
+# Usage:
+#   it_behaves_like 'a sanitized title_multiloc', factory: :project
+#
+# @param factory [Symbol] A factory that accepts a `title_multiloc`.
+RSpec.shared_examples 'a sanitized title_multiloc' do |factory:|
+  it 'strips HTML tags from the title' do
+    record = create(factory, title_multiloc: { 'en' => '<b>bold</b> title' })
+    expect(record.title_multiloc['en']).to eq 'bold title'
+  end
+
+  it 'strips script/event-handler payloads from the title' do
+    record = create(factory, title_multiloc: { 'en' => '<img src=x onerror=alert(1)>hi' })
+    expect(record.title_multiloc['en']).to eq 'hi'
+  end
+
+  # A single `full_sanitizer` pass would leave 'Fish &amp; chips' here.
+  it 'strips markup without entity-encoding the text that survives' do
+    record = create(factory, title_multiloc: { 'en' => '<b>Fish</b> & chips' })
+    expect(record.title_multiloc['en']).to eq 'Fish & chips'
+  end
+end

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -92,6 +92,18 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
+  context 'an event or static page title carrying HTML' do
+    let!(:event) { store_raw(create(:event), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+    let!(:static_page) { store_raw(create(:static_page), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+
+    it 'strips all HTML from each of them' do
+      run_task
+      [event, static_page].each do |record|
+        expect(record.reload.title_multiloc['en']).to eq 'hi'
+      end
+    end
+  end
+
   context 'a comment body carrying a script tag' do
     let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p>hi</p><script>alert(1)</script>' }) }
 

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -32,16 +32,16 @@ describe 'single_use:purge_stored_xss rake task' do
   context 'an idea body carrying an event-handler payload' do
     let!(:idea) { store_raw(create(:idea), :body_multiloc, { 'en' => '<p>x</p><img src=x onerror=alert(1)>' }) }
 
-    it 'strips the handler' do
+    it 'strips the handler and keeps the rest of the body' do
       run_task
-      expect(idea.reload.body_multiloc['en']).not_to include('onerror')
+      expect(idea.reload.body_multiloc['en']).to eq '<p>x</p><img src="x">'
     end
 
     it 'records the change with context' do
       run_task
       change = report['changes'].find { |c| c.dig('context', 'model') == 'Idea' && c.dig('context', 'attribute') == 'body_multiloc' }
       expect(change['context']).to include('model' => 'Idea', 'id' => idea.id, 'attribute' => 'body_multiloc')
-      expect(change['new_value']['en']).not_to include('onerror')
+      expect(change['new_value']['en']).to eq '<p>x</p><img src="x">'
     end
   end
 
@@ -50,8 +50,7 @@ describe 'single_use:purge_stored_xss rake task' do
 
     it 'strips all HTML from the title' do
       run_task
-      expect(idea.reload.title_multiloc['en']).not_to include('onerror')
-      expect(idea.reload.title_multiloc['en']).not_to include('<img')
+      expect(idea.reload.title_multiloc['en']).to eq 'hi'
     end
 
     it 'does not entity-encode the text it leaves behind' do
@@ -96,9 +95,10 @@ describe 'single_use:purge_stored_xss rake task' do
   context 'a comment body carrying a script tag' do
     let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p>hi</p><script>alert(1)</script>' }) }
 
-    it 'strips the script' do
+    # The script tag goes; its text content stays, inert.
+    it 'strips the script and keeps the rest of the body' do
       run_task
-      expect(comment.reload.body_multiloc['en']).not_to include('<script>')
+      expect(comment.reload.body_multiloc['en']).to eq '<p>hi</p>alert(1)'
     end
   end
 
@@ -112,9 +112,9 @@ describe 'single_use:purge_stored_xss rake task' do
 
     it 'strips the payload and keeps the link' do
       run_task
-      body = comment.reload.body_multiloc['en']
-      expect(body).not_to include('onerror')
-      expect(body).to include('href="https://example.com"')
+      expect(comment.reload.body_multiloc['en']).to eq(
+        '<p>See <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a></p>'
+      )
     end
   end
 
@@ -143,9 +143,9 @@ describe 'single_use:purge_stored_xss rake task' do
       store_raw(create(:machine_translation, attribute_name: 'body_multiloc'), :translation, '<p>hi</p><img src=x onerror=alert(1)>')
     end
 
-    it 'strips the handler' do
+    it 'strips the handler and keeps the rest of the translation' do
       run_task
-      expect(mt.reload.translation).not_to include('onerror')
+      expect(mt.reload.translation).to eq '<p>hi</p><img src="x">'
     end
   end
 

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -61,8 +61,6 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
-  # The admin management feed renders a changed title_multiloc as raw HTML, so a moderator-editable
-  # title is a carrier too - on every model whose title can reach that feed.
   context 'a project, phase or folder title carrying HTML' do
     let!(:project) { store_raw(create(:project), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
     let!(:phase) { store_raw(create(:phase), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -82,6 +82,19 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
+  context 'a topic title carrying HTML' do
+    let!(:input_topic) { store_raw(create(:input_topic), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+    let!(:global_topic) { store_raw(create(:global_topic), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+    let!(:default_topic) { store_raw(create(:default_input_topic), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+
+    it 'strips all HTML from each topic model' do
+      run_task
+      [input_topic, global_topic, default_topic].each do |record|
+        expect(record.reload.title_multiloc['en']).to eq 'hi'
+      end
+    end
+  end
+
   context 'a comment body carrying a script tag' do
     let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p>hi</p><script>alert(1)</script>' }) }
 

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -61,6 +61,27 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
+  # The admin management feed renders a changed title_multiloc as raw HTML, so a moderator-editable
+  # title is a carrier too - on every model whose title can reach that feed.
+  context 'a project, phase or folder title carrying HTML' do
+    let!(:project) { store_raw(create(:project), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+    let!(:phase) { store_raw(create(:phase), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+    let!(:folder) { store_raw(create(:project_folder), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+
+    it 'strips all HTML from each of them' do
+      run_task
+      [project, phase, folder].each do |record|
+        expect(record.reload.title_multiloc['en']).to eq 'hi'
+      end
+    end
+
+    it 'reports each one under its own model' do
+      run_task
+      models = report['changes'].filter_map { |c| c.dig('context', 'model') if c.dig('context', 'attribute') == 'title_multiloc' }
+      expect(models).to include('Project', 'Phase', 'ProjectFolders::Folder')
+    end
+  end
+
   context 'a comment body carrying a script tag' do
     let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p>hi</p><script>alert(1)</script>' }) }
 

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -54,6 +54,12 @@ describe 'single_use:purge_stored_xss rake task' do
       expect(idea.reload.title_multiloc['en']).not_to include('onerror')
       expect(idea.reload.title_multiloc['en']).not_to include('<img')
     end
+
+    it 'does not entity-encode the text it leaves behind' do
+      store_raw(idea, :title_multiloc, { 'en' => '<b>Fish</b> & chips' })
+      run_task
+      expect(idea.reload.title_multiloc['en']).to eq 'Fish & chips'
+    end
   end
 
   context 'a comment body carrying a script tag' do
@@ -62,6 +68,43 @@ describe 'single_use:purge_stored_xss rake task' do
     it 'strips the script' do
       run_task
       expect(comment.reload.body_multiloc['en']).not_to include('<script>')
+    end
+  end
+
+  # A comment body allows mentions only, so sanitising alone would strip the anchors that
+  # `Comment#sanitize_body_multiloc` puts there on write. Removing a payload must not cost the
+  # comment its links.
+  context 'a comment body carrying both a payload and a link' do
+    let!(:comment) do
+      store_raw(create(:comment), :body_multiloc, { 'en' =>
+        '<p>See <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a></p><img src=x onerror=alert(1)>' })
+    end
+
+    it 'strips the payload and keeps the link' do
+      run_task
+      body = comment.reload.body_multiloc['en']
+      expect(body).not_to include('onerror')
+      expect(body).to include('href="https://example.com"')
+    end
+  end
+
+  # Payload classes the old pre-filter missed: none of these contain `on*=`, `<script`,
+  # `javascript:`, `vbscript:` or `data:text/html`, but the write path strips all of them.
+  context 'payloads that carry no executable keyword' do
+    {
+      'iframe with a non-allowlisted src' => '<iframe src="https://evil.example"></iframe>',
+      'form and input' => '<form action="https://evil.example"><input name="pw"></form>',
+      'object' => '<object data="https://evil.example"></object>',
+      'style block' => '<style>body{display:none}</style>',
+      'entity-encoded scheme' => '<a href="javas&#99;ript:alert(1)">x</a>'
+    }.each do |label, payload|
+      context "an idea body carrying #{label}" do
+        let!(:idea) { store_raw(create(:idea), :body_multiloc, { 'en' => "<p>hi</p>#{payload}" }) }
+
+        it 'is found by the pre-filter and rewritten' do
+          expect { run_task }.to(change { idea.reload.body_multiloc })
+        end
+      end
     end
   end
 

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'single_use:purge_stored_xss rake task' do
+  before { load_rake_tasks_if_not_loaded }
+
+  after do
+    Rake::Task['single_use:purge_stored_xss'].reenable
+    FileUtils.rm_f(report_path)
+    FileUtils.rm_f(dry_run_report_path)
+  end
+
+  let(:report_path) { Rails.root.join('purge_stored_xss.json') }
+  let(:dry_run_report_path) { Rails.root.join('purge_stored_xss_dry_run.json') }
+
+  def run_task(dry_run: false, host: nil)
+    Rake::Task['single_use:purge_stored_xss'].invoke(dry_run ? nil : 'execute', host)
+  end
+
+  def report
+    JSON.parse(File.read(report_path))
+  end
+
+  # Models now sanitise on write, so a legacy payload has to be written past the callbacks, the way
+  # it was stored before the fix. `update_column` skips validations and callbacks.
+  def store_raw(record, attribute, value)
+    record.update_column(attribute, value)
+    record
+  end
+
+  context 'an idea body carrying an event-handler payload' do
+    let!(:idea) { store_raw(create(:idea), :body_multiloc, { 'en' => '<p>x</p><img src=x onerror=alert(1)>' }) }
+
+    it 'strips the handler' do
+      run_task
+      expect(idea.reload.body_multiloc['en']).not_to include('onerror')
+    end
+
+    it 'records the change with context' do
+      run_task
+      change = report['changes'].find { |c| c.dig('context', 'model') == 'Idea' && c.dig('context', 'attribute') == 'body_multiloc' }
+      expect(change['context']).to include('model' => 'Idea', 'id' => idea.id, 'attribute' => 'body_multiloc')
+      expect(change['new_value']['en']).not_to include('onerror')
+    end
+  end
+
+  context 'an idea title carrying HTML' do
+    let!(:idea) { store_raw(create(:idea), :title_multiloc, { 'en' => '<img src=x onerror=alert(1)>hi' }) }
+
+    it 'strips all HTML from the title' do
+      run_task
+      expect(idea.reload.title_multiloc['en']).not_to include('onerror')
+      expect(idea.reload.title_multiloc['en']).not_to include('<img')
+    end
+  end
+
+  context 'a comment body carrying a script tag' do
+    let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p>hi</p><script>alert(1)</script>' }) }
+
+    it 'strips the script' do
+      run_task
+      expect(comment.reload.body_multiloc['en']).not_to include('<script>')
+    end
+  end
+
+  context 'a machine translation carrying an event-handler payload' do
+    let!(:mt) do
+      store_raw(create(:machine_translation, attribute_name: 'body_multiloc'), :translation, '<p>hi</p><img src=x onerror=alert(1)>')
+    end
+
+    it 'strips the handler' do
+      run_task
+      expect(mt.reload.translation).not_to include('onerror')
+    end
+  end
+
+  context 'clean content' do
+    let!(:idea) { create(:idea, body_multiloc: { 'en' => '<p>perfectly fine</p>' }) }
+
+    it 'is left untouched and reported as no change' do
+      expect { run_task }.not_to(change { idea.reload.body_multiloc })
+      expect(report['changes']).to be_empty
+      # Without this the example would also pass if the task had errored on every tenant.
+      expect(report['errors']).to be_empty
+      expect(report['processed_tenants']).to include(Tenant.current.host)
+    end
+  end
+
+  context 'a dry run' do
+    let!(:idea) { store_raw(create(:idea), :body_multiloc, { 'en' => '<img src=x onerror=alert(1)>' }) }
+
+    it 'writes nothing but still reports the change it would make' do
+      expect { run_task(dry_run: true) }.not_to(change { idea.reload.body_multiloc })
+      expect(File).not_to exist(report_path)
+      dry_run_report = JSON.parse(File.read(dry_run_report_path))
+      expect(dry_run_report['changes']).not_to be_empty
+    end
+  end
+
+  context 'when the task is run twice' do
+    let!(:idea) { store_raw(create(:idea), :body_multiloc, { 'en' => '<img src=x onerror=alert(1)>' }) }
+
+    it 'has nothing to do on the second run' do
+      run_task
+      Rake::Task['single_use:purge_stored_xss'].reenable
+
+      expect { run_task }.not_to(change { idea.reload.body_multiloc })
+      expect(report['changes']).to be_empty
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -23,8 +23,7 @@ describe 'single_use:purge_stored_xss rake task' do
     JSON.parse(File.read(report_path))
   end
 
-  # Models now sanitise on write, so a legacy payload has to be written past the callbacks, the way
-  # it was stored before the fix. `update_column` skips validations and callbacks.
+  # Models sanitise on write now, so a legacy payload has to be stored past the callbacks.
   def store_raw(record, attribute, value)
     record.update_column(attribute, value)
     record
@@ -71,9 +70,8 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
-  # A comment body allows mentions only, so sanitising alone would strip the anchors that
-  # `Comment#sanitize_body_multiloc` puts there on write. Removing a payload must not cost the
-  # comment its links.
+  # A comment body allows mentions only, so sanitising alone would strip the anchors linkify puts
+  # there on write. Removing a payload must not cost the comment its links.
   context 'a comment body carrying both a payload and a link' do
     let!(:comment) do
       store_raw(create(:comment), :body_multiloc, { 'en' =>
@@ -88,8 +86,8 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
-  # Payload classes the old pre-filter missed: none of these contain `on*=`, `<script`,
-  # `javascript:`, `vbscript:` or `data:text/html`, but the write path strips all of them.
+  # None of these contain an executable keyword, but the write path strips all of them - so the
+  # pre-filter has to be wide enough to find them.
   context 'payloads that carry no executable keyword' do
     {
       'iframe with a non-allowlisted src' => '<iframe src="https://evil.example"></iframe>',

--- a/front/app/containers/Admin/dashboard/ManagementFeed/ChangesTable.tsx
+++ b/front/app/containers/Admin/dashboard/ManagementFeed/ChangesTable.tsx
@@ -13,6 +13,7 @@ import {
 } from '@citizenlab/cl2-component-library';
 
 import { useIntl } from 'utils/cl-intl';
+import { htmlToPlainText } from 'utils/textUtils';
 
 import messages from './messages';
 
@@ -53,12 +54,15 @@ const ChangesTable = ({ changes }: { changes: Record<string, any> }) => {
                         <Text fontWeight="bold" color="primary" fontSize="s">
                           {valueKey.toUpperCase()}:
                         </Text>
-                        {/* When the value might be a project / folder / idea description, we display it as HTML */}
-                        <Box
-                          dangerouslySetInnerHTML={{
-                            __html: value[valueKey],
-                          }}
-                        />
+                        {/* Descriptions contain HTML, which we show as text rather than render */}
+                        <Text
+                          fontSize="s"
+                          wordBreak="break-word"
+                          color="primary"
+                          whiteSpace="pre-wrap"
+                        >
+                          {htmlToPlainText(String(value[valueKey]))}
+                        </Text>
                       </Box>
                     ))}
                   </Box>

--- a/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/TitleMultilocLongField.tsx
+++ b/front/app/containers/Admin/projects/project/analysis/InputPreview/components/CustomFields/LongFieldValue/CustomFieldLongFieldValues/TitleMultilocLongField.tsx
@@ -16,10 +16,7 @@ const TitleMultilocLongField = ({ input, customField }: Props) => {
   return (
     <Box>
       <Title variant="h3" my="0px">
-        <T
-          value={input.attributes[customField.data.attributes.key]}
-          supportHtml={true}
-        />
+        <T value={input.attributes[customField.data.attributes.key]} />
       </Title>
     </Box>
   );

--- a/front/app/containers/IdeasFeedPage/Sidebar/TopicItem.tsx
+++ b/front/app/containers/IdeasFeedPage/Sidebar/TopicItem.tsx
@@ -69,7 +69,7 @@ const TopicItem = ({
               <Emoji emoji={topic.data.attributes.icon} size="24px" />
             )}
             <Text m="0px" p="0px" fontWeight="bold" variant="bodyL">
-              <T value={topic?.data.attributes.title_multiloc} supportHtml />
+              <T value={topic?.data.attributes.title_multiloc} />
             </Text>
           </Box>
           <Box

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/ResultList.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundResults/ResultList.tsx
@@ -66,7 +66,7 @@ const ResultList = ({ title, description, items }: Props) => {
                   mb={isMobileOrSmaller ? '8px' : undefined}
                   mr={isMobileOrSmaller ? undefined : '16px'}
                 >
-                  <T value={item.title_multiloc} supportHtml />
+                  <T value={item.title_multiloc} />
                 </Box>
                 <Box width="166px" flexShrink={0}>
                   <OutcomeBreakdownBar

--- a/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundStatements.tsx
+++ b/front/app/containers/ProjectsShowPage/timeline/CommonGround/CommonGroundStatements.tsx
@@ -216,7 +216,7 @@ const CommonGroundStatements = ({ phaseId }: Props) => {
       >
         <Box mb="12px" id={`statement-body-${current.data.id}`}>
           <Text fontSize="l">
-            <T value={current.data.attributes.title_multiloc} supportHtml />
+            <T value={current.data.attributes.title_multiloc} />
           </Text>
         </Box>
 

--- a/front/app/utils/textUtils.test.ts
+++ b/front/app/utils/textUtils.test.ts
@@ -1,4 +1,9 @@
-import { capitalize, withoutSpacing } from './textUtils';
+import {
+  capitalize,
+  htmlToPlainText,
+  stripHtml,
+  withoutSpacing,
+} from './textUtils';
 
 describe('withoutSpacing', () => {
   it('removes spaces from simple string', () => {
@@ -15,6 +20,55 @@ describe('withoutSpacing', () => {
       <li>${'with spaces 2'}</li>
     </ul>
   `).toEqual(expectedResult);
+  });
+});
+
+describe('htmlToPlainText', () => {
+  it('returns text without the surrounding markup', () => {
+    expect(htmlToPlainText('<p>Hello <strong>world</strong></p>')).toEqual(
+      'Hello world\n'
+    );
+  });
+
+  it('breaks lines between block elements', () => {
+    expect(htmlToPlainText('<p>One</p><p>Two</p>')).toEqual('One\nTwo\n');
+    expect(htmlToPlainText('One<br />Two')).toEqual('One\nTwo');
+  });
+
+  it('drops script and event handler payloads', () => {
+    expect(htmlToPlainText('Hi<script>alert(1)</script>')).toEqual('Hi');
+    expect(htmlToPlainText('Hi<style>body { color: red }</style>')).toEqual(
+      'Hi'
+    );
+    expect(htmlToPlainText('<img src=x onerror="alert(1)">')).toEqual('');
+    expect(htmlToPlainText('<a href="javascript:alert(1)">Click</a>')).toEqual(
+      'Click'
+    );
+  });
+
+  it('keeps text that only looks like markup', () => {
+    expect(htmlToPlainText('5 &lt; 6 &amp; 7 &gt; 6')).toEqual('5 < 6 & 7 > 6');
+  });
+
+  it('handles an empty string', () => {
+    expect(htmlToPlainText('')).toEqual('');
+  });
+});
+
+describe('stripHtml', () => {
+  it('returns a single line of text', () => {
+    expect(stripHtml('<p>One</p><p>Two</p>')).toEqual('One Two');
+    expect(stripHtml('<ul><li>One</li><li>Two</li></ul>')).toEqual('One Two');
+    expect(stripHtml('  <p>  Spaced   out  </p>  ')).toEqual('Spaced out');
+  });
+
+  it('drops script and event handler payloads', () => {
+    expect(stripHtml('Hi<script>alert(1)</script>')).toEqual('Hi');
+    expect(stripHtml('<img src=x onerror="alert(1)">')).toEqual('');
+  });
+
+  it('truncates to the given length', () => {
+    expect(stripHtml('<p>One</p><p>Two</p>', 5)).toEqual('On...');
   });
 });
 

--- a/front/app/utils/textUtils.ts
+++ b/front/app/utils/textUtils.ts
@@ -17,12 +17,24 @@ export const truncateMultiloc = (
   }, {});
 };
 
-export function stripHtml(html: string, maxLength?: number) {
-  const tmp = document.createElement('DIV');
-  tmp.innerHTML = html;
-  const result = tmp.textContent || tmp.innerText || '';
+const blockBoundaryRegEx = /<\/(p|div|li|h[1-6]|tr|blockquote)>|<br\s*\/?>/gi;
 
-  return truncate(result, maxLength);
+// Converts HTML to plain text, preserving line breaks. DOMParser is inert (no
+// scripts run, no event handlers fire), unlike `innerHTML`, so this is XSS-safe.
+export function htmlToPlainText(html: string) {
+  const withLineBreaks = html.replace(blockBoundaryRegEx, '\n');
+  const { body } = new DOMParser().parseFromString(withLineBreaks, 'text/html');
+  // Otherwise their source code would show up as text.
+  body.querySelectorAll('script, style').forEach((element) => element.remove());
+
+  return body.textContent;
+}
+
+// Single line of plain text, for meta tags and previews.
+export function stripHtml(html: string, maxLength?: number) {
+  const text = htmlToPlainText(html).replace(/\s+/g, ' ').trim();
+
+  return truncate(text, maxLength);
 }
 
 // Default slug rules including arabic character ranges

--- a/front/app/utils/word/converters/htmlConverter.ts
+++ b/front/app/utils/word/converters/htmlConverter.ts
@@ -1,3 +1,4 @@
+import { htmlToPlainText } from 'utils/textUtils';
 import {
   createEmptyParagraph,
   createParagraph,
@@ -9,16 +10,8 @@ const getTextLines = (text: string) =>
     .map((line) => line.trim())
     .filter(Boolean);
 
-const convertHtmlToTextLines = (html: string) => {
-  const withLineBreaks = html
-    .replace(/<\/(h[1-6]|p|div|li|tr|blockquote)>/gi, '\n')
-    .replace(/<br\s*\/?>/gi, '\n');
-
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(withLineBreaks, 'text/html');
-  const text = doc.body.textContent || '';
-  return getTextLines(text);
-};
+const convertHtmlToTextLines = (html: string) =>
+  getTextLines(htmlToPlainText(html));
 
 export const createParagraphsFromHtml = (html: string) => {
   const lines = convertHtmlToTextLines(html);


### PR DESCRIPTION
Claude plan [here](https://github.com/CitizenLabDotCo/citizenlab-claude/blob/main/plans/TAN-8413-improve-xss-sanitisation.md).

Stored XSS on idea pages executed script in authenticated admin/moderator sessions (reported on `mitgestalten.wien.gv.at`). Root cause: HTML sanitisation is per-field on write, and two fields were unwired — **draft idea bodies** (`sanitize_body_multiloc` was gated `unless: :draft?`) and **idea titles** (only whitespace-stripped, yet rendered as HTML in places). Both are now sanitised on write, existing rows are purged, and the sanitiser is verified + guarded.

The branch was reviewed against `master` twice — after the initial implementation, and again after those fixes landed. Both rounds, their findings and their fixes are recorded in the plan linked above.

## Why this touches nine models, not one

The second review found a render sink the first had missed: `ManagementFeed/ChangesTable.tsx` passed **every changed multiloc from an activity diff** to `dangerouslySetInnerHTML` — deliberately, since the same cell renders project and folder descriptions. The feed carries item types `project | phase | folder | idea | permission`.

So a moderator renaming a project, phase or folder to `<img src=x onerror=…>` landed raw HTML in an **admin's** feed: the same moderator→admin escalation as the reported incident, on models this branch had not touched. `InputTopic` turned out to be exposed the same way through the ideas feed sidebar, and had no title handling at all — not even the whitespace strip the other models carry.

Titles are therefore sanitised on `Idea`, `Project`, `Phase`, `ProjectFolders::Folder`, `InputTopic`, `GlobalTopic`, `DefaultInputTopic`, `Event` and `StaticPage`, all through one shared implementation. PR review then asked for the render sinks themselves, so the two halves now agree: titles are plain text on write, and rendered as text.

## Ticket claims — status
| # | Claim (as ticketed) | Status | Note |
|---|---|---|---|
| 1 | Stored XSS executes in admin/moderator session | ✅ Fixed | Real carrier: draft `body_multiloc`. Ungated `sanitize_body_multiloc`. |
| 2 | Reads viewer's private profile PII via session | ✅ Fixed | Consequence of #1. |
| 3 | Carrier is `Idea#custom_field_values` | ❌ Refuted | Record had `custom_field_values: {}`; answers render React-escaped, not an HTML sink. |
| 4 | `IframeScrubber` accepts `javascript:`/`data:` in `href` | ❌ Refuted | Stripped by inherited `scrub_attributes` (verified via Loofah directly). |
| 5 | `img[src]` / `style` not validated | ❌ Refuted | `src` scheme stripped; `style` CSS-scrubbed (`url(javascript:)`, `expression()`, `position`). |
| 6 | Moderation cell renders raw HTML | ✅ At source | Renders `body_multiloc`, now sanitised. FE hardening = deferred Phase 5. |
| 7 | Shared `T` renderer / no client-side sanitiser (~26 sinks) | ◑ Partly | The five sinks that rendered a `title_multiloc` are closed here (management feed + four `supportHtml` props). The rest render fields that really are HTML, and wait on the client-side sanitiser. |
| 8 | `title_multiloc` unsanitised | ✅ Fixed | Stripped to plain text on write — on `Idea`, and on eight more models once the second sink was found (see above). |
| 9 | `comment.rb` mention-only allowlist | ✅ No gap | Allowlist still strips scripts/handlers. |
| 10 | Root cause: per-field server-side only | ◑ Partly | Known fields fixed + purge; systemic client backstop = Phase 5. |
| 11 | Existing stored payloads not cleaned | ✅ Fixed | Purge rake task, applying each field's full write-path pipeline across twelve scopes per tenant. |

✅ Fixed · ❌ Refuted empirically · ⏸ Deferred · ◑ Partial

Of the ticket's 5 "confirmed gaps", 2 were real (`#1, #8`) and 3 were refuted by testing (`#3, #4, #5`).

## Additional defences (not in the ticket)
- **Machine-translation output** — provider HTML was rendered raw with zero sanitisation. Each translation now runs through the source field's own pipeline, so it can never be more permissive than the text it was translated from. Every translatable field has an explicit rule; anything unlisted still fails closed to plain text but is reported, rather than picking up a default silently.
- **One shared pipeline** — `SanitizationService#sanitize_body(_multiloc)` and `#strip_multiloc_to_plain_text` are the single implementation, used by all nine models, MT and the purge task. Allowlists stay per-model.
- **Titles stay plain text** — stripping markup no longer entity-encodes what survives (`Fish & chips`, not `Fish &amp; chips`), and only runs when the title changed.
- **Slugs use the sanitised title** — `<b>Bold</b> idea` no longer yields the slug `b-bold-b-idea`. `Sluggable` registers on `ApplicationRecord`, so the title callback carries `prepend: true` to run ahead of it. New inputs only; no stored rows change.
- **User names** — `first_name`/`last_name` used a bare `full_sanitizer` pass, which entity-encoded what it kept (`O&#39;Brien`) and left a payload hiding behind its own encoding intact. Both now use the shared plain-text pipeline.
- **Render sinks closed, not just sources** (added after review) — the management feed shows an activity diff as text instead of raw HTML, and the four components that rendered a `title_multiloc` through `T`'s `supportHtml` no longer do.
- **`stripHtml` no longer parses via `innerHTML`** — it built a detached `<div>` and assigned untrusted HTML to it, which fires handlers such as `<img onerror>` even though the element is never inserted. It now parses inertly with `DOMParser`, through the same helper the feed uses. Eight call sites, including the SEO meta description of every project/idea/event page. As a side effect it stops running adjacent blocks together (`<p>One</p><p>Two</p>` was `OneTwo`).
- **Latent bugs fixed** — `IframeScrubber#initialize` mutated its `features` argument; `GlobalTopic#strip_title` guarded on `description_multiloc` while stripping `title_multiloc`, so a topic with no description never had its title trimmed.
- **Purge robustness** — `TenantScript` only rescues per tenant, so a single unreadable row would have cost that tenant every remaining sweep. Failures are now contained per record and reported with full context.
- **Regression guards** — specs locking the sanitiser's scheme + CSS scrubbing (so a future lib swap can't reopen `#4/#5`), plus one per behaviour above.

## Known trade-off — titles containing `<` immediately followed by a letter

Stripping markup from a plain-text field cannot be lossless. `<` followed by an ASCII letter always opens a tag, so a stored title cannot be both byte-identical to what was typed **and** inert in a raw-HTML sink:

```
"IF x<y THEN do stuff"  =>  "IF x"
"Plan <A> vs <B>"       =>  "Plan  vs "
"Budget 3<5 million"    =>  unchanged   (< before a digit is not a tag)
"<3 our city"           =>  unchanged
```

Escaping instead is worse: it puts `Fish &amp; chips` back into every non-HTML consumer — exports, email subjects, search, and ordinary React text rendering — which is the bug the first review round removed. Storing raw and fixing the sinks isn't sufficient either: the known sinks are closed here, but a title also reaches templates, exports and components this branch can't enumerate, so the guarantee has to hold at the source.

This applies on write and retroactively via the purge, so the dry-run report is checked for it before the fleet run (below). Fuzzing (20k random strings over HTML metacharacters) found no output containing a parsable start tag, so the safety property holds; only the text loss is at issue.

## Scope
Every item in the table is resolved here (fixed, refuted-with-guards, or purged) **except `#7`** — the client-side sanitiser (defence-in-depth) is deferred to its own follow-up PR (Ticket [TAN-8468](https://app.notion.com/p/govocal/Add-client-side-HTML-sanitiser-defence-in-depth-for-render-sinks-3b89663b7b26807a88c5f860381fe3fe?source=copy_link)). It's not required to close the incident; library choice (DOMPurify vs other) to be decided when picked up.

Three things first listed as deferred are fixed here instead, after review:

- **`ChangesTable`** — it can't be fixed by deleting a prop, since the same cell has to show descriptions, but it doesn't need the sanitiser either: an audit diff reads fine as text. It now renders the whole diff as plain text.
- **The four components rendering a `title_multiloc` with `supportHtml`** — topic titles in the ideas feed sidebar, Common Ground statements and results, and the admin analysis input preview. Prop deletions; `T` then renders through React's `children`.
- **`Event` and `StaticPage` titles** — the last two models carrying the asymmetry this branch removed everywhere else. Sanitised on write and swept by the purge.

What remains for TAN-8468 is the ~21 `T` sinks that render genuinely-HTML fields — descriptions, bodies, bios — where a prop deletion would lose formatting and only a sanitiser will do.

## Deploy step
After merge/deploy, run the purge: dry run → review the report → execute.

```
rake single_use:purge_stored_xss
```

Two things to check in the dry-run report before executing:

1. **Title truncation** — look for `title_multiloc` changes where the new value is a strict prefix of the old and the removed tail contains no `>`. Those are the lossy cases described above, not payload removal.
2. **Non-security rewrites** — the purge applies today's write-path rules to all history, so legacy content can change for reasons unrelated to XSS (e.g. `<table>` markup in an idea body, `&nbsp;` collapsing to a space). Read the per-tenant diff, not just the counts. `update_columns` is one-way; the report's `old_value` is the only record.

## Tests
Model, acceptance, service, MT and purge-task specs added/updated; rubocop clean. Every behaviour described above has a spec that was verified to fail without its fix — including the two ordering-sensitive ones, where removing `prepend: true` regresses the slug and unwiring a model's callback fails its shared examples.

The three assertions every title-bearing model needs live in one shared example (`spec/support/shared_examples/sanitized_title_multiloc.rb`) rather than being copied nine times. Purge task spec is `.ignore.rb` (single-use convention).

Front end: jest specs for `htmlToPlainText` and the rewritten `stripHtml` — markup stripped, block boundaries, script/style/`onerror`/`javascript:` payloads dropped, entities preserved, truncation. Full front-end suite green.

# Changelog
## Technical
- [TAN-8413] Improve XSS sanitisation of stored titles and body content
