### PR TITLE
Skip flaky verification-modal redirect e2e test pending the auth race fix

### DIFF
--- a/front/cypress/e2e/auth/verification_modal.cy.ts
+++ b/front/cypress/e2e/auth/verification_modal.cy.ts
@@ -51,7 +51,15 @@ describe('Verification modal', () => {
       });
     });
 
-    it('lets you participate if you meet group conditions', () => {
+    // Skipped: intermittently hits the same post-authentication redirect race
+    // documented in ideation_permissions/idea_posting_permissions.cy.ts. After
+    // completing sign-up + verification in the modal, the queued success
+    // action — the redirect to the idea form — is silently dropped and the
+    // user stays on the project page, so the pathname assertion below fails.
+    // This is not a test problem: the race is real and can hit users on slow
+    // connections. Re-enable together with that test once the auth race is
+    // fixed.
+    it.skip('lets you participate if you meet group conditions', () => {
       cy.clearCookies();
       cy.visit('/projects/verified-charlie-poeple-project');
       cy.acceptCookies();


### PR DESCRIPTION
Skips `Verification modal > Participation with group conditions > lets you participate if you meet group conditions` in `front/cypress/e2e/auth/verification_modal.cy.ts`.

This test intermittently fails on the final assertion — after completing sign-up + verification in the modal, the expected redirect to `/ideas/new` is dropped and the user stays on the project page (seen again in the latest manually-triggered e2e run, pipeline 347023). It's the same post-authentication redirect race as the test skipped in #14531; both should be re-enabled together once the auth race is fixed.

Only this single test is skipped; the sibling "does not let you participate" test still runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


CC @luucvanderzee same issue as the other PR I tagged you in. Once that is fixed I think we can re-enable this one too :)