### PR TITLE
[TAN-8470] Allow report templates from extra surveys

### DIFF
--- a/front/app/components/UI/PhaseFilter/index.tsx
+++ b/front/app/components/UI/PhaseFilter/index.tsx
@@ -3,7 +3,11 @@ import React, { useMemo } from 'react';
 import { Box, Select, Spinner, Text } from '@citizenlab/cl2-component-library';
 import { IOption } from 'typings';
 
-import { IPhaseData, ParticipationMethod } from 'api/phases/types';
+import {
+  IPhaseData,
+  ParticipationMethod,
+  PhasePlacementFilter,
+} from 'api/phases/types';
 import usePhases from 'api/phases/usePhases';
 
 import useLocalize from 'hooks/useLocalize';
@@ -18,6 +22,7 @@ interface Props {
   projectId: string;
   phaseId?: string;
   participationMethods: ParticipationMethod[];
+  placementType?: PhasePlacementFilter;
   onPhaseFilter: (filter: IOption) => void;
   customPhaseFilter?: (phases: IPhaseData[]) => IPhaseData[];
 }
@@ -33,10 +38,11 @@ const PhaseFilter = ({
   projectId,
   phaseId,
   participationMethods,
+  placementType,
   onPhaseFilter,
   customPhaseFilter,
 }: Props) => {
-  const { data: phases } = usePhases(projectId);
+  const { data: phases } = usePhases(projectId, placementType);
   const localize = useLocalize();
   const correctPhases = useMemo(() => {
     if (!phases) return null;

--- a/front/app/containers/Admin/projects/project/information/ReportTab/CreateReportModal/index.tsx
+++ b/front/app/containers/Admin/projects/project/information/ReportTab/CreateReportModal/index.tsx
@@ -155,6 +155,7 @@ const CreateReportModal = ({
               projectId={projectId}
               phaseId={templatePhaseId}
               participationMethods={PARTICIPATION_METHODS}
+              placementType="all"
               onPhaseFilter={(option) => setTemplatePhaseId(option.value)}
             />
           </Box>
@@ -182,7 +183,7 @@ const CreateReportModal = ({
 };
 
 const CreateReportModalWrapper = ({ projectId, ...otherProps }: Props) => {
-  const { data: phases } = usePhases(projectId);
+  const { data: phases } = usePhases(projectId, 'all');
   if (!phases) return null;
 
   return (

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Toolbox/index.tsx
@@ -101,7 +101,7 @@ const ReportBuilderToolbox = ({
     (isSuperAdmin(authUser) ||
       isProjectModerator(authUser, communityMonitorProject.data.id));
 
-  const { data: phases } = usePhases(projectId);
+  const { data: phases } = usePhases(projectId, 'all');
   const { data: userFields } = useUserCustomFields({ inputTypes: ['select'] });
   const projectPlanningCalendarEnabled = useFeatureFlag({
     name: 'project_planning_calendar',

--- a/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
+++ b/front/app/containers/Admin/reporting/components/ReportBuilder/Widgets/SurveyQuestionResultWidget/Settings/index.tsx
@@ -190,6 +190,7 @@ const Settings = () => {
           projectId={projectId}
           phaseId={phaseId}
           participationMethods={['native_survey', 'community_monitor_survey']}
+          placementType="all"
           onPhaseFilter={handlePhaseFilter}
         />
       )}


### PR DESCRIPTION
# Changelog

## Added
- When creating a report on an information phase, the phase-template dropdown now also offers the project's extra (parallel) surveys, so results of an extra survey can be shared in a report. Previously only timeline phases were listed.
- The survey-question widget in the report builder can now point at an extra survey, and the widget toolbox recognises projects whose only survey is an extra survey.
