### PR TITLE
Flaky E2E Fix: project_page_voting_budgeting.cy.ts — gate vote-button clicks on enabled state

### DIFF
--- a/front/cypress/e2e/project_page_voting_budgeting.cy.ts
+++ b/front/cypress/e2e/project_page_voting_budgeting.cy.ts
@@ -102,9 +102,13 @@ describe('Budgeting project', () => {
 
     cy.intercept('PUT', '**/baskets/ideas/**').as('voteForIdea');
 
+    // The vote buttons can carry the `disabled` class while the voting
+    // context initializes — a click during that window is a silent no-op,
+    // so gate on the enabled state before clicking.
     cy.get('#e2e-ideas-container')
       .find('.e2e-assign-budget-button')
       .should('have.class', 'not-in-basket')
+      .should('not.have.class', 'disabled')
       .click()
       .should('have.class', 'in-basket');
 
@@ -149,13 +153,15 @@ describe('Budgeting project', () => {
       .click();
     cy.wait('@unsubmitBasket');
 
-    cy.get('#e2e-ideas-container')
-      .find('.e2e-assign-budget-button')
-      .should('have.class', 'in-basket');
-
+    // After the unsubmit lands, the vote buttons keep the `disabled` class
+    // until the basket refetches complete; `in-basket` alone is true during
+    // that window and a click on the still-disabled button is a silent
+    // no-op. Gate on the enabled state before clicking.
     cy.intercept('PUT', '**/baskets/ideas/**').as('removeVote');
     cy.get('#e2e-ideas-container')
       .find('.e2e-assign-budget-button')
+      .should('have.class', 'in-basket')
+      .should('not.have.class', 'disabled')
       .click()
       .should('have.class', 'not-in-basket');
     cy.wait('@removeVote');


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

**Root cause (in `project_page_voting_budgeting.cy.ts`):** the full-suite master run ([pipeline 347090](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347090)) recorded "`#e2e-modify-votes` never found" — but that error is retry-state masking, not the real failure. Attempt 1's screenshot shows what actually happened: after the modify click unsubmitted the basket (a one-way transition), the test clicked the vote button to remove the idea **while the button still carried the `disabled` class** — the passing `in-basket` assertion printed the element as `.in-basket.disabled`, and no `baskets/ideas` PUT ever fired, because clicking a disabled button is a silent no-op. The buttons stay disabled until the post-unsubmit basket refetches complete; `in-basket` alone is true during that window. The blind `cy.wait(2000)`s removed in #14537 had been accidentally bridging it. Cypress then retried the test against a now-unsubmitted basket where the modify button legitimately doesn't exist — producing the misleading recorded error. The allocate test's burned retries in the same run fit the same gate at page load (buttons transiently disabled while the voting context initializes).

**Why this fixes rather than suppresses:** both vote-button clicks now assert `.should('not.have.class', 'disabled')` before clicking — precise assertion-based waiting on the app's own enabling condition, retried by Cypress until the buttons are genuinely clickable. No fixed waits, no loosened assertions; all downstream assertions unchanged. With the real failure gone, the one-way modify transition is no longer orphaned mid-test, so the masking retry pattern disappears too.

**Prior attempts:** #14483 fixed the CTA-bar detachment in the submit test; #14537 extended that to the modify test and replaced the blind waits with request waits. This closes the enable-state race those waits had been hiding.

**Stability evidence:** [pipeline 347099](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347099) — single-spec, 3 nodes, 3/3 green; [pipeline 347100](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347100) — full 16-node suite on this branch, fully green.

# Changelog

## Technical

- Fixed the budgeting E2E spec clicking vote buttons during their disabled refetch window.