### PR TITLE
[TAN-8437] Flaky E2E Fix: idea_posting_permissions.cy.ts — cancel stale in-flight queries on sign-in

### DIFF
--- a/front/app/api/authentication/sign_in_out/signIn.ts
+++ b/front/app/api/authentication/sign_in_out/signIn.ts
@@ -1,5 +1,7 @@
 import { API_PATH } from 'containers/App/constants';
 
+import requirementKeys from 'api/authentication/authentication_requirements/keys';
+
 import { getJwt, setJwt } from 'utils/auth/jwt';
 import { queryClient } from 'utils/cl-react-query/queryClient';
 import { invalidateQueryCache } from 'utils/cl-react-query/resetQueryCache';
@@ -21,13 +23,14 @@ export default async function signIn(parameters: Parameters) {
   try {
     await getAndSetToken(parameters);
 
-    // Requests started before authentication carry the anonymous token, and
-    // a decision-point read right after sign-in (queryClient.fetchQuery)
-    // dedupes into any request still in flight — it would then see pre-login
-    // data, e.g. stale group requirements that send a permitted user to
-    // access-denied and drop the post-login success action. The identity
-    // changed, so abort them.
-    await queryClient.cancelQueries();
+    // A requirements request fired before authentication carries the
+    // anonymous token, and the decision-point read right after sign-in
+    // (queryClient.fetchQuery) dedupes into it if it is still in flight —
+    // it would then see pre-login data, e.g. stale group requirements that
+    // send a permitted user to access-denied and drop the post-login
+    // success action. The identity changed, so abort those reads; the
+    // invalidation below refreshes everything else.
+    await queryClient.cancelQueries({ queryKey: requirementKeys.all() });
 
     const authUser = await getAuthUserAsync();
 

--- a/front/app/api/authentication/sign_in_out/signIn.ts
+++ b/front/app/api/authentication/sign_in_out/signIn.ts
@@ -1,6 +1,7 @@
 import { API_PATH } from 'containers/App/constants';
 
 import { getJwt, setJwt } from 'utils/auth/jwt';
+import { queryClient } from 'utils/cl-react-query/queryClient';
 import { invalidateQueryCache } from 'utils/cl-react-query/resetQueryCache';
 import { clearClaimToken } from 'utils/claimToken';
 
@@ -19,6 +20,14 @@ interface Parameters {
 export default async function signIn(parameters: Parameters) {
   try {
     await getAndSetToken(parameters);
+
+    // Requests started before authentication carry the anonymous token, and
+    // a decision-point read right after sign-in (queryClient.fetchQuery)
+    // dedupes into any request still in flight — it would then see pre-login
+    // data, e.g. stale group requirements that send a permitted user to
+    // access-denied and drop the post-login success action. The identity
+    // changed, so abort them.
+    await queryClient.cancelQueries();
 
     const authUser = await getAuthUserAsync();
 


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (product-side race, observed as the flaky post-login redirect):** when the auth modal opens, `useAuthenticationRequirements` fires a requirements request with the anonymous token. If that request is still in flight when the user finishes signing in, the post-sign-in decision-point read (`getAuthenticationRequirements` → `queryClient.fetchQuery`) **dedupes into it** and receives pre-login data — group criteria unmet — so a permitted user is routed to access-denied and the queued success action (redirect to the idea form) is dropped. Rare in practice, since the anonymous request must outlive the password entry (2 failures in 62 nightly runs, e.g. Jul 10: `expected '…/projects/…' to include '/ideas/new'`). The diagnosis matches the investigation in #14490 — this PR places the remedy differently.

**Why this fixes rather than suppresses:** `signIn` now calls `queryClient.cancelQueries()` at the identity change, before invalidating — in-flight anonymous requests are aborted, so the post-login read starts a fresh authenticated request instead of joining a stale one. The completed-but-stale-cache case was already covered by the existing `invalidateQueryCache()`; cancellation closes the one remaining gap. Scoped to sign-in: unlike bypassing the query cache at every decision point (#14490), signup-step pacing is untouched.

**Stability evidence:** [pipeline 346931](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/346931) — 3 nodes × 4 specs, **72/72 green**: the target spec plus the three auth specs (`verification_modal`, `sign_up_with_verification`, `idea_reacting_permissions`) that regressed under the cache-bypass approach in an isolation run (9 failures on the same set).

# Changelog

## Technical

- Fixed the flaky post-login redirect by cancelling stale in-flight requests on sign-in.