### PR TITLE
TAN-8389-Fix/error-loading-data-phase-insights

### DIFF
--- a/back/app/services/custom_field_service.rb
+++ b/back/app/services/custom_field_service.rb
@@ -75,21 +75,12 @@ class CustomFieldService
   def delete_custom_field_option_values(option_key, field)
     return if field.resource_type != 'User'
 
-    if field.supports_multiple_selection?
-      # When option is the only selection
-      User
-        .where("custom_field_values->>'#{field.key}' = ?", [option_key].to_json)
-        .update_all("custom_field_values = custom_field_values - '#{field.key}'")
-      # When option was selected amongst other values
-      User
-        .where("(custom_field_values->>'#{field.key}')::jsonb ? :value", value: option_key)
-        .update_all("custom_field_values = jsonb_set(custom_field_values, '{#{field.key}}', (custom_field_values->'#{field.key}') - '#{option_key}')")
-    else
-      # When single select
-      User
-        .where("custom_field_values->>'#{field.key}' = ?", option_key)
-        .update_all("custom_field_values = custom_field_values - '#{field.key}'")
-    end
+    delete_option_from_values(User.all, field.key, option_key, field.supports_multiple_selection?)
+    # The same field can be asked inside a survey form, in which case the answers are
+    # stored on the input under a prefixed key instead of on the user.
+    delete_option_from_values(
+      Idea.all, UserFieldsInFormService.prefix_key(field.key), option_key, field.supports_multiple_selection?
+    )
   end
 
   # @param [Hash<String, _>] custom_field_values
@@ -174,6 +165,24 @@ class CustomFieldService
     scope
       .where("custom_field_values ? '#{key}'")
       .update_all("custom_field_values = custom_field_values - '#{key}'")
+  end
+
+  def delete_option_from_values(scope, key, option_key, multiple_selection)
+    if multiple_selection
+      # When option is the only selection
+      scope
+        .where("custom_field_values->>'#{key}' = ?", [option_key].to_json)
+        .update_all("custom_field_values = custom_field_values - '#{key}'")
+      # When option was selected amongst other values
+      scope
+        .where("(custom_field_values->>'#{key}')::jsonb ? :value", value: option_key)
+        .update_all("custom_field_values = jsonb_set(custom_field_values, '{#{key}}', (custom_field_values->'#{key}') - '#{option_key}')")
+    else
+      # When single select
+      scope
+        .where("custom_field_values->>'#{key}' = ?", option_key)
+        .update_all("custom_field_values = custom_field_values - '#{key}'")
+    end
   end
 
   # *** text ***

--- a/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
+++ b/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
@@ -129,18 +129,33 @@ module UserCustomFields
       counts.with_indifferent_access
     end
 
+    # Domicile values are area ids, so they have to be mapped back onto option keys.
+    #
+    # The mapping is best-effort: values can reference an area that no longer exists,
+    # because deleting an area only cleans up the answers stored on users, not the ones
+    # a survey form stored on its inputs. Such values are counted as blank rather than
+    # raising, which is consistent with +add_missing_options+ tolerating the same
+    # inconsistency a few lines earlier.
     private_class_method def self.convert_area_ids_to_option_keys!(counts, custom_field)
       raise 'custom_field is not the domicile field' unless custom_field.domicile?
 
       area_id_to_option_key = Area.includes(:custom_field_option)
-        .all.to_h { |area| [area.id, area.custom_field_option.key] }
+        .filter_map { |area| [area.id, area.custom_field_option.key] if area.custom_field_option }
+        .to_h
 
       # Adding special keys to the mapping
       somewhere_else_option = custom_field.options.left_joins(:area).find_by(areas: { id: nil })
-      area_id_to_option_key['outside'] = somewhere_else_option.key
-      area_id_to_option_key[FieldValueCounter::UNKNOWN_VALUE_LABEL] = FieldValueCounter::UNKNOWN_VALUE_LABEL
+      area_id_to_option_key['outside'] = somewhere_else_option.key if somewhere_else_option
+      area_id_to_option_key[UNKNOWN_VALUE_LABEL] = UNKNOWN_VALUE_LABEL
 
-      counts.transform_keys! { |key| area_id_to_option_key.fetch(key) }
+      # Counts are summed instead of assigned, because several keys can map onto
+      # +UNKNOWN_VALUE_LABEL+ and would otherwise overwrite each other.
+      converted = counts.each_with_object({}) do |(key, count), result|
+        option_key = area_id_to_option_key.fetch(key, UNKNOWN_VALUE_LABEL)
+        result[option_key] = (result[option_key] || 0) + count
+      end
+
+      counts.replace(converted)
     end
 
     private_class_method def self.convert_keys_to_option_ids!(counts, custom_field)

--- a/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
@@ -69,6 +69,44 @@ RSpec.describe UserCustomFields::FieldValueCounter do
         expect(counts.keys).to match_array(expected_keys)
         expect(counts.values).to all eq(0)
       end
+
+      context 'when values reference an area that no longer exists' do
+        # Regression test. Deleting an area does not clean up the domicile answers a
+        # survey form stored on its inputs, so those values keep pointing at a deleted
+        # area. Mapping the area ids back onto option keys used to raise a KeyError,
+        # which made every consumer of these counts (phase insights, reporting widgets)
+        # return a 500.
+        subject(:counts) do
+          described_class.counts_by_field_option(custom_field_values, custom_field)
+        end
+
+        let(:deleted_area_id) { SecureRandom.uuid }
+        let(:custom_field_values) do
+          [
+            { 'domicile' => areas.first.id },
+            { 'domicile' => deleted_area_id },
+            { 'domicile' => deleted_area_id },
+            {}
+          ]
+        end
+
+        it 'counts them as blank instead of raising', :aggregate_failures do
+          expect { counts }.not_to raise_error
+
+          first_area_option_key = areas.first.custom_field_option.key
+          expect(counts[first_area_option_key]).to eq 1
+          # 2 answers pointing at the deleted area + 1 answer that was left empty.
+          expect(counts[described_class::UNKNOWN_VALUE_LABEL]).to eq 3
+        end
+
+        it 'keeps the total count intact' do
+          expect(counts.values.sum).to eq custom_field_values.size
+        end
+
+        it 'does not leak the deleted area id into the counts' do
+          expect(counts.keys).not_to include deleted_area_id
+        end
+      end
     end
 
     context 'when user fields are stored in ideas' do

--- a/back/lib/tasks/single_use/20260812_scrub_stale_domicile_values.rake
+++ b/back/lib/tasks/single_use/20260812_scrub_stale_domicile_values.rake
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Deleting an area used to leave behind the domicile answers a survey form had stored on
+# its inputs (only the answers stored on users were cleaned up), so those inputs keep
+# referencing an area that no longer exists. This task removes the leftovers on tenants
+# that were affected before the cleanup was extended to inputs.
+namespace :single_use do
+  desc 'Remove domicile answers on inputs that reference an area that no longer exists'
+  task :scrub_stale_domicile_values, %i[execute] => [:environment] do |_t, args|
+    execute = args[:execute] == 'execute'
+    puts "---------- STARTING TASK: Scrub stale domicile values ----------\n\n"
+    puts "Mode: #{execute ? 'EXECUTE - changes WILL be applied' : 'Dry run - no changes will be applied'}\n\n"
+
+    reporter = ScriptReporter.new
+
+    Tenant.all.find_each do |tenant|
+      next unless Apartment.connection.schema_exists?(tenant.schema_name)
+
+      begin
+        tenant.switch do
+          reporter.add_processed_tenant(tenant)
+
+          domicile_field = CustomField.find_by(key: 'domicile', resource_type: 'User')
+          next if domicile_field.nil?
+
+          key = UserFieldsInFormService.prefix_key(domicile_field.key)
+          known_values = Area.ids << 'outside'
+
+          # Two separate condition strings on purpose: the jsonb `?` operator cannot share
+          # a string with bind parameters.
+          stale_inputs = Idea
+            .where("custom_field_values ? '#{key}'")
+            .where.not("custom_field_values->>'#{key}' IN (?)", known_values)
+
+          stale_by_area_id = stale_inputs.pluck(Arel.sql("custom_field_values->>'#{key}'")).tally
+          next if stale_by_area_id.empty?
+
+          total = stale_by_area_id.values.sum
+          puts "Tenant: #{tenant.host} - #{total} input(s) referencing #{stale_by_area_id.size} deleted area(s)"
+          stale_by_area_id.each { |area_id, count| puts "  #{area_id}: #{count} input(s)" }
+
+          stale_inputs.update_all("custom_field_values = custom_field_values - '#{key}'") if execute
+
+          reporter.add_change(
+            stale_by_area_id,
+            {},
+            context: { tenant: tenant.host, custom_field_key: key, inputs_affected: total }
+          )
+        end
+      rescue Apartment::TenantNotFound, StandardError => e
+        reporter.add_error(e.message, context: { tenant: tenant.host })
+        puts "ERROR! Failed to process tenant #{tenant.host}: #{e.message}"
+      end
+    end
+
+    reporter.report!('scrub_stale_domicile_values.json', verbose: false)
+
+    puts "\n---------- FINISHED TASK: Scrub stale domicile values ----------\n\n"
+  end
+end

--- a/back/spec/services/custom_field_service_spec.rb
+++ b/back/spec/services/custom_field_service_spec.rb
@@ -110,6 +110,55 @@ describe CustomFieldService do
       expect(u1.reload.custom_field_values).to eq({})
       expect(u2.reload.custom_field_values).to eq v2
     end
+
+    # When a user field is asked inside a survey form, the answers live on the input
+    # rather than on the user. Leaving them behind makes them reference an option that no
+    # longer exists, which later breaks the code counting answers per option.
+    it 'deletes the option from the values a user field stored on inputs for a single select' do
+      cf1 = create(:custom_field_select)
+      cfo1 = create(:custom_field_option, custom_field: cf1)
+      cfo2 = create(:custom_field_option, custom_field: cf1)
+      key = "u_#{cf1.key}"
+      input1 = create(:idea, custom_field_values: { key => cfo1.key, 'other_field' => 'stays' })
+      input2 = create(:idea, custom_field_values: { key => cfo2.key })
+
+      service.delete_custom_field_option_values(cfo1.key, cf1)
+
+      expect(input1.reload.custom_field_values).to eq({ 'other_field' => 'stays' })
+      expect(input2.reload.custom_field_values).to eq({ key => cfo2.key })
+    end
+
+    it 'deletes the option from the values a user field stored on inputs for a multiselect' do
+      cf1 = create(:custom_field_multiselect)
+      cfo1 = create(:custom_field_option, custom_field: cf1)
+      cfo2 = create(:custom_field_option, custom_field: cf1)
+      key = "u_#{cf1.key}"
+      input1 = create(:idea, custom_field_values: { key => [cfo1.key] })
+      input2 = create(:idea, custom_field_values: { key => [cfo1.key, cfo2.key] })
+      input3 = create(:idea, custom_field_values: { key => [cfo2.key] })
+
+      service.delete_custom_field_option_values(cfo1.key, cf1)
+
+      expect(input1.reload.custom_field_values).to eq({})
+      expect(input2.reload.custom_field_values).to eq({ key => [cfo2.key] })
+      expect(input3.reload.custom_field_values).to eq({ key => [cfo2.key] })
+    end
+
+    it 'deletes the domicile values an input holds for an area that gets destroyed' do
+      domicile_field = create(:custom_field_domicile)
+      area = create(:area)
+      other_area = create(:area)
+      input1 = create(:idea, custom_field_values: { 'u_domicile' => area.id })
+      input2 = create(:idea, custom_field_values: { 'u_domicile' => other_area.id })
+      user = create(:user, domicile: area.id)
+
+      # Mirrors what SideFxAreaService#before_destroy does when an area is deleted.
+      service.delete_custom_field_option_values(area.id, domicile_field)
+
+      expect(input1.reload.custom_field_values).to eq({})
+      expect(input2.reload.custom_field_values).to eq({ 'u_domicile' => other_area.id })
+      expect(user.reload.custom_field_values).to eq({})
+    end
   end
 
   describe 'fields_to_json_schema' do

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -409,6 +409,52 @@ RSpec.describe Insights::BasePhaseInsightsService do
         )
       end
     end
+
+    context 'domicile field' do
+      let!(:domicile_field) { create(:custom_field_domicile) }
+      let!(:area) { create(:area) }
+
+      let(:participation1) { create(:basket_participation, user_custom_field_values: { 'domicile' => area.id }) }
+      let(:flattened_participations) { [participation1] }
+      let(:participant_ids) { flattened_participations.pluck(:participant_id).uniq }
+
+      # The option that is not backed by an area, offered as 'Somewhere else'.
+      let(:somewhere_else_key) { domicile_field.options.left_joins(:area).find_by(areas: { id: nil }).key }
+
+      it 'includes series indexed by option key' do
+        result = service.send(:demographics_data, flattened_participations, participant_ids)
+
+        expect(result).to include(
+          hash_including(
+            key: 'domicile',
+            series: { area.custom_field_option.key => 1, somewhere_else_key => 0, '_blank' => 0 }
+          )
+        )
+      end
+
+      context 'when a value references an area that no longer exists' do
+        # Regression test. Deleting an area used to leave behind the domicile answers a
+        # survey form had stored on its inputs, so those values keep referencing a
+        # deleted area. Mapping them back onto option keys raised a KeyError, which took
+        # down the whole insights endpoint (metrics, timeline and demographics at once).
+        let(:participation2) do
+          create(:basket_participation, user_custom_field_values: { 'domicile' => SecureRandom.uuid })
+        end
+        let(:flattened_participations) { [participation1, participation2] }
+
+        it 'counts them as blank instead of raising' do
+          expect { service.send(:demographics_data, flattened_participations, participant_ids) }
+            .not_to raise_error
+        end
+
+        it 'keeps every participant accounted for in the series' do
+          result = service.send(:demographics_data, flattened_participations, participant_ids)
+          domicile_series = result.find { |field| field[:key] == 'domicile' }[:series]
+
+          expect(domicile_series).to eq({ area.custom_field_option.key => 1, '_blank' => 1 })
+        end
+      end
+    end
   end
 
   describe '#birthyear_demographics_data' do


### PR DESCRIPTION
Fix insights 500 when a demographic answer points at a deleted area

Deleting an area only removed the references stored on users, not the ones
a survey form stored on its inputs under a prefixed key. Those answers kept
pointing at a deleted area, and mapping them back onto option keys raised a
KeyError, taking down the whole phase insights endpoint (metrics, timeline
and demographics at once) plus the reporting widgets that share the counter.

- Count unknown area ids as blank instead of raising. Counts are summed
  rather than assigned, so several ids collapsing onto the same bucket
  cannot silently drop responses.
- Extend the area-deletion cleanup to inputs, matching what
  delete_custom_field_values already does for the same pair of models.
- Add a dry-run rake task to scrub values that are already dangling.


# Changelog
## Fixed
-  Fix insights error loading when a demographic answer points at a deleted area

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
