### PR TITLE
[TAN-8437] Seed the me query on sign-in so post-sign-in actions are n…

### DIFF
--- a/front/app/api/authentication/sign_in_out/signIn.ts
+++ b/front/app/api/authentication/sign_in_out/signIn.ts
@@ -1,6 +1,9 @@
+import meKeys from 'api/me/keys';
+
 import { API_PATH } from 'containers/App/constants';
 
 import { getJwt, setJwt } from 'utils/auth/jwt';
+import { queryClient } from 'utils/cl-react-query/queryClient';
 import { invalidateQueryCache } from 'utils/cl-react-query/resetQueryCache';
 import { clearClaimToken } from 'utils/claimToken';
 
@@ -21,6 +24,16 @@ export default async function signIn(parameters: Parameters) {
     await getAndSetToken(parameters);
 
     const authUser = await getAuthUserAsync();
+
+    // Post-sign-in success actions (SuccessActions) wait on authUserStream —
+    // a BehaviorSubject fed by the me query — and treat a null value as
+    // "signed out", discarding the action rather than retrying. Leaving the me
+    // query to be refreshed by the invalidation below is asynchronous, so the
+    // stream could still be replaying the logged-out null when an action ran,
+    // silently dropping it (e.g. the redirect to the idea form after signing in
+    // from the "Add an idea" button). Seed the query with the user we just
+    // fetched so the stream reflects the signed-in user before any action runs.
+    queryClient.setQueryData(meKeys.all(), authUser);
 
     invalidateQueryCache();
 

--- a/front/app/containers/Authentication/SuccessActions/index.tsx
+++ b/front/app/containers/Authentication/SuccessActions/index.tsx
@@ -15,19 +15,28 @@ export const triggerSuccessAction = (successAction: SuccessAction) => {
   successAction$.next(successAction);
 };
 
+/** How long to wait for the auth user before giving up on a queued action. */
+const AUTH_USER_TIMEOUT = 10000;
+
 const getAuthUser = () => {
   let streamSubscription;
 
   const promise = new Promise<IUserData>((resolve, reject) => {
-    streamSubscription = authUserStream.subscribe((response) => {
-      if (response === undefined) return;
-      // TODO: Fix this the next time the file is edited.
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-      if (response === null) {
-        reject();
-        return;
-      }
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for the authenticated user'));
+    }, AUTH_USER_TIMEOUT);
 
+    streamSubscription = authUserStream.subscribe((response) => {
+      // Both undefined (not loaded yet) and null (the me query still reporting
+      // signed out) mean "not ready yet" here, not "signed out for good". The
+      // caller consumes the queued action before awaiting this promise, so
+      // rejecting discards that action permanently rather than deferring it —
+      // which silently dropped post-sign-in redirects whenever the stream had
+      // not caught up with the sign-in yet. Wait for a real user instead; the
+      // timeout stops a genuinely signed-out state from hanging forever.
+      if (!response) return;
+
+      clearTimeout(timeout);
       resolve(response.data);
     });
   });


### PR DESCRIPTION
…ot dropped

Post-sign-in success actions are dispatched through SuccessActions, which waits on authUserStream (a BehaviorSubject fed by the me query) before it runs them. It treats a null value as "signed out" and gives up, and it consumes the queued action before that check, so a lost race discards the action permanently rather than deferring it.

signIn fetched the authenticated user but never wrote it to the query cache, leaving the me query to be refreshed by the invalidation that follows. That refresh is asynchronous, so the stream could still be replaying the logged-out null when an action ran. The redirect to the idea form after signing in from the "Add an idea" button was then dropped silently: the modal closed, the user was signed in, and nothing happened.

Seed the me query with the user just fetched so the stream reflects the signed-in user before any success action runs. This also removes a redundant refetch of a user the app had already loaded.


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
