### PR TITLE
Flaky E2E Fix: project_page_voting_budgeting.cy.ts — retryable query chains + deterministic basket waits

### DIFF
--- a/front/cypress/e2e/project_page_voting_budgeting.cy.ts
+++ b/front/cypress/e2e/project_page_voting_budgeting.cy.ts
@@ -120,10 +120,11 @@ describe('Budgeting project', () => {
 
   it('can submit the budget', () => {
     cy.dockProjectCtaBar();
+    cy.intercept('PATCH', '**/baskets/*').as('submitBasket');
     cy.get('#e2e-voting-submit-button')
       .should('be.visible')
       .click({ force: true });
-    cy.wait(1000);
+    cy.wait('@submitBasket');
 
     cy.contains('Budget submitted');
     cy.scrollTo('bottom');
@@ -136,28 +137,28 @@ describe('Budgeting project', () => {
 
   it('can modify the budget and remove an option', () => {
     cy.dockProjectCtaBar();
+
+    cy.intercept('PATCH', '**/baskets/*').as('unsubmitBasket');
+    // Keep the assertions and the click in one query chain: late-loading
+    // content (map config, randomly sorted idea cards) re-renders the page
+    // and can detach the button — a chained query re-runs from the start,
+    // while a fresh cy.get after a blind wait finds nothing and fails.
     cy.get('#e2e-modify-votes')
       .should('be.visible')
-      .should('contain', 'Modify your submission');
-
-    cy.wait(2000);
-
-    cy.get('#e2e-modify-votes').click();
+      .should('contain', 'Modify your submission')
+      .click();
+    cy.wait('@unsubmitBasket');
 
     cy.get('#e2e-ideas-container')
       .find('.e2e-assign-budget-button')
       .should('have.class', 'in-basket');
 
-    cy.wait(2000);
-
-    cy.get('#e2e-ideas-container');
-
-    cy.wait(1000);
-
+    cy.intercept('PUT', '**/baskets/ideas/**').as('removeVote');
     cy.get('#e2e-ideas-container')
       .find('.e2e-assign-budget-button')
       .click()
       .should('have.class', 'not-in-basket');
+    cy.wait('@removeVote');
 
     cy.get('#e2e-voting-submit-button')
       .should('be.visible')


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `project_page_voting_budgeting.cy.ts`):** nightly failure screenshots show `#e2e-voting-submit-button` found and visible, then **gone from the DOM** during a blind `cy.wait` — late-loading project-page content (the map-config fetch, the randomly sorted idea cards) re-renders the page, the CTA bar undocks, and the button unmounts, so the follow-up fresh `cy.get` reports "never found". PR #14483 (merged Aug 10) correctly fixed this in the "can submit the budget" test by chaining the visibility assertion and the click. But the "can modify the budget and remove an option" test kept the identical visible-assert → `cy.wait(2000)` → fresh-`cy.get().click()` defect. All four of its recorded nightly failures (Aug 4 ×2, Aug 6, Aug 10 — all pre-#14483) were cascades: `#e2e-modify-votes` only renders once a basket is submitted, and the submit test's failure left the basket unsubmitted. With the cascade now fixed, the modify test's own copy of the race is the remaining way for this spec to flap.

**Why this fixes rather than suppresses:** the modify test's assertions and click are now one retryable query chain — when a re-render detaches the element mid-flight, Cypress re-runs the chain from the start instead of failing a stale fresh get. The remaining blind waits in both tests are replaced with deterministic waits on the real network transitions they were papering over: the basket submit/unsubmit `PATCH /baskets/:id` and the vote-removal `PUT /baskets/ideas/:id`. No assertions were removed or loosened, and no fixed-length waits were added.

**Prior attempt:** builds on #14483, which fixed the same mechanism in the submit test; this completes the job for the spec.

**Stability evidence:** two single-spec pipelines, 3 independent nodes each — 6/6 repetitions green: [pipeline 347064](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347064), [pipeline 347065](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347065).

# Changelog

## Technical

- Fixed the flaky budgeting project E2E spec (element detachment during page re-renders, blind waits replaced with request waits).