### PR TITLE
Skip flaky post-login redirect e2e test pending the auth race fix

### DIFF
--- a/front/cypress/e2e/ideation_permissions/idea_posting_permissions.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/idea_posting_permissions.cy.ts
@@ -139,7 +139,7 @@ describe('idea posting restricted to a group', () => {
     cy.url().should('not.include', `/ideas/new`);
   });
 
-  // Skipped (TAN-8437): this test intermittently catches a real product race
+  // Skipped: this test intermittently catches a real product race
   // in the authentication flow, not a test problem. When the auth modal
   // opens, useAuthenticationRequirements fires a requirements request with
   // the ANONYMOUS token. If that request is still in flight when the user

--- a/front/cypress/e2e/ideation_permissions/idea_posting_permissions.cy.ts
+++ b/front/cypress/e2e/ideation_permissions/idea_posting_permissions.cy.ts
@@ -139,7 +139,23 @@ describe('idea posting restricted to a group', () => {
     cy.url().should('not.include', `/ideas/new`);
   });
 
-  it('redirects users after authentication to form page if they are permitted', () => {
+  // Skipped (TAN-8437): this test intermittently catches a real product race
+  // in the authentication flow, not a test problem. When the auth modal
+  // opens, useAuthenticationRequirements fires a requirements request with
+  // the ANONYMOUS token. If that request is still in flight when the user
+  // completes sign-in, the post-sign-in decision-point read
+  // (getAuthenticationRequirements -> queryClient.fetchQuery) dedupes into
+  // it — react-query joins an in-flight fetch before consulting staleness,
+  // and the invalidateQueryCache() in signIn() marks caches stale but does
+  // not abort in-flight requests. The step machine then evaluates PRE-LOGIN
+  // requirements: checkMissingData / group criteria misroute the permitted
+  // user (access-denied or an onboarding step) and the queued success action
+  // — the redirect to the idea form — is silently dropped. Fails ~1 in 30
+  // runs under CI contention; real users on slow connections can hit the
+  // same window. Re-enable once the product race is fixed (e.g. keying the
+  // decision-point requirements read by the current identity, or aborting
+  // in-flight anonymous requests at every identity change).
+  it.skip('redirects users after authentication to form page if they are permitted', () => {
     cy.visit(`projects/${projectSlug}`);
     cy.dataCy('e2e-ideation-start-idea-button').should('be.visible').click();
     logIn(cy, permittedUserEmail, permittedUserPassword);


### PR DESCRIPTION
The test correctly detects a product race (stale anonymous requirements consulted after sign-in dropping the post-login redirect) but fails ~1 in 30 contended runs, burning unrelated CI runs.

Skipped with the mechanism documented in place for the auth fix to re-enable.

**CC @luucvanderzee is this something you could potentially look into? It looks like this "flaky" test was catching a real intermittent issue, but the necessary fix itself is one I am less confident implementing given it deals with authentication. I think you may be the best person to take a look here? :pray:**

I'm going to merge this PR to skip the test for now though to unblock e2e tests.