### PR TITLE
[TAN-8489] Add default vertical spacing between project page widgets

### DIFF
--- a/front/app/components/DescriptionBuilder/Editor/Editor.tsx
+++ b/front/app/components/DescriptionBuilder/Editor/Editor.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { colors } from '@citizenlab/cl2-component-library';
+import { Box, colors } from '@citizenlab/cl2-component-library';
 import {
   Editor as CraftEditor,
   SerializedNodes,
@@ -9,6 +9,8 @@ import {
 
 import RenderNode from 'containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode';
 
+import { useVerticalRhythmMargin } from 'components/admin/ContentBuilder/verticalRhythm';
+
 type EditorProps = {
   isPreview: boolean;
   resolver?: Resolver;
@@ -16,9 +18,11 @@ type EditorProps = {
   children?: React.ReactNode;
 };
 
-// Without this, craftjs crashes.
+// Without a wrapper element, craftjs crashes.
 const PlainDiv = ({ render }) => {
-  return <div>{render}</div>;
+  const marginTop = useVerticalRhythmMargin();
+
+  return <Box mt={marginTop}>{render}</Box>;
 };
 
 const Editor: React.FC<EditorProps> = ({

--- a/front/app/components/ProjectPageBuilder/Editor/index.tsx
+++ b/front/app/components/ProjectPageBuilder/Editor/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Box } from '@citizenlab/cl2-component-library';
 import { SerializedNodes } from '@craftjs/core';
 
+import { VerticalRhythmContext } from 'components/admin/ContentBuilder/verticalRhythm';
 import AboutBox from 'components/admin/ContentBuilder/Widgets/AboutBox';
 import AccordionMultiloc from 'components/admin/ContentBuilder/Widgets/AccordionMultiloc';
 import ButtonMultiloc from 'components/admin/ContentBuilder/Widgets/ButtonMultiloc';
@@ -38,38 +39,40 @@ type EditorProps = {
 
 const Editor = ({ onNodesChange, isPreview, children }: EditorProps) => {
   return (
-    <BaseEditor
-      resolver={{
-        Box,
-        Container,
-        TwoColumn,
-        ThreeColumn,
-        TextMultiloc,
-        ImageMultiloc,
-        IframeMultiloc,
-        FileAttachment,
-        AboutBox,
-        AccordionMultiloc,
-        WhiteSpace,
-        InfoWithAccordions,
-        RichTextMultiloc,
-        HtmlBlockMultiloc,
-        ImageTextCards,
-        ButtonMultiloc,
-        PageLink,
-        PhasesWidget,
-        EventsWidget,
-        ExtraSurveysWidget,
-        ProjectBanner,
-        ProjectTitle,
-        ProjectPageRoot,
-        ProjectPageBody,
-      }}
-      isPreview={isPreview}
-      onNodesChange={onNodesChange}
-    >
-      {children}
-    </BaseEditor>
+    <VerticalRhythmContext.Provider value={true}>
+      <BaseEditor
+        resolver={{
+          Box,
+          Container,
+          TwoColumn,
+          ThreeColumn,
+          TextMultiloc,
+          ImageMultiloc,
+          IframeMultiloc,
+          FileAttachment,
+          AboutBox,
+          AccordionMultiloc,
+          WhiteSpace,
+          InfoWithAccordions,
+          RichTextMultiloc,
+          HtmlBlockMultiloc,
+          ImageTextCards,
+          ButtonMultiloc,
+          PageLink,
+          PhasesWidget,
+          EventsWidget,
+          ExtraSurveysWidget,
+          ProjectBanner,
+          ProjectTitle,
+          ProjectPageRoot,
+          ProjectPageBody,
+        }}
+        isPreview={isPreview}
+        onNodesChange={onNodesChange}
+      >
+        {children}
+      </BaseEditor>
+    </VerticalRhythmContext.Provider>
   );
 };
 

--- a/front/app/components/admin/ContentBuilder/verticalRhythm.test.ts
+++ b/front/app/components/admin/ContentBuilder/verticalRhythm.test.ts
@@ -1,0 +1,29 @@
+import { getBoundaryMargin } from './verticalRhythm';
+
+describe('getBoundaryMargin', () => {
+  it('returns undefined when either role is missing', () => {
+    expect(getBoundaryMargin(undefined, 'flow', false)).toBeUndefined();
+    expect(getBoundaryMargin('flow', undefined, false)).toBeUndefined();
+  });
+
+  it('keeps consecutive bands flush', () => {
+    expect(getBoundaryMargin('band', 'band', false)).toBe('0px');
+  });
+
+  it('separates bands from other roles with the section margin', () => {
+    expect(getBoundaryMargin('flow', 'band', false)).toBe('48px');
+    expect(getBoundaryMargin('band', 'card', false)).toBe('48px');
+    expect(getBoundaryMargin('card', 'band', true)).toBe('32px');
+  });
+
+  it('keeps consecutive cards tight', () => {
+    expect(getBoundaryMargin('card', 'card', false)).toBe('12px');
+    expect(getBoundaryMargin('card', 'card', true)).toBe('8px');
+  });
+
+  it('uses the flow margin for remaining boundaries', () => {
+    expect(getBoundaryMargin('flow', 'flow', false)).toBe('32px');
+    expect(getBoundaryMargin('flow', 'card', false)).toBe('32px');
+    expect(getBoundaryMargin('card', 'flow', true)).toBe('24px');
+  });
+});

--- a/front/app/components/admin/ContentBuilder/verticalRhythm.ts
+++ b/front/app/components/admin/ContentBuilder/verticalRhythm.ts
@@ -1,0 +1,83 @@
+import { createContext, useContext } from 'react';
+
+import { useBreakpoint } from '@citizenlab/cl2-component-library';
+import { useEditor, useNode } from '@craftjs/core';
+
+// Spacing between stacked widgets is a property of the boundary between two
+// roles, not of a widget: https://govocal-prototypes.pages.dev/playground/fo-spacing-rhythm/
+export const VerticalRhythmContext = createContext(false);
+
+type WidgetRole = 'flow' | 'card' | 'band';
+
+const WIDGET_ROLES: Record<string, WidgetRole> = {
+  TextMultiloc: 'flow',
+  RichTextMultiloc: 'flow',
+  ImageMultiloc: 'flow',
+  IframeMultiloc: 'flow',
+  ButtonMultiloc: 'flow',
+  WhiteSpace: 'flow',
+  HtmlBlockMultiloc: 'flow',
+  FileAttachment: 'flow',
+  PageLink: 'flow',
+  TwoColumn: 'flow',
+  ThreeColumn: 'flow',
+  AccordionMultiloc: 'card',
+  AboutBox: 'card',
+  ImageTextCards: 'card',
+  InfoWithAccordions: 'card',
+  ExtraSurveysWidget: 'card',
+  PhasesWidget: 'band',
+  EventsWidget: 'band',
+};
+
+const BOUNDARY_MARGINS = {
+  tight: { desktop: '12px', phone: '8px' },
+  flow: { desktop: '32px', phone: '24px' },
+  section: { desktop: '48px', phone: '32px' },
+} as const;
+
+export const getBoundaryMargin = (
+  previousRole: WidgetRole | undefined,
+  role: WidgetRole | undefined,
+  isPhone: boolean
+): string | undefined => {
+  if (!previousRole || !role) return undefined;
+
+  const size = isPhone ? 'phone' : 'desktop';
+
+  if (previousRole === 'band' && role === 'band') return '0px';
+  if (previousRole === 'band' || role === 'band') {
+    return BOUNDARY_MARGINS.section[size];
+  }
+  if (previousRole === 'card' && role === 'card') {
+    return BOUNDARY_MARGINS.tight[size];
+  }
+  return BOUNDARY_MARGINS.flow[size];
+};
+
+// Margin above the current craft node, derived from the roles of the node and
+// its previous sibling. Undefined when rhythm is off for this builder, the
+// node has no role (regions, columns' inner containers), or it comes first.
+export const useVerticalRhythmMargin = (): string | undefined => {
+  const rhythmEnabled = useContext(VerticalRhythmContext);
+  const isPhone = useBreakpoint('phone');
+  const { id, name, parent } = useNode((node) => ({
+    name: node.data.name,
+    parent: node.data.parent,
+  }));
+  const { query } = useEditor();
+
+  if (!rhythmEnabled || !parent) return undefined;
+
+  const siblingIds = query.node(parent).get().data.nodes;
+  const index = siblingIds.indexOf(id);
+  if (index <= 0) return undefined;
+
+  const previousName = query.node(siblingIds[index - 1]).get().data.name;
+
+  return getBoundaryMargin(
+    WIDGET_ROLES[previousName],
+    WIDGET_ROLES[name],
+    isPhone
+  );
+};

--- a/front/app/components/admin/ContentBuilder/verticalRhythm.ts
+++ b/front/app/components/admin/ContentBuilder/verticalRhythm.ts
@@ -7,6 +7,9 @@ import { useEditor, useNode } from '@craftjs/core';
 // roles, not of a widget: https://govocal-prototypes.pages.dev/playground/fo-spacing-rhythm/
 export const VerticalRhythmContext = createContext(false);
 
+// flow: inline content that reads as one column of text (paragraphs, images,
+// buttons). card: a visually bounded box (accordions, info boxes). band: a
+// full-width section with its own background (phases, events).
 type WidgetRole = 'flow' | 'card' | 'band';
 
 const WIDGET_ROLES: Record<string, WidgetRole> = {

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode/index.tsx
@@ -6,6 +6,7 @@ import { MessageDescriptor } from 'react-intl';
 import styled from 'styled-components';
 
 import messages from 'components/admin/ContentBuilder/messages';
+import { useVerticalRhythmMargin } from 'components/admin/ContentBuilder/verticalRhythm';
 
 import { FormattedMessage } from 'utils/cl-intl';
 
@@ -26,6 +27,7 @@ const StyledBox = styled(Box)`
 const CONTAINER = 'Container';
 
 const RenderNode = ({ render }) => {
+  const rhythmMarginTop = useVerticalRhythmMargin();
   const {
     id,
     name,
@@ -138,7 +140,8 @@ const RenderNode = ({ render }) => {
           ? colors.divider
           : 'transparent'
       }
-      my="4px"
+      mt={rhythmMarginTop ?? '4px'}
+      mb={rhythmMarginTop === undefined ? '4px' : '0px'}
       isRoot={id === ROOT_NODE}
     >
       {nodeLabelIsVisible && (


### PR DESCRIPTION
# Changelog

## Fixed
- Project pages no longer render the description flush against the section below it: all content widgets now get a sensible default vertical gap based on what meets what (regular content, grouped cards, or full-width sections like Phases/Events), so admins no longer need to insert White space widgets by hand existing ones keep working and just add extra room. The admin builder canvas shows the same spacing as the published page. Spacing values follow the [front-office vertical rhythm spec](https://govocal-prototypes.pages.dev/playground/fo-spacing-rhythm/).

