### PR TITLE
TAN-8389 Tolerate deleted areas in domicile value counts

### DIFF
--- a/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
+++ b/back/engines/commercial/user_custom_fields/app/services/user_custom_fields/field_value_counter.rb
@@ -133,14 +133,20 @@ module UserCustomFields
       raise 'custom_field is not the domicile field' unless custom_field.domicile?
 
       area_id_to_option_key = Area.includes(:custom_field_option)
-        .all.to_h { |area| [area.id, area.custom_field_option.key] }
+        .filter_map { |area| [area.id, area.custom_field_option.key] if area.custom_field_option }
+        .to_h
 
       # Adding special keys to the mapping
       somewhere_else_option = custom_field.options.left_joins(:area).find_by(areas: { id: nil })
-      area_id_to_option_key['outside'] = somewhere_else_option.key
-      area_id_to_option_key[FieldValueCounter::UNKNOWN_VALUE_LABEL] = FieldValueCounter::UNKNOWN_VALUE_LABEL
+      area_id_to_option_key['outside'] = somewhere_else_option.key if somewhere_else_option
+      area_id_to_option_key[UNKNOWN_VALUE_LABEL] = UNKNOWN_VALUE_LABEL
 
-      counts.transform_keys! { |key| area_id_to_option_key.fetch(key) }
+      # Several keys can collapse onto UNKNOWN_VALUE_LABEL, so counts are summed.
+      converted = counts.each_with_object({}) do |(key, count), result|
+        option_key = area_id_to_option_key.fetch(key, UNKNOWN_VALUE_LABEL)
+        result[option_key] = (result[option_key] || 0) + count
+      end
+      counts.replace(converted)
     end
 
     private_class_method def self.convert_keys_to_option_ids!(counts, custom_field)

--- a/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
+++ b/back/engines/commercial/user_custom_fields/spec/services/user_custom_fields/field_value_counter_spec.rb
@@ -69,6 +69,23 @@ RSpec.describe UserCustomFields::FieldValueCounter do
         expect(counts.keys).to match_array(expected_keys)
         expect(counts.values).to all eq(0)
       end
+
+      context 'with values referencing a deleted area' do
+        let(:options) { { record_type: 'ideas' } }
+        let(:records) { Idea.all }
+
+        it 'counts them as blank instead of raising', :aggregate_failures do
+          create(:idea_status_proposed)
+          create(:idea, author: nil, custom_field_values: { 'u_domicile' => areas.first.id })
+          deleted_area = create(:area)
+          create(:idea, author: nil, custom_field_values: { 'u_domicile' => deleted_area.id })
+          deleted_area.destroy!
+
+          expect(counts[areas.first.custom_field_option.key]).to eq 1
+          expect(counts[described_class::UNKNOWN_VALUE_LABEL]).to eq 1
+          expect(counts.keys).not_to include(deleted_area.id)
+        end
+      end
     end
 
     context 'when user fields are stored in ideas' do


### PR DESCRIPTION
# Changelog
### Fixed
- [TAN-8389] Insights errors after deleting an area (that users specified as their domicile).
