### PR TITLE
[NO-TICKET] Performace improvements - defer content builder editor UI

### DIFF
--- a/front/app/component-library/components/ColorPickerInput/ChromePicker.tsx
+++ b/front/app/component-library/components/ColorPickerInput/ChromePicker.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import {
+  ChromePicker as ReactColorChromePicker,
+  ColorResult,
+} from 'react-color';
+
+interface Props {
+  color: string;
+  onChange: (color: ColorResult) => void;
+}
+
+// Separate module so react-color, and the CommonJS lodash build it depends on,
+// load only once a colour picker is opened. The library barrel is imported by
+// most of the app, so a static import here reaches every page including the
+// citizen-facing ones, which have no colour picker at all.
+const ChromePicker = ({ color, onChange }: Props) => (
+  <ReactColorChromePicker
+    disableAlpha={true}
+    color={color}
+    onChange={onChange}
+    onChangeComplete={onChange}
+  />
+);
+
+export default ChromePicker;

--- a/front/app/component-library/components/ColorPickerInput/index.tsx
+++ b/front/app/component-library/components/ColorPickerInput/index.tsx
@@ -1,6 +1,6 @@
-import React, { PureComponent, FormEvent } from 'react';
+import React, { PureComponent, FormEvent, lazy, Suspense } from 'react';
 
-import { ChromePicker, ColorResult } from 'react-color';
+import type { ColorResult } from 'react-color';
 import styled from 'styled-components';
 
 import { colors } from '../../utils/styleUtils';
@@ -8,6 +8,8 @@ import testEnv from '../../utils/testUtils/testEnv';
 import IconTooltip from '../IconTooltip';
 import Input from '../Input';
 import Label from '../Label';
+
+const ChromePicker = lazy(() => import('./ChromePicker'));
 
 const Container = styled.div``;
 
@@ -141,12 +143,9 @@ class ColorPickerInput extends PureComponent<Props, State> {
           {opened && (
             <Popover data-testid={testEnv('popover')}>
               <Cover onClick={this.close} data-testid={testEnv('cover')} />
-              <ChromePicker
-                disableAlpha={true}
-                color={value}
-                onChange={this.change}
-                onChangeComplete={this.change}
-              />
+              <Suspense fallback={null}>
+                <ChromePicker color={value} onChange={this.change} />
+              </Suspense>
             </Popover>
           )}
         </InputWrapper>

--- a/front/app/components/UI/EmojiPicker/Picker.tsx
+++ b/front/app/components/UI/EmojiPicker/Picker.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import data from '@emoji-mart/data';
+import EmojiMartPicker from '@emoji-mart/react';
+
+interface Props {
+  locale: string;
+  onEmojiSelect: (emoji: { native: string }) => void;
+}
+
+// Separate module so the emoji-mart library and its data set load only when the
+// picker is opened. Every widget in the content builder reaches this component
+// through its settings panel, which would otherwise put emoji-mart in the
+// bundle of any page that renders content-builder widgets.
+const Picker = ({ locale, onEmojiSelect }: Props) => (
+  <EmojiMartPicker
+    data={data}
+    perLine={8}
+    locale={locale}
+    onEmojiSelect={onEmojiSelect}
+  />
+);
+
+export default Picker;

--- a/front/app/components/UI/EmojiPicker/index.tsx
+++ b/front/app/components/UI/EmojiPicker/index.tsx
@@ -1,8 +1,6 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, lazy, Suspense } from 'react';
 
 import { Box, Text, colors } from '@citizenlab/cl2-component-library';
-import data from '@emoji-mart/data';
-import Picker from '@emoji-mart/react';
 import styled from 'styled-components';
 
 import useLocale from 'hooks/useLocale';
@@ -13,6 +11,8 @@ import { useIntl } from 'utils/cl-intl';
 
 import { getEmojiMartLocale } from './localeMapping';
 import messages from './messages';
+
+const Picker = lazy(() => import('./Picker'));
 
 const PickerContainer = styled.div`
   position: relative;
@@ -130,15 +130,15 @@ const EmojiPickerInput = ({
       </Box>
       {isOpen && (
         <PopoverContainer placement={placement}>
-          <Picker
-            data={data}
-            perLine={8}
-            locale={getEmojiMartLocale(locale)}
-            onEmojiSelect={(emoji: { native: string }) => {
-              onChange(emoji.native);
-              setIsOpen(false);
-            }}
-          />
+          <Suspense fallback={null}>
+            <Picker
+              locale={getEmojiMartLocale(locale)}
+              onEmojiSelect={(emoji: { native: string }) => {
+                onChange(emoji.native);
+                setIsOpen(false);
+              }}
+            />
+          </Suspense>
         </PopoverContainer>
       )}
     </PickerContainer>

--- a/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
+++ b/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
@@ -1,4 +1,12 @@
-import React, { memo, useState, useCallback, useRef, useEffect } from 'react';
+import React, {
+  memo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+  lazy,
+  Suspense,
+} from 'react';
 
 import {
   IconTooltip,
@@ -11,9 +19,12 @@ import { SupportedLocale, Multiloc } from 'typings';
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useLocale from 'hooks/useLocale';
 
-import QuillEditor, {
-  Props as QuillEditorProps,
-} from 'components/UI/QuillEditor';
+import type { Props as QuillEditorProps } from 'components/UI/QuillEditor';
+
+// Content-builder widgets reach this component from their settings panel, so a
+// static import would put the quill library in the bundle of every page that
+// renders those widgets — including the citizen-facing ones, which never edit.
+const QuillEditor = lazy(() => import('components/UI/QuillEditor'));
 
 import { isNilOrError } from 'utils/helperUtils';
 import { sanitizeForClassname } from 'utils/JSONFormUtils';
@@ -138,17 +149,19 @@ const QuillMutilocWithLocaleSwitcher = memo<Props>((props) => {
         )}
       </LabelContainer>
 
-      <QuillEditor
-        {...quillProps}
-        id={id}
-        ariaLabelledBy={`${sanitizeForClassname(props.id)}-label`}
-        ariaDescribedBy={ariaDescribedBy}
-        ariaInvalid={ariaInvalid}
-        value={valueMultiloc?.[selectedLocale]}
-        onChange={handleValueOnChange}
-        maxCharCount={maxCharCount}
-        minCharCount={minCharCount}
-      />
+      <Suspense fallback={null}>
+        <QuillEditor
+          {...quillProps}
+          id={id}
+          ariaLabelledBy={`${sanitizeForClassname(props.id)}-label`}
+          ariaDescribedBy={ariaDescribedBy}
+          ariaInvalid={ariaInvalid}
+          value={valueMultiloc?.[selectedLocale]}
+          onChange={handleValueOnChange}
+          maxCharCount={maxCharCount}
+          minCharCount={minCharCount}
+        />
+      </Suspense>
     </Container>
   );
 });

--- a/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
+++ b/front/app/components/UI/QuillEditor/QuillMultilocWithLocaleSwitcher.tsx
@@ -1,12 +1,4 @@
-import React, {
-  memo,
-  useState,
-  useCallback,
-  useRef,
-  useEffect,
-  lazy,
-  Suspense,
-} from 'react';
+import React, { memo, useState, useCallback, useRef, useEffect } from 'react';
 
 import {
   IconTooltip,
@@ -19,12 +11,9 @@ import { SupportedLocale, Multiloc } from 'typings';
 import useAppConfigurationLocales from 'hooks/useAppConfigurationLocales';
 import useLocale from 'hooks/useLocale';
 
-import type { Props as QuillEditorProps } from 'components/UI/QuillEditor';
-
-// Content-builder widgets reach this component from their settings panel, so a
-// static import would put the quill library in the bundle of every page that
-// renders those widgets — including the citizen-facing ones, which never edit.
-const QuillEditor = lazy(() => import('components/UI/QuillEditor'));
+import QuillEditor, {
+  Props as QuillEditorProps,
+} from 'components/UI/QuillEditor';
 
 import { isNilOrError } from 'utils/helperUtils';
 import { sanitizeForClassname } from 'utils/JSONFormUtils';
@@ -149,19 +138,17 @@ const QuillMutilocWithLocaleSwitcher = memo<Props>((props) => {
         )}
       </LabelContainer>
 
-      <Suspense fallback={null}>
-        <QuillEditor
-          {...quillProps}
-          id={id}
-          ariaLabelledBy={`${sanitizeForClassname(props.id)}-label`}
-          ariaDescribedBy={ariaDescribedBy}
-          ariaInvalid={ariaInvalid}
-          value={valueMultiloc?.[selectedLocale]}
-          onChange={handleValueOnChange}
-          maxCharCount={maxCharCount}
-          minCharCount={minCharCount}
-        />
-      </Suspense>
+      <QuillEditor
+        {...quillProps}
+        id={id}
+        ariaLabelledBy={`${sanitizeForClassname(props.id)}-label`}
+        ariaDescribedBy={ariaDescribedBy}
+        ariaInvalid={ariaInvalid}
+        value={valueMultiloc?.[selectedLocale]}
+        onChange={handleValueOnChange}
+        maxCharCount={maxCharCount}
+        minCharCount={minCharCount}
+      />
     </Container>
   );
 });

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/Editor.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/Editor.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy, Suspense } from 'react';
 
 import { colors } from '@citizenlab/cl2-component-library';
 import {
@@ -9,7 +9,10 @@ import {
 
 import { ScopedDndContext } from 'components/admin/ResourceList/SortableList';
 
-import RenderNode from './RenderNode';
+// Only the builder renders nodes through RenderNode; previews use PlainDiv.
+// A static import would ship the builder's node chrome to citizen pages, which
+// render the same widgets in preview mode.
+const RenderNode = lazy(() => import('./RenderNode'));
 
 type EditorProps = {
   isPreview: boolean;
@@ -22,6 +25,12 @@ type EditorProps = {
 const PlainDiv = ({ render }) => {
   return <div>{render}</div>;
 };
+
+const LazyRenderNode = ({ render }: { render: React.ReactNode }) => (
+  <Suspense fallback={null}>
+    <RenderNode render={render} />
+  </Suspense>
+);
 
 const Editor: React.FC<EditorProps> = ({
   isPreview,
@@ -37,7 +46,7 @@ const Editor: React.FC<EditorProps> = ({
         error: 'red',
         transition: 'none',
       }}
-      onRender={isPreview ? PlainDiv : RenderNode}
+      onRender={isPreview ? PlainDiv : LazyRenderNode}
       onNodesChange={(data) => {
         onNodesChange && onNodesChange(data.getSerializedNodes());
       }}


### PR DESCRIPTION
Performance gains: project LCP 13168ms → 12092ms (−8.2%), home 14924ms → 13940ms (−6.6%). 

# Changelog
## Technical 
- Lazy load content builder libraries (quill, emoji-mart, react-color)

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
