### PR TITLE
Tan 8409 events order in project show page

### DIFF
--- a/front/app/components/ProjectPageBuilder/Widgets/Events/EventsSection.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/Events/EventsSection.tsx
@@ -26,19 +26,26 @@ const StyledPagination = styled(Pagination)`
 `;
 
 type Props = {
+  id?: string;
   title: MessageDescriptor;
   events: IEvents;
   currentPage: number;
   onPageChange: (page: number) => void;
 };
 
-const EventsSection = ({ title, events, currentPage, onPageChange }: Props) => {
+const EventsSection = ({
+  id,
+  title,
+  events,
+  currentPage,
+  onPageChange,
+}: Props) => {
   if (events.data.length === 0) {
     return null;
   }
 
   return (
-    <Box>
+    <Box id={id}>
       <Title variant="h3" color="tenantText" m="0" mb="16px">
         <FormattedMessage {...title} />
       </Title>

--- a/front/app/components/ProjectPageBuilder/Widgets/Events/index.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/Events/index.tsx
@@ -50,7 +50,12 @@ const EventsWidget: UserComponent<Props> = ({ sectionBackground }) => {
     pageSize: PAGE_SIZE,
   };
   const { data: upcomingEvents } = useEvents(
-    { ...eventsParams, currentAndFutureOnly: true, pageNumber: upcomingPage },
+    {
+      ...eventsParams,
+      currentAndFutureOnly: true,
+      sort: '-start_at',
+      pageNumber: upcomingPage,
+    },
     { enabled: !!projectId }
   );
   const { data: pastEvents } = useEvents(
@@ -84,12 +89,14 @@ const EventsWidget: UserComponent<Props> = ({ sectionBackground }) => {
           </Title>
           <Box display="flex" flexDirection="column" gap="48px">
             <EventsSection
+              id="e2e-project-page-upcoming-events"
               title={sharedMessages.upcomingAndOngoingEvents}
               events={upcomingEvents}
               currentPage={upcomingPage}
               onPageChange={setUpcomingPage}
             />
             <EventsSection
+              id="e2e-project-page-past-events"
               title={sharedMessages.pastEvents}
               events={pastEvents}
               currentPage={pastPage}

--- a/front/cypress/e2e/project_page_information.cy.ts
+++ b/front/cypress/e2e/project_page_information.cy.ts
@@ -7,6 +7,7 @@ describe('Information with events CTA', () => {
   const projectDescriptionPreview = randomString(30);
   let projectId: string;
   let projectSlug: string;
+  let ctaEventId: string;
 
   const firstName = randomString();
   const lastName = randomString();
@@ -59,7 +60,9 @@ describe('Information with events CTA', () => {
       description: 'Event description',
       startDate: moment().subtract(1, 'day').toDate(),
       endDate: moment().add(1, 'day').toDate(),
-    }).then(() => {
+    }).then((event) => {
+      ctaEventId = event.body.data.id;
+
       cy.visit(`/en/projects/${projectSlug}`);
 
       cy.get('#e2e-project-see-events-button').should('exist');
@@ -67,6 +70,59 @@ describe('Information with events CTA', () => {
       cy.get('#e2e-cta-bar-see-events').should('exist');
       cy.get('#e2e-event-previews').should('exist');
       cy.get('#e2e-project-page-events').should('exist');
+    });
+  });
+
+  describe('upcoming events order', () => {
+    const soonestEventTitle = randomString();
+    const latestEventTitle = randomString();
+    let soonestEventId: string;
+    let latestEventId: string;
+
+    before(() => {
+      // Removing event from the previous test
+      cy.apiRemoveEvent(ctaEventId);
+
+      // Create 2 events in reverse chronological order, so that a wrong sort order
+      // cannot pass by accidentally matching the creation order.
+      cy.apiCreateEvent({
+        projectId,
+        title: latestEventTitle,
+        location: 'Event location',
+        includeLocation: true,
+        description: 'Event description',
+        startDate: moment().add(3, 'month').toDate(),
+        endDate: moment().add(3, 'month').add(1, 'day').toDate(),
+      }).then((event) => {
+        latestEventId = event.body.data.id;
+      });
+
+      cy.apiCreateEvent({
+        projectId,
+        title: soonestEventTitle,
+        location: 'Event location',
+        includeLocation: true,
+        description: 'Event description',
+        startDate: moment().add(1, 'day').toDate(),
+        endDate: moment().add(2, 'day').toDate(),
+      }).then((event) => {
+        soonestEventId = event.body.data.id;
+      });
+    });
+
+    it('lists the upcoming events with the soonest one first', () => {
+      cy.visit(`/en/projects/${projectSlug}`);
+
+      const eventCards = '#e2e-project-page-upcoming-events .e2e-event-card';
+
+      cy.get(eventCards).should('have.length', 2);
+      cy.get(eventCards).eq(0).should('contain', soonestEventTitle);
+      cy.get(eventCards).eq(1).should('contain', latestEventTitle);
+    });
+
+    after(() => {
+      cy.apiRemoveEvent(soonestEventId);
+      cy.apiRemoveEvent(latestEventId);
     });
   });
 

--- a/front/cypress/e2e/project_page_information.cy.ts
+++ b/front/cypress/e2e/project_page_information.cy.ts
@@ -80,8 +80,10 @@ describe('Information with events CTA', () => {
     let latestEventId: string;
 
     before(() => {
-      // Removing event from the previous test
-      cy.apiRemoveEvent(ctaEventId);
+      // Remove event from the previous test
+      if (ctaEventId) {
+        cy.apiRemoveEvent(ctaEventId);
+      }
 
       // Create 2 events in reverse chronological order, so that a wrong sort order
       // cannot pass by accidentally matching the creation order.

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -78,6 +78,7 @@ declare global {
       apiCreateCause: typeof apiCreateCause;
       apiVerifyBogus: typeof apiVerifyBogus;
       apiCreateEvent: typeof apiCreateEvent;
+      apiRemoveEvent: typeof apiRemoveEvent;
       apiToggleProjectDescriptionBuilder: typeof apiToggleProjectDescriptionBuilder;
       apiCreateReportBuilder: typeof apiCreateReportBuilder;
       apiRemoveReportBuilder: typeof apiRemoveReportBuilder;
@@ -1229,6 +1230,21 @@ function apiRemovePhase(phaseId: string) {
       },
       method: 'DELETE',
       url: `web_api/v1/phases/${phaseId}`,
+    });
+  });
+}
+
+function apiRemoveEvent(eventId: string) {
+  return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
+    const adminJwt = response.body.jwt;
+
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminJwt}`,
+      },
+      method: 'DELETE',
+      url: `web_api/v1/events/${eventId}`,
     });
   });
 }
@@ -2481,6 +2497,7 @@ Cypress.Commands.add('setConsentCookie', setConsentCookie);
 Cypress.Commands.add('setLoginCookie', setLoginCookie);
 Cypress.Commands.add('apiVerifyBogus', apiVerifyBogus);
 Cypress.Commands.add('apiCreateEvent', apiCreateEvent);
+Cypress.Commands.add('apiRemoveEvent', apiRemoveEvent);
 Cypress.Commands.add(
   'apiToggleProjectDescriptionBuilder',
   apiToggleProjectDescriptionBuilder


### PR DESCRIPTION
# Changelog
## Fixed
- Events card in project show page appears in start_at ascendant order.

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
