### PR TITLE
[TAN-8481] Fix create policy for author-less draft ideas

### DIFF
--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -1,6 +1,13 @@
 # frozen_string_literal: true
 
 class IdeaPolicy < ApplicationPolicy
+  # A draft may be written despite a denied reason only when the row is
+  # attributable to a user who could still become permitted, since the check
+  # runs again at publication (see #update?). user_not_signed_in fails both
+  # halves: an author-less draft can never be published, so there is no later
+  # check to defer to.
+  DEFERRABLE_DRAFT_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
+
   class Scope < ApplicationPolicy::Scope
     def resolve
       project_scope = scope_for(Project)
@@ -60,17 +67,11 @@ class IdeaPolicy < ApplicationPolicy
     return false if !phase
 
     reason = if record.draft?
-      # User permission checks are deferred to publication, as the user may
-      # still become permitted while filling in the form.
-      Permissions::PhasePermissionsService.new(phase, user).context_denied_reason
+      draft_denied_reason(phase)
     else
       return false if !active? && !record.participation_method_on_creation.supports_inputs_without_author?
 
-      Permissions::PhasePermissionsService.new(
-        phase,
-        user,
-        request: record.request # Only present if pmethod.everyone_tracking_enabled? is true
-      ).denied_reason_for_action('posting_idea')
+      posting_denied_reason(phase)
     end
     raise_not_authorized(reason) if reason
 
@@ -118,6 +119,19 @@ class IdeaPolicy < ApplicationPolicy
   end
 
   private
+
+  def draft_denied_reason(phase)
+    reason = posting_denied_reason(phase)
+    DEFERRABLE_DRAFT_REASONS.include?(reason) ? nil : reason
+  end
+
+  def posting_denied_reason(phase)
+    Permissions::PhasePermissionsService.new(
+      phase,
+      user,
+      request: record.request # Only present if pmethod.everyone_tracking_enabled? is true
+    ).denied_reason_for_action('posting_idea')
+  end
 
   def owner?
     user && record.author_id == user.id

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 
 class IdeaPolicy < ApplicationPolicy
-  # Denied reasons that still allow a draft to be created. The posting check
-  # runs again when the draft is published (see #update?), and the author can
-  # fix any of these before then: registration unfinished, verification
-  # pending, required profile fields still blank.
-  #
-  # user_not_signed_in is deliberately not here. It only arises where posting
-  # requires an account, and there a signed-out draft is a dead row: publishing
-  # needs owner?, which matches on author_id, and the only route to becoming
-  # that owner is a claim token, which is issued solely where posting is open to
-  # everyone (see IdeasController#create). So nothing would ever re-check it.
-  # Signed-out drafts on everyone-permitted phases are unaffected: on those
-  # phases nothing is denied in the first place.
-  DEFERRABLE_DENIED_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
-
   class Scope < ApplicationPolicy::Scope
     def resolve
       project_scope = scope_for(Project)
@@ -129,7 +115,7 @@ class IdeaPolicy < ApplicationPolicy
 
   def draft_denied_reason(phase)
     reason = posting_denied_reason(phase)
-    DEFERRABLE_DENIED_REASONS.include?(reason) ? nil : reason
+    Permissions::PhasePermissionsService::DEFERRABLE_DENIED_REASONS.include?(reason) ? nil : reason
   end
 
   def posting_denied_reason(phase)

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -11,9 +11,9 @@ class IdeaPolicy < ApplicationPolicy
   # needs owner?, which matches on author_id, and the only route to becoming
   # that owner is a claim token, which is issued solely where posting is open to
   # everyone (see IdeasController#create). So nothing would ever re-check it.
-  # Signed-out drafts on everyone-permitted phases are unaffected - there no
-  # reason is denied in the first place.
-  DEFERRABLE_DRAFT_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
+  # Signed-out drafts on everyone-permitted phases are unaffected: on those
+  # phases nothing is denied in the first place.
+  DEFERRABLE_DENIED_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
 
   class Scope < ApplicationPolicy::Scope
     def resolve
@@ -129,7 +129,7 @@ class IdeaPolicy < ApplicationPolicy
 
   def draft_denied_reason(phase)
     reason = posting_denied_reason(phase)
-    DEFERRABLE_DRAFT_REASONS.include?(reason) ? nil : reason
+    DEFERRABLE_DENIED_REASONS.include?(reason) ? nil : reason
   end
 
   def posting_denied_reason(phase)

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -64,7 +64,7 @@ class IdeaPolicy < ApplicationPolicy
     else
       return false if !active? && !record.participation_method_on_creation.supports_inputs_without_author?
 
-      posting_denied_reason(phase)
+      phase_posting_denied_reason(phase)
     end
     raise_not_authorized(reason) if reason
 
@@ -114,11 +114,11 @@ class IdeaPolicy < ApplicationPolicy
   private
 
   def draft_denied_reason(phase)
-    reason = posting_denied_reason(phase)
+    reason = phase_posting_denied_reason(phase)
     Permissions::PhasePermissionsService::DEFERRABLE_DENIED_REASONS.include?(reason) ? nil : reason
   end
 
-  def posting_denied_reason(phase)
+  def phase_posting_denied_reason(phase)
     Permissions::PhasePermissionsService.new(
       phase,
       user,

--- a/back/app/policies/idea_policy.rb
+++ b/back/app/policies/idea_policy.rb
@@ -1,11 +1,18 @@
 # frozen_string_literal: true
 
 class IdeaPolicy < ApplicationPolicy
-  # A draft may be written despite a denied reason only when the row is
-  # attributable to a user who could still become permitted, since the check
-  # runs again at publication (see #update?). user_not_signed_in fails both
-  # halves: an author-less draft can never be published, so there is no later
-  # check to defer to.
+  # Denied reasons that still allow a draft to be created. The posting check
+  # runs again when the draft is published (see #update?), and the author can
+  # fix any of these before then: registration unfinished, verification
+  # pending, required profile fields still blank.
+  #
+  # user_not_signed_in is deliberately not here. It only arises where posting
+  # requires an account, and there a signed-out draft is a dead row: publishing
+  # needs owner?, which matches on author_id, and the only route to becoming
+  # that owner is a claim token, which is issued solely where posting is open to
+  # everyone (see IdeasController#create). So nothing would ever re-check it.
+  # Signed-out drafts on everyone-permitted phases are unaffected - there no
+  # reason is denied in the first place.
   DEFERRABLE_DRAFT_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
 
   class Scope < ApplicationPolicy::Scope

--- a/back/app/services/permissions/phase_permissions_service.rb
+++ b/back/app/services/permissions/phase_permissions_service.rb
@@ -110,6 +110,19 @@ module Permissions
     # front/app/utils/actionDescriptors/index.ts.
     FIXABLE_DENIED_REASONS = %w[user_not_signed_in user_not_active user_not_verified user_missing_requirements].freeze
 
+    # Reasons that still allow a draft input to be created, because the posting
+    # check runs again when the draft is published (see IdeaPolicy#update?) and
+    # the author can fix any of these before then.
+    #
+    # user_not_signed_in is deliberately absent. It only arises where posting
+    # requires an account, and there a signed-out draft is a dead row:
+    # publishing needs IdeaPolicy#owner?, which matches on author_id, and the
+    # only route to becoming that owner is a claim token, which is issued solely
+    # where posting is open to everyone (see IdeasController#create). So nothing
+    # would ever re-check it. Signed-out drafts on everyone-permitted phases are
+    # unaffected: on those phases nothing is denied in the first place.
+    DEFERRABLE_DENIED_REASONS = %w[user_not_active user_not_verified user_missing_requirements].freeze
+
     def participation_possible?
       action_descriptors.values.any? do |descriptor|
         descriptor[:enabled] || FIXABLE_DENIED_REASONS.include?(descriptor[:disabled_reason])

--- a/back/spec/acceptance/ideas/ideas_create_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_create_spec.rb
@@ -81,6 +81,24 @@ resource 'Ideas' do
             expect(response_data.dig(:attributes, :claim_token_expires_at)).to eq(idea.claim_token.expires_at.iso8601(3))
           end
         end
+
+        describe 'when saving a draft' do
+          let(:publication_status) { 'draft' }
+          let(:project) do
+            create(:single_phase_ideation_project, phase_attrs: { with_permissions: true }).tap do |project|
+              project
+                .phases.sole
+                .permissions.find_by(action: 'posting_idea')
+                .update!(permitted_by: 'users')
+            end
+          end
+
+          example '[error] Create a draft idea where posting requires sign-in', document: false do
+            expect { do_request }.not_to change(Idea, :count)
+            assert_status 401
+            expect(json_response_body).to include_response_error(:base, 'user_not_signed_in')
+          end
+        end
       end
 
       context 'when resident' do

--- a/back/spec/policies/idea_policy_spec.rb
+++ b/back/spec/policies/idea_policy_spec.rb
@@ -398,6 +398,7 @@ describe IdeaPolicy do
   context 'on a draft native survey response' do
     let(:phase) { create(:active_native_survey_phase, with_permissions: true) }
     let(:project) { phase.project }
+    let(:permission) { phase.permissions.find_by(action: 'posting_idea') }
     let(:idea) do
       create(
         :native_survey_response,
@@ -411,11 +412,60 @@ describe IdeaPolicy do
     context 'for a visitor when posting requires sign-in' do
       let(:user) { nil }
 
+      before { permission.update!(permitted_by: 'users') }
+
+      it 'raises, since an author-less draft could never be published' do
+        expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError, /user_not_signed_in/)
+      end
+    end
+
+    context 'for a visitor when posting is open to everyone' do
+      let(:user) { nil }
+
+      before { permission.update!(permitted_by: 'everyone') }
+
+      it { is_expected.to permit(:create) }
+    end
+
+    context 'for a user who has not met the requirements yet' do
+      let(:user) { create(:user) }
+
       before do
-        phase.permissions.find_by(action: 'posting_idea').update!(permitted_by: 'users')
+        permission.update!(permitted_by: 'users', global_custom_fields: true)
+        create(:custom_field_gender, required: true)
       end
 
       it { is_expected.to permit(:create) }
+    end
+
+    context 'for a resident when posting is limited to admins and moderators' do
+      let(:user) { create(:user) }
+
+      before { permission.update!(permitted_by: 'admins_moderators') }
+
+      it 'raises' do
+        expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError, /user_not_permitted/)
+      end
+    end
+
+    context 'for a resident outside the permitted group' do
+      let(:user) { create(:user) }
+
+      before { permission.update!(permitted_by: 'users', groups: [create(:group)]) }
+
+      it 'raises' do
+        expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError, /user_not_in_group/)
+      end
+    end
+
+    context 'when submission is disabled on the phase' do
+      let(:user) { create(:user) }
+
+      before { phase.update!(submission_enabled: false) }
+
+      it 'raises' do
+        expect { policy.create? }.to raise_error(Pundit::NotAuthorizedError, /posting_disabled/)
+      end
     end
 
     context 'for a resident when the project is not visible to them' do


### PR DESCRIPTION
## What this fixes
Draft inputs skipped the phase's posting permission check.

## What changed
Drafts now go through the same posting permission check as published inputs. Three reasons still let a draft through, because the author can resolve them while filling in the form and the check runs again when the draft is published:

- registration not finished
- verification pending
- required profile fields still blank

Not being signed in no longer lets a draft through. Where posting is genuinely open to everyone no reason is denied in the first place, so participation without an account is unaffected.

## Why it was like that
Not a deliberate design. A refactor in March 2021 changed `return` to `return true` on two lines of this method; one needed it, the other quietly turned "deny drafts" into "allow every draft". No test covered that line before or after, which is why it survived.

## Testing
- The policy example that asserted a signed-out visitor *may* create a draft on a sign-in-required phase now asserts it is refused. Five new examples cover open-to-everyone and unmet-requirements (both still allowed), plus admins-only, group-restricted and posting-disabled (all refused).
- New request spec: no login plus draft status is refused and writes nothing.
- Checked by hand: anonymous submitting on an open phase still works, a signed-in user's answers still save page by page, and a signed-out visitor gets the sign-in prompt with no row written.

## Not included
Rate limiting the create endpoint, clearing existing author-less rows, and draft visibility by direct link — I am considering separate ticket(s) for some/all of these.

# Changelog
## Fixed
- [TAN-8481] Fix create policy for author-less draft ideas. No longer possible for a visitor to create a draft idea when such participation is not permitted.
