### PR TITLE
[TAN-8452] Use placeholders in custom AI analysis prompts

### DIFF
--- a/back/config/schemas/settings.schema.json.erb
+++ b/back/config/schemas/settings.schema.json.erb
@@ -1401,7 +1401,7 @@
           "enabled": { "type": "boolean", "default": false },
           "prompt_template": {
             "title": "Custom AI analysis prompt",
-            "description": "Optional custom prompt template (ERB format) to override the default Q&A prompt. Available variables: project_title, question, inputs_text, language, include_comments.",
+            "description": "Optional custom prompt template to override the default Q&A prompt. Insert a value by writing its name between %{ and }, e.g. %{project_title}. Available placeholders: %{project_title}, %{question}, %{inputs_text}, %{language}, %{comments_instruction}. No other syntax is supported: anything else is sent to the model as-is.",
             "type": "string"
           }
         }

--- a/back/engines/commercial/analysis/app/lib/analysis/LLM/placeholder_prompt.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/LLM/placeholder_prompt.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Analysis
+  module LLM
+    # Renders a prompt template that comes from tenant settings, i.e. content we
+    # do not control. Only `%{placeholder}` substitution is supported: the
+    # template is never evaluated, so it cannot run code, read the environment or
+    # reach the database.
+    #
+    # Templates that live in config/prompts go through LLM::Prompt instead: those
+    # are part of the codebase and may use the full ERB syntax.
+    class PlaceholderPrompt
+      PLACEHOLDER_PATTERN = /%\{(\w+)\}/
+
+      # @param template [String] e.g. "Project: %{project_title}"
+      # @param values [Hash<Symbol, Object>] the values allowed to be substituted.
+      #   Placeholders that are not among them are left untouched, so a typo in a
+      #   tenant's template degrades the prompt instead of breaking the analysis.
+      # @return [String]
+      def render(template, **values)
+        allowed = values.transform_keys(&:to_s)
+
+        # The block form of gsub inserts the return value literally: neither
+        # backslash sequences (\1, \\) nor placeholders contained in a value are
+        # interpreted, so a value can never inject a placeholder of its own.
+        template.gsub(PLACEHOLDER_PATTERN) do
+          key = Regexp.last_match(1)
+          allowed.key?(key) ? allowed[key].to_s : Regexp.last_match(0)
+        end
+      end
+    end
+  end
+end

--- a/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
+++ b/back/engines/commercial/analysis/app/lib/analysis/q_and_a_method/one_pass_llm.rb
@@ -9,6 +9,12 @@ module Analysis
     # The number of tokens we reserve for the LLM response containing the answer
     TOKENS_FOR_RESPONSE = 600
 
+    # Substituted for %{comments_instruction} in a tenant's custom prompt
+    # template. A custom template cannot branch on include_comments itself, so we
+    # hand it the sentence the default template would have added.
+    COMMENTS_INSTRUCTION = 'Some responses might contain comments from other users, separated by +++. ' \
+                           'You can include the information taken from the comments in your response.'
+
     def generate_plan
       plan = nil
       include_comments = true
@@ -97,7 +103,11 @@ module Analysis
       }
 
       if custom_template
-        ERB.new(custom_template).result_with_hash(params)
+        LLM::PlaceholderPrompt.new.render(
+          custom_template,
+          **params.except(:include_comments),
+          comments_instruction: include_comments ? COMMENTS_INSTRUCTION : ''
+        )
       else
         filename = file_ai_analysis_enabled? ? 'q_and_a.v2' : 'q_and_a'
         LLM::Prompt.new.fetch(filename, **params)

--- a/back/engines/commercial/analysis/spec/lib/llm/placeholder_prompt_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/llm/placeholder_prompt_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Analysis::LLM::PlaceholderPrompt do
+  let(:service) { described_class.new }
+
+  describe 'render' do
+    it 'substitutes the placeholders it is given' do
+      expect(service.render('Project %{project_title}: %{question}', project_title: 'Bike lanes', question: 'Why?'))
+        .to eq 'Project Bike lanes: Why?'
+    end
+
+    it 'substitutes every occurrence of a placeholder' do
+      expect(service.render('%{a} then %{a}', a: 'x')).to eq 'x then x'
+    end
+
+    it 'leaves unknown placeholders untouched' do
+      expect(service.render('%{project_title} %{typo}', project_title: 'Bike lanes'))
+        .to eq 'Bike lanes %{typo}'
+    end
+
+    it 'leaves stray percent signs untouched' do
+      expect(service.render('50% of respondents %{q}', q: 'agree')).to eq '50% of respondents agree'
+    end
+
+    it 'does not evaluate ERB tags' do
+      expect(service.render("<%= raise 'boom' %> <% $stdout.puts 1 %>")).to eq "<%= raise 'boom' %> <% $stdout.puts 1 %>"
+    end
+
+    it 'does not evaluate placeholders coming from a substituted value' do
+      expect(service.render('%{inputs_text}', inputs_text: '%{secret}', secret: 'leaked')).to eq '%{secret}'
+    end
+
+    it 'does not interpret backslash sequences in a substituted value' do
+      expect(service.render('%{inputs_text}', inputs_text: '\0 \1 \\')).to eq '\0 \1 \\'
+    end
+
+    it 'renders a nil value as an empty string' do
+      expect(service.render('in %{language}.', language: nil)).to eq 'in .'
+    end
+  end
+end

--- a/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
+++ b/back/engines/commercial/analysis/spec/lib/q_and_a_method_spec.rb
@@ -60,6 +60,43 @@ RSpec.describe Analysis::QAndAMethod do
       })
     end
 
+    describe 'with a custom prompt template' do
+      def prompt_for(template)
+        inputs # the prompt is built before chat_async is called, so the inputs must exist by then
+        SettingsService.new.activate_feature!('data_repository_ai_analysis', settings: { 'prompt_template' => template })
+
+        prompt = nil
+        mock_llm = instance_double(Analysis::LLM::GPT54).tap do |llm|
+          expect(llm).to receive(:chat_async) { |messages| prompt = messages.first.inputs.sole }
+        end
+
+        plan = Analysis::QAndAMethod::OnePassLLM.new(question).generate_plan
+        plan.llm = mock_llm
+        plan.q_and_a_method_class.new(question).execute(plan)
+
+        prompt
+      end
+
+      it 'substitutes the placeholders' do
+        prompt = prompt_for('Project %{project_title}. Answer %{question} in %{language}. %{inputs_text}')
+
+        expect(prompt).to include("Project #{analysis.project.title_multiloc.values.first}.")
+        expect(prompt).to include('Answer What is the most popular theme? in English.')
+        expect(prompt).to include(inputs[2].id)
+      end
+
+      it 'substitutes the comments instruction when comments are included' do
+        expect(prompt_for('%{comments_instruction}'))
+          .to include(Analysis::QAndAMethod::OnePassLLM::COMMENTS_INSTRUCTION)
+      end
+
+      it 'does not evaluate a template that contains code' do
+        prompt = prompt_for("<%= AppConfiguration.instance.host %> <% raise 'boom' %>")
+
+        expect(prompt).to eq "<%= AppConfiguration.instance.host %> <% raise 'boom' %>"
+      end
+    end
+
     it 'includes the comments in the prompt' do
       create(:comment, idea: inputs[1], body_multiloc: { en: 'I want to comment on that' })
 


### PR DESCRIPTION
This PR has been made with Claude code.

# Changelog

## Changed
- The "Custom AI analysis prompt" setting (AdminHQ → Data repository: AI analysis) now uses simple placeholders instead of ERB. Write a value's name between %{ and }, for example %{project_title}; anything else in the template is sent to the model as-is. Available placeholders: %{project_title}, %{question}, %{inputs_text}, %{language}, %{comments_instruction}. No platform currently has a custom prompt configured (checked in prod rails console, request performed in the notion ticket), so no existing setup is affected.

## Technical
- Q&A prompt templates coming from tenant settings are no longer evaluated as ERB. They are rendered by the new `Analysis::LLM::PlaceholderPrompt`, which only substitutes `%{placeholder}` values and never evaluates the template.
- `include_comments` is replaced by `%{comments_instruction}`, which expands to the comments guidance sentence or an empty string, since a placeholder template cannot branch on a boolean.
- `Analysis::LLM::Prompt` keeps using ERB for the templates in `config/prompts`: those are part of the codebase and are never handed tenant-supplied content.
- Adds specs for `PlaceholderPrompt` and for the custom-template branch of `QAndAMethod::OnePassLLM`, which had no coverage.