### PR TITLE
[TAN-8381] Freshness check: ignore plan-only overlay updates

### DIFF
--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -154,9 +154,6 @@ if [ "$MODE" = "check" ]; then
     fi
     if git -C "$PRIVATE_DIR" rev-parse -q --verify refs/heads/main >/dev/null 2>&1 \
        && git -C "$PRIVATE_DIR" rev-parse -q --verify refs/remotes/origin/main >/dev/null 2>&1; then
-      # Plan documents land on overlay main continuously; a dev who lacks the
-      # latest plans is not stale in any way that affects their sessions, so
-      # commits touching only plans/ don't count toward staleness.
       behind="$(git -C "$PRIVATE_DIR" rev-list --count refs/heads/main..refs/remotes/origin/main -- . ':(exclude)plans' 2>/dev/null || echo 0)"
       if [ "$behind" -gt 0 ]; then
         last="$(git -C "$PRIVATE_DIR" log -1 --format=%cs refs/heads/main 2>/dev/null || echo unknown)"

--- a/bin/setup-claude
+++ b/bin/setup-claude
@@ -19,7 +19,8 @@
 #                               hook) without touching the dev's git state
 #   bin/setup-claude --check    staleness diagnostic: exit 1 and say what's
 #                               wrong when the overlay clone is missing or
-#                               behind origin/main, symlinks are missing or
+#                               behind origin/main (commits touching only
+#                               plans/ don't count), symlinks are missing or
 #                               dangling, or core.hooksPath is unset. Makes no
 #                               changes apart from a throttled `git fetch`
 #                               (at most once per
@@ -153,10 +154,13 @@ if [ "$MODE" = "check" ]; then
     fi
     if git -C "$PRIVATE_DIR" rev-parse -q --verify refs/heads/main >/dev/null 2>&1 \
        && git -C "$PRIVATE_DIR" rev-parse -q --verify refs/remotes/origin/main >/dev/null 2>&1; then
-      behind="$(git -C "$PRIVATE_DIR" rev-list --count refs/heads/main..refs/remotes/origin/main 2>/dev/null || echo 0)"
+      # Plan documents land on overlay main continuously; a dev who lacks the
+      # latest plans is not stale in any way that affects their sessions, so
+      # commits touching only plans/ don't count toward staleness.
+      behind="$(git -C "$PRIVATE_DIR" rev-list --count refs/heads/main..refs/remotes/origin/main -- . ':(exclude)plans' 2>/dev/null || echo 0)"
       if [ "$behind" -gt 0 ]; then
         last="$(git -C "$PRIVATE_DIR" log -1 --format=%cs refs/heads/main 2>/dev/null || echo unknown)"
-        issues+=("overlay main is $behind commit(s) behind origin/main (local main last commit: $last)")
+        issues+=("overlay main is $behind commit(s) behind origin/main, not counting plan-only updates (local main last commit: $last)")
       fi
     fi
 

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -631,9 +631,7 @@ assert_eq "$CHECK_STATUS" "0" "after full setup: --check passes again"
 
 # ----------------------------------------------------------------------------
 # Test: commits on origin/main touching only plans/ don't count as staleness
-# (plan documents sync to main continuously; lacking the latest plans doesn't
-# make a dev's config stale), while a commit that also touches anything else
-# still does.
+# while a commit that also touches anything else still does.
 # ----------------------------------------------------------------------------
 (
   cd "$FIXTURE_WT"

--- a/bin/setup-claude.test.sh
+++ b/bin/setup-claude.test.sh
@@ -630,6 +630,42 @@ assert_eq "$CHECK_STATUS" "0" "after full setup: --check passes again"
 
 
 # ----------------------------------------------------------------------------
+# Test: commits on origin/main touching only plans/ don't count as staleness
+# (plan documents sync to main continuously; lacking the latest plans doesn't
+# make a dev's config stale), while a commit that also touches anything else
+# still does.
+# ----------------------------------------------------------------------------
+(
+  cd "$FIXTURE_WT"
+  git checkout -q main
+  mkdir -p plans
+  echo "a plan" > plans/some-feature-branch.md
+  git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
+  git -c user.email=t@t -c user.name=t commit -q -m "Update plan"
+  git push -q origin main
+)
+rm -f "$PRIVATE/.git/setup-claude-check-fetch-stamp"
+run_check_capture fetch
+assert_eq "$CHECK_STATUS" "0" "plans-only drift: --check exits 0"
+(
+  cd "$FIXTURE_WT"
+  git checkout -q main
+  echo "more plan" > plans/some-feature-branch.md
+  echo "real config change" > real-config-change.txt
+  git -c user.email=t@t -c user.name=t -c core.excludesFile=/dev/null add -A
+  git -c user.email=t@t -c user.name=t commit -q -m "Plan update plus real change"
+  git push -q origin main
+)
+rm -f "$PRIVATE/.git/setup-claude-check-fetch-stamp"
+run_check_capture fetch
+assert_eq "$CHECK_STATUS" "1" "mixed plans+config drift: --check exits 1"
+assert_contains "$CHECK_OUT" "behind origin/main" "mixed drift: --check names the drift"
+run_setup
+run_check_capture
+assert_eq "$CHECK_STATUS" "0" "after full setup: --check passes again (plans tests)"
+
+
+# ----------------------------------------------------------------------------
 # Test: no remote + no clone (dev without overlay access) exits 0 so the
 # check stays silent for them; remote set + clone missing exits 1; --relink
 # with no clone is a hard error.


### PR DESCRIPTION
## Changelog

Technical
- The Claude config freshness check (`bin/setup-claude --check`, also run by the session-start hook) no longer counts overlay commits that only touch `plans/` as staleness. 