### PR TITLE
[TAN-8516] Stop the que crash loop on non-StandardError exceptions (multiline text smart group rules)

### DIFF
--- a/back/engines/commercial/smart_groups/spec/rules/custom_field_text_spec.rb
+++ b/back/engines/commercial/smart_groups/spec/rules/custom_field_text_spec.rb
@@ -92,6 +92,17 @@ describe SmartGroups::Rules::CustomFieldText do
       rule = described_class.new(custom_field.id, 'not_is_empty')
       expect(rule.filter(User).count).to eq User.count
     end
+
+    # Rules on multiline text fields exist in production: the field type is only validated when the
+    # rule is created, and this used to work because the filter queried `custom_field_values` directly.
+    context 'when the custom field is a multiline text field' do
+      let(:custom_field) { create(:custom_field, input_type: 'multiline_text') }
+
+      it "filters on the 'is' and 'contains' predicates" do
+        expect(described_class.new(custom_field.id, 'is', 'two').filter(User).count).to eq 1
+        expect(described_class.new(custom_field.id, 'contains', 'hre').filter(User).count).to eq 1
+      end
+    end
   end
 
   describe 'description_multiloc' do

--- a/back/lib/active_job_que_extension.rb
+++ b/back/lib/active_job_que_extension.rb
@@ -1,6 +1,18 @@
 # frozen_string_literal: true
 
 module ActiveJobQueExtension
+  # Raised in place of an exception that is not a StandardError, so that the job goes through Que's
+  # regular error handling (see `#_run`). The original exception is available as `cause`.
+  class NonStandardError < StandardError
+    def initialize(original)
+      super("#{original.class}: #{original.message}")
+      set_backtrace(original.backtrace)
+    end
+  end
+
+  # Exceptions that must keep propagating out of a job: they concern the process, not the job.
+  UNRECOVERABLE_EXCEPTIONS = [SignalException, SystemExit, NoMemoryError].freeze
+
   def self.included(base)
     base.class_eval do
       class_attribute :should_retry
@@ -42,4 +54,37 @@ module ActiveJobQueExtension
     )
   end
   ruby2_keywords(:perform) if respond_to?(:ruby2_keywords, true)
+
+  # Que only rescues StandardError around a job, both in `Que::JobMethods#_run` and in
+  # `Que::Worker#work_job`. Anything else raised by a job (NotImplementedError and the other
+  # ScriptErrors, SystemStackError, ...) escapes both, terminates the worker thread and, because Que
+  # starts its worker threads with `abort_on_exception = true`, the whole `que` process. The job row
+  # is left untouched (error_count 0, run_at in the past), so the restarted process picks that very
+  # job first and dies again: a crash loop that only ends when someone expires the job by hand, and
+  # that kills every other job in flight in the process on each iteration (TAN-8516).
+  #
+  # Wrap those exceptions in a StandardError and apply the same error handling as
+  # `Que::JobMethods#_run`, so the job is retried or expired according to `perform_retries` like
+  # any other failure.
+  def _run(reraise_errors: false, **)
+    super
+  rescue Exception => e # rubocop:disable Lint/RescueException
+    raise if e.is_a?(StandardError) || UNRECOVERABLE_EXCEPTIONS.any? { |klass| e.is_a?(klass) } || !que_target
+
+    error = NonStandardError.new(e)
+    que_target.que_error = error
+
+    run_error_notifier =
+      begin
+        handle_error(error)
+      rescue StandardError => handle_error_error
+        Que.notify_error(handle_error_error, que_target.que_attrs)
+        true
+      end
+
+    Que.notify_error(error, que_target.que_attrs) if run_error_notifier
+    retry_in_default_interval unless que_target.que_resolved
+
+    raise error if reraise_errors
+  end
 end

--- a/back/lib/input_type_strategy/multiline_text.rb
+++ b/back/lib/input_type_strategy/multiline_text.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module InputTypeStrategy
-  class MultilineText < Base
-    def supports_text?
-      true
-    end
+  # Multiline text answers are stored exactly like single-line text answers, so the text answer
+  # conditions (`answers_eq`, `answers_matching`) apply as well. Smart group `custom_field_text`
+  # rules on multiline text registration fields exist in production and depend on this (TAN-8516).
+  class MultilineText < Text
   end
 end

--- a/back/spec/jobs/application_job_spec.rb
+++ b/back/spec/jobs/application_job_spec.rb
@@ -86,6 +86,50 @@ RSpec.describe ApplicationJob, use_transactional_fixtures: false do
       end
     end
 
+    # Que only rescues StandardError. Without ActiveJobQueExtension#_run, the exception below would
+    # kill the worker thread and, through abort_on_exception, the whole process (TAN-8516).
+    describe 'when a job raises an exception that is not a StandardError' do
+      around do |example|
+        initial_retry_interval = Que::Job.retry_interval
+        Que::Job.retry_interval = 0.001
+        example.run
+        Que::Job.retry_interval = initial_retry_interval
+      end
+
+      before do
+        stub_const('TestNonStandardErrorJob', Class.new(ApplicationJob) do
+          class_attribute :counter, default: 0
+
+          def run
+            self.class.counter += 1
+            raise NotImplementedError, 'not supported'
+          end
+        end)
+      end
+
+      it 'keeps the worker alive and retries the job like any other failure' do
+        TestNonStandardErrorJob.perform_later
+        wait_until(wait_timeout) { TestNonStandardErrorJob.counter >= 2 }
+        expect(TestNonStandardErrorJob.counter).to be >= 2
+      end
+
+      it 'records the original exception on the job' do
+        que_job = QueJob.find(TestNonStandardErrorJob.perform_later.provider_job_id)
+        wait_until(wait_timeout) { que_job.reload.error_count.positive? }
+        expect(que_job.last_error_message).to include('NotImplementedError: not supported')
+      end
+
+      context 'when `perform_retries false`' do
+        before { TestNonStandardErrorJob.perform_retries false }
+
+        it 'expires the job instead of retrying it' do
+          que_job = QueJob.find(TestNonStandardErrorJob.perform_later.provider_job_id)
+          wait_until(wait_timeout) { que_job.reload.expired_at.present? }
+          expect(TestNonStandardErrorJob.counter).to eq(1)
+        end
+      end
+    end
+
     describe 'error tracking' do
       context 'when job raises error' do
         before do


### PR DESCRIPTION
Task: [TAN-8516](https://app.notion.com/p/3bd9663b7b26810a84e8ce673b8a7e3b)

## What happened

Since #14530 (`AnswerableFilter`) reached production-benelux on 2026-08-14 ~16:45 UTC, `UpdateMemberCountJob` raises `NotImplementedError: InputTypeStrategy::MultilineText does not support the matching answers condition` ([Sentry, 43k events](https://sentry.hq.citizenlab.co/share/issue/384de2fed8d84766a7ae222e1e0dcf6a/), [`eq` variant](https://sentry.hq.citizenlab.co/share/issue/0a7a48a3d84342aaab30f67b2c031783/)) for tenants that have a smart group with a `custom_field_text` rule on a `multiline_text` registration field. Before #14530 the rule queried `users.custom_field_values` directly and worked for any input type; the new path dispatches to the field's strategy and only `InputTypeStrategy::Text` implements `answers_eq` / `answers_matching`.

`NotImplementedError` is a `ScriptError`, not a `StandardError`. Que 2.4.1 only rescues `StandardError` around a job (`Que::JobMethods#_run`, `Que::Worker#work_job`), so the exception escaped, the worker thread died and, because Que starts worker threads with `abort_on_exception = true`, the whole `bundle exec que` process exited. The job row was never touched (`error_count` 0, `run_at` in the past), so the container Swarm restarted polled the same job first and died again.

Measured on `/citizenlab/production-benelux/que` (CloudWatch Logs Insights, 2026-08-14 16:47 UTC to 2026-08-15 05:50 UTC): que container starts went from 5 per 30 min to 1,200 to 1,400 per 30 min (about 40 restarts per minute across the swarm); 7 `UpdateMemberCountJob` rows were started 27,713 / 14,298 / 4,136 / 3,200 / 2,563 / 2,022 / 887 times. Every crash also killed the other jobs in flight in that process, so long jobs could not complete at all (one `Analysis::HeatmapGenerationJob`: 15,641 starts, 0 completions). On the dashboards this is the `MaxQueueTimePrio50` sawtooth and the swarm ASG pinned at max (each restart is a full Rails boot, which keeps the CPU target-tracking policy above target).

## Changes

1. `InputTypeStrategy::MultilineText < Text`: multiline text answers are stored like single-line text answers, so the text answer conditions apply. Restores the pre-#14530 behaviour for existing rules. Regression spec in the smart group `CustomFieldText` rule spec (reproduces the production error without the fix).
2. `ActiveJobQueExtension#_run`: exceptions that are not `StandardError` (`ScriptError`, `SystemStackError`, ...) are wrapped in a `StandardError` (original as `cause`) and go through the same error handling as `Que::JobMethods#_run`, so the job is retried or expired according to `perform_retries` like any other failure, and the process survives. `SignalException`, `SystemExit` and `NoMemoryError` still propagate. Specs run a real `Que::Locker` and, without the change, reproduce the production symptom (`que/worker.rb:41 ... terminated with exception`).

## Ops note (independent of this PR)

The loop on production stops as soon as the poison rows are no longer pollable; until this is deployed, new `UpdateMemberCountJob` rows for the affected tenants keep appearing (any user / invite / follow / verification side effect enqueues one). SQL to expire them is in the Notion task.

# Changelog

- Fixed: smart group text rules on multiline text registration fields raised `NotImplementedError` since #14530, which crash-looped the background job workers.
- Fixed: a job raising an exception that is not a `StandardError` no longer takes the whole `que` worker process down; it is retried or expired like any other failing job.

# For translators

No copy changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
