### PR TITLE
Flaky E2E Fix: survey_results_and_data_management.cy.ts — targeted mouse drag for adding survey fields

### DIFF
--- a/front/cypress/e2e/survey_builder/survey_results_and_data_management.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_results_and_data_management.cy.ts
@@ -8,6 +8,22 @@ const waitForCustomFormFields = () => {
   cy.wait(1000);
 };
 
+// Add a toolbox item to the survey's default page with a real mouse drag.
+// The keyboard-based addItemToFormBuilder derives its arrow-key step count
+// from DOM sibling indexes, which intermittently computes zero steps and
+// lifts + drops the item in place — nothing gets added and the field
+// settings panel never opens. Dragging to the page's explicit drop zone
+// removes that failure mode. A fresh native survey's default page always
+// has the key `page1`, which gives the drop zone its stable selector.
+const addSurveyField = (toolboxSelector: string) => {
+  cy.dragToolboxItemTo(toolboxSelector, '[data-cy="e2e-page-drop-page1"]');
+
+  // The newly added field's settings panel opens with an empty title.
+  // Asserting emptiness both proves the drop registered and guards against
+  // typing into the panel of a previously added field.
+  cy.get('#e2e-title-multiloc').should('be.visible').should('have.value', '');
+};
+
 describe('Survey Builder - Results and Data Management', () => {
   const phaseTitle = randomString();
   let questionTitle = randomString();
@@ -45,7 +61,7 @@ describe('Survey Builder - Results and Data Management', () => {
     waitForCustomFormFields();
 
     // Multiple choice choose one
-    cy.addItemToFormBuilder('#toolbox_select');
+    addSurveyField('#toolbox_select');
     cy.get('#e2e-title-multiloc').type(multipleChoiceChooseOneTitle, {
       force: true,
     });
@@ -54,7 +70,7 @@ describe('Survey Builder - Results and Data Management', () => {
     cy.get('#e2e-option-input-1').type(chooseOneOption2, { force: true });
 
     // Multiple choice choose multiple
-    cy.addItemToFormBuilder('#toolbox_select');
+    addSurveyField('#toolbox_select');
     cy.get('#e2e-title-multiloc').type(multipleChoiceChooseManyTitle, {
       force: true,
     });
@@ -63,7 +79,7 @@ describe('Survey Builder - Results and Data Management', () => {
     cy.get('#e2e-option-input-1').type(chooseManyOption2, { force: true });
 
     // Linear scale
-    cy.addItemToFormBuilder('#toolbox_linear_scale');
+    addSurveyField('#toolbox_linear_scale');
     cy.get('#e2e-title-multiloc').type(linearScaleTitle, { force: true });
 
     // Save the survey
@@ -131,7 +147,7 @@ describe('Survey Builder - Results and Data Management', () => {
 
     cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
-    cy.addItemToFormBuilder('#toolbox_number');
+    addSurveyField('#toolbox_number');
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });
 
     // Save the survey
@@ -174,7 +190,7 @@ describe('Survey Builder - Results and Data Management', () => {
   it('allows export of survey results', () => {
     cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
-    cy.addItemToFormBuilder('#toolbox_multiline_text');
+    addSurveyField('#toolbox_multiline_text');
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });
 
     // Save the survey
@@ -225,7 +241,7 @@ describe('Survey Builder - Results and Data Management', () => {
   it('allows export of survey responses through the PII review modal', () => {
     cy.visit(`admin/projects/${projectId}/phases/${phaseId}/survey-form/edit`);
     waitForCustomFormFields();
-    cy.addItemToFormBuilder('#toolbox_multiline_text');
+    addSurveyField('#toolbox_multiline_text');
     cy.get('#e2e-title-multiloc').type(questionTitle, { force: true });
 
     // Save the survey


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `survey_builder/survey_results_and_data_management.cy.ts`):** every test in this spec adds survey fields with the keyboard-based `addItemToFormBuilder` command, which simulates @hello-pangea/dnd's keyboard drag (space to lift, N arrow presses, space to drop) and derives N from jQuery `.index()` deltas — DOM sibling positions with no relationship to the drag distance. Under CI those indexes intermittently compute N = 0, so the command lifts and drops the toolbox item in place: no field is added, the field settings panel never opens, and the test times out on `#e2e-title-multiloc`. CI screenshots from the latest manual e2e run ([pipeline 347023](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347023)) show exactly this — lift + drop with no arrow keypresses, canvas unchanged — across three different tests in the spec: two recovered on Cypress retry, while "allows export of survey responses through the PII review modal" failed all 3 attempts and sank the run.

**Why this fixes rather than suppresses:** field adds now use the mouse-based `dragToolboxItemTo` aimed at the default page's explicit drop zone (`[data-cy="e2e-page-drop-page1"]` — a fresh native survey's first page always has the key `page1`), so there is no index arithmetic to silently no-op. After each drop, the new `addSurveyField` helper asserts the settings panel is visible **with an empty title**, which both proves the drop registered and prevents typing into a previously added field's still-open panel. No waits were added and all subsequent assertions are unchanged; a drop that genuinely fails still fails the test, now at the right step with a clear message. The same mouse-drag approach is already used by `community_monitor_survey.cy.ts`, which ran clean in the same pipeline where this spec failed.

**Stability evidence:** [pipeline 347050](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347050) — 3 nodes each running the full spec independently, all green (baseline: 1 of 3 nodes red on this spec in pipeline 347023).

# Changelog

## Technical

- Fixed the flaky survey results & data management E2E spec (keyboard drag-and-drop silently failing to add survey fields).