### PR TITLE
Flaky E2E Fix: survey_results_and_data_management.cy.ts — retry swallowed toolbox drags

### DIFF
--- a/front/cypress/e2e/survey_builder/survey_results_and_data_management.cy.ts
+++ b/front/cypress/e2e/survey_builder/survey_results_and_data_management.cy.ts
@@ -15,8 +15,37 @@ const waitForCustomFormFields = () => {
 // settings panel never opens. Dragging to the page's explicit drop zone
 // removes that failure mode. A fresh native survey's default page always
 // has the key `page1`, which gives the drop zone its stable selector.
+//
+// The drag itself can still be silently swallowed: a late custom_fields
+// refetch re-renders the droppable mid-drag and @hello-pangea/dnd abandons
+// the drop (full-suite failure screenshots show the complete mouse sequence
+// dispatched with the canvas unchanged). That refetch is one-shot per page
+// load, so a re-drag after the canvas settles lands on a stable DOM. The
+// retry is bounded so a genuinely broken form builder still fails loudly.
 const addSurveyField = (toolboxSelector: string) => {
-  cy.dragToolboxItemTo(toolboxSelector, '[data-cy="e2e-page-drop-page1"]');
+  cy.dataCy('e2e-field-row')
+    .its('length')
+    .then((initialCount) => {
+      const attemptDrag = (attemptsLeft: number) => {
+        cy.dragToolboxItemTo(
+          toolboxSelector,
+          '[data-cy="e2e-page-drop-page1"]'
+        );
+        // Give a slow-but-successful drop time to render its field row —
+        // re-dragging after a drop that did register would add a duplicate.
+        cy.wait(500);
+        cy.dataCy('e2e-field-row').then(($rows) => {
+          if ($rows.length === initialCount) {
+            expect(
+              attemptsLeft,
+              'drag attempts before a new field row appeared'
+            ).to.be.greaterThan(0);
+            attemptDrag(attemptsLeft - 1);
+          }
+        });
+      };
+      attemptDrag(4);
+    });
 
   // The newly added field's settings panel opens with an empty title.
   // Asserting emptiness both proves the drop registered and guards against


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `survey_builder/survey_results_and_data_management.cy.ts`):** the mouse-drag field add from #14536 removed the keyboard helper's deterministic no-op, but a second failure mode survived it: a late `custom_fields` refetch re-renders the droppable mid-drag, and @hello-pangea/dnd abandons the in-flight drop. Failure screenshots from the full-suite master run ([pipeline 347069](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347069)) show the complete mouse sequence dispatched with the canvas unchanged. The window only opens when the refetch response straggles — which is why isolated single-spec pipelines (fresh idle backend) never caught it and the contended full suite did.

**Why this fixes rather than suppresses:** the refetch that cancels the drag is one-shot per page load, so a re-drag after the canvas settles lands on a stable DOM. `addSurveyField` now records the field-row count, drags, verifies the count grew, and re-drags a bounded number of times (5 attempts, 500ms settle — the settle also prevents re-dragging after a slow-but-successful drop, which would add a duplicate). The hard settings-panel assertion (visible + empty title) is unchanged, so a genuinely broken form builder still fails loudly, now with an explicit "drag attempts before a new field row appeared" message. Mirrors the bounded click-verify-retry precedent from #14526.

**Prior attempt:** #14536 (merged today) — fixed the primary mechanism; this closes the residual one it documented.

**Stability evidence:** [pipeline 347078](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347078) — single-spec, 6 independent nodes, 6/6 green; [pipeline 347079](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347079) — full suite on this branch, this spec green on all nodes (the workflow's only failure was the unrelated `profile_page.cy.ts` axe-violation flake, which predates this change and is tracked separately).

# Changelog

## Technical

- Hardened the survey results E2E spec against drags cancelled by mid-drag re-renders (bounded drag-verify-retry).