### PR TITLE
Flaky E2E Fix: extra_surveys_widget.cy.ts — retry the widget-selection click

### DIFF
--- a/front/cypress/e2e/extra_surveys/extra_surveys_widget.cy.ts
+++ b/front/cypress/e2e/extra_surveys/extra_surveys_widget.cy.ts
@@ -100,8 +100,26 @@ describe('Extra surveys widget in the project page builder', () => {
     );
     cy.visit(`/admin/project-page-builder/projects/${projectId}`);
 
-    // Select the widget by clicking its rendered button
-    cy.get('.e2e-extra-survey-button').first().click({ force: true });
+    // Select the widget by clicking its rendered button. The builder
+    // attaches selection handlers through refs and re-attaches them on
+    // re-renders, with no DOM signal for when a click will register — a
+    // single early click can be silently lost (verified via DOM probe:
+    // nothing gets selected and the settings panel never opens). Click,
+    // check the panel opened, and retry a bounded number of times.
+    const selectWidget = (attemptsLeft: number) => {
+      cy.get('.e2e-extra-survey-button').first().click({ force: true });
+      cy.get('body').then(($body) => {
+        if ($body.find('#extra-surveys-format-button').length === 0) {
+          expect(
+            attemptsLeft,
+            'widget selection attempts before settings panel opened'
+          ).to.be.greaterThan(0);
+          cy.wait(500);
+          selectWidget(attemptsLeft - 1);
+        }
+      });
+    };
+    selectWidget(10);
 
     cy.get('#extra-surveys-format-button').click({ force: true });
     cy.get('#e2e-extra-surveys-button-text').type(customButtonText, {


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `extra_surveys/extra_surveys_widget.cy.ts`):** the plain-button-format test selects the widget with a single forced click on its rendered button, then expects the settings panel. The page builder attaches its selection handlers through refs and re-attaches them on every canvas re-render, with no DOM signal for when a click will register — a click landing in an attachment gap is silently lost. A DOM probe run confirmed the mechanism: after the click, nothing is selected and the settings panel (checked via its unconditional controls) never renders. The race is latent since the spec was written (Jul 29); something in the Aug 10 merge window shifted the builder page's render timing enough to expose it — failing the Aug 11 nightly and 2 of 3 nodes in a master repro run. Notably NOT a product regression: the suspect PRs' changes to this widget's logic are provably behavior-preserving.

**Why this fixes rather than suppresses:** the selection click is now click-verify-retry — click, check whether the settings panel opened, retry (bounded at 10 × 500ms) if it didn't, and fail with an explicit message if it never opens. All subsequent assertions are unchanged; a genuinely broken settings panel still fails the test.

**Stability evidence:** [pipeline 346913](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346913) — 3 nodes, 9/9 tests green across the spec (same-day unfixed baseline: 2 of 3 nodes red on master).

# Changelog

## Technical

- Fixed the flaky extra-surveys widget E2E test (lost selection click in the page builder).