### PR TITLE
TAN-8495 Fix idea display for square images on demo platform

### DIFF
--- a/front/app/components/IdeaCard/CardImage/index.tsx
+++ b/front/app/components/IdeaCard/CardImage/index.tsx
@@ -35,17 +35,28 @@ const IdeaCardImage = styled(Image)`
 interface Props {
   phase?: IPhaseData;
   image: string | null;
+  imageFallback?: string;
   hideImagePlaceholder: boolean;
 }
 
-const CardImage = ({ phase, image, hideImagePlaceholder }: Props) => {
+const CardImage = ({
+  phase,
+  image,
+  imageFallback,
+  hideImagePlaceholder,
+}: Props) => {
   const votingMethod = phase?.attributes.voting_method;
 
   return (
     <>
       {image && (
         <IdeaCardImageWrapper>
-          <IdeaCardImage src={image} cover={true} alt="" />
+          <IdeaCardImage
+            src={image}
+            fallbackSrc={imageFallback}
+            cover={true}
+            alt=""
+          />
         </IdeaCardImageWrapper>
       )}
 

--- a/front/app/components/IdeaCard/index.tsx
+++ b/front/app/components/IdeaCard/index.tsx
@@ -72,12 +72,19 @@ const IdeaCard = ({
   const smallerThanPhone = useBreakpoint('phone');
   const smallerThanTablet = useBreakpoint('tablet');
 
-  const image =
-    !hideImage && ideaImage
-      ? smallerThanTablet
-        ? ideaImage.data.attributes.versions.medium
-        : ideaImage.data.attributes.versions.square_medium ?? null
-      : null;
+  const versions =
+    !hideImage && ideaImage ? ideaImage.data.attributes.versions : undefined;
+
+  // `square_medium` was added long after images started being uploaded, and the API
+  // returns its URL whether or not the version was ever generated. Fall back to
+  // `medium`, which every idea image has, so a missing square version doesn't leave
+  // an empty box on the card.
+  const image = smallerThanTablet
+    ? versions?.medium ?? null
+    : versions?.square_medium ?? versions?.medium ?? null;
+  const imageFallback = smallerThanTablet
+    ? undefined
+    : versions?.medium ?? undefined;
 
   const localize = useLocalize();
 
@@ -133,6 +140,7 @@ const IdeaCard = ({
       <CardImage
         phase={phaseData}
         image={image}
+        imageFallback={imageFallback}
         hideImagePlaceholder={hideImagePlaceholder}
       />
 

--- a/front/app/components/UI/Image/index.tsx
+++ b/front/app/components/UI/Image/index.tsx
@@ -30,6 +30,9 @@ const ImageElement = styled.img<{
 interface Props {
   id?: string;
   src: HTMLImageElement['src'];
+  // Rendered instead of `src` when `src` fails to load. Useful for image versions
+  // that are not guaranteed to exist for uploads predating the version.
+  fallbackSrc?: HTMLImageElement['src'];
   alt: HTMLImageElement['alt'];
   role?: string;
   cover?: boolean;
@@ -43,6 +46,7 @@ interface Props {
 const Image: React.FC<Props> = ({
   id,
   src,
+  fallbackSrc,
   alt,
   role,
   cover = false,
@@ -53,14 +57,26 @@ const Image: React.FC<Props> = ({
   className,
 }) => {
   const [loaded, setLoaded] = useState(false);
+  // Holds the src that failed rather than a boolean, so that a new `src` prop
+  // retries the primary source instead of staying stuck on the fallback.
+  const [failedSrc, setFailedSrc] = useState<string | null>(null);
+
+  const usesFallback = !!fallbackSrc && failedSrc === src;
 
   const handleImageLoaded = () => {
     setLoaded(true);
   };
 
+  const handleImageError = () => {
+    // Skip when already on the fallback, so a failing fallback can't loop.
+    if (fallbackSrc && !usesFallback) {
+      setFailedSrc(src);
+    }
+  };
+
   return (
     <ImageElement
-      src={src}
+      src={usesFallback ? fallbackSrc : src}
       alt={alt}
       role={role}
       cover={cover}
@@ -69,6 +85,7 @@ const Image: React.FC<Props> = ({
       placeholderBg={placeholderBg}
       loaded={loaded}
       onLoad={handleImageLoaded}
+      onError={handleImageError}
       id={id}
       className={className || ''}
       loading={isLazy ? 'lazy' : 'eager'}


### PR DESCRIPTION
# Changelog
## Fixed
- Square images for idea cards on demo platforms now show as expected 

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
