### PR TITLE
[TAN-8413] Strip markup from names before the user slug is built

### DIFF
--- a/back/app/services/user_slug_service.rb
+++ b/back/app/services/user_slug_service.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # NOTE: Apr 2026 - Slug is still generated for users but no longer used in the codebase.
 # It will be removed in the near future when we are sure there is no further use for it.
 class UserSlugService

--- a/back/app/services/user_slug_service.rb
+++ b/back/app/services/user_slug_service.rb
@@ -3,7 +3,7 @@
 class UserSlugService
   def generate_slug(user, string)
     string = plain_text(string)
-    # A name of nothing but markup strips to blank, and a blank slug fails validation.
+    # A blank slug fails validation.
     return SecureRandom.uuid if abbreviated_user_names? || string.blank?
 
     SlugService.new.generate_slug user, string
@@ -18,9 +18,8 @@ class UserSlugService
       # slugs. Therefore we generate the slugs manually
       plain_names = unpersisted_users.index_with { |user| plain_text(user.full_name).to_s }
       slugs = SlugService.new.generate_slugs(unpersisted_users) { |user| plain_names[user] }
-      # Guard on the name, not the slug: a blank name still comes back as '-1' once a second one
-      # collides with it. An invitee with nothing to build a slug from keeps none - they are
-      # invite_pending, so the slug validation is off, and accepting the invite generates one.
+      # Guard on the name, not the slug: SlugService returns '' for the first blank name
+      # and '-1' for the next. A pending invitee skips slug validation and gets one on accept.
       unpersisted_users.zip(slugs) do |(user, slug)|
         user.slug = slug if plain_names[user].present?
       end
@@ -29,9 +28,8 @@ class UserSlugService
 
   private
 
-  # A name reaches us before `User` sanitises its own, and two of the three callers never go through
-  # `User` at all: an invite assigns the slug outside the callback chain, and the users controller
-  # builds the name straight from the request. So strip here rather than trusting the caller.
+  # Two of the three callers never reach `User`'s own sanitisation: an invite assigns the slug
+  # outside the callback chain, and the users controller builds the name from the request.
   def plain_text(name)
     SanitizationService.new.strip_to_plain_text(name)
   end

--- a/back/app/services/user_slug_service.rb
+++ b/back/app/services/user_slug_service.rb
@@ -4,7 +4,9 @@
 # It will be removed in the near future when we are sure there is no further use for it.
 class UserSlugService
   def generate_slug(user, string)
-    return SecureRandom.uuid if abbreviated_user_names? || string == ''
+    string = plain_text(string)
+    # A name of nothing but markup strips to blank, and a blank slug fails validation.
+    return SecureRandom.uuid if abbreviated_user_names? || string.blank?
 
     SlugService.new.generate_slug user, string
   end
@@ -16,13 +18,25 @@ class UserSlugService
       # Since invites will later be created in a single transaction, the
       # normal mechanism for generating slugs could result in non-unique
       # slugs. Therefore we generate the slugs manually
-      unpersisted_users.zip(SlugService.new.generate_slugs(unpersisted_users, &:full_name)) do |(user, slug)|
-        user.slug = slug if user.full_name.present?
+      plain_names = unpersisted_users.index_with { |user| plain_text(user.full_name).to_s }
+      slugs = SlugService.new.generate_slugs(unpersisted_users) { |user| plain_names[user] }
+      # Guard on the name, not the slug: a blank name still comes back as '-1' once a second one
+      # collides with it. An invitee with nothing to build a slug from keeps none - they are
+      # invite_pending, so the slug validation is off, and accepting the invite generates one.
+      unpersisted_users.zip(slugs) do |(user, slug)|
+        user.slug = slug if plain_names[user].present?
       end
     end
   end
 
   private
+
+  # A name reaches us before `User` sanitises its own, and two of the three callers never go through
+  # `User` at all: an invite assigns the slug outside the callback chain, and the users controller
+  # builds the name straight from the request. So strip here rather than trusting the caller.
+  def plain_text(name)
+    SanitizationService.new.strip_to_plain_text(name)
+  end
 
   def abbreviated_user_names?
     AppConfiguration.instance.feature_activated?('abbreviated_user_names')

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -2091,6 +2091,17 @@ resource 'Users' do
             expect(user.reload.last_name).to eq 'NewLastName'
             expect(user.reload.slug).to eq 'newfirstname-newlastname'
           end
+
+          # The slug is built from the request here, not from the stored name.
+          context 'when the name carries markup' do
+            let(:first_name) { '<b>NewFirstName</b>' }
+
+            example_request 'Keeps the markup out of both the name and the slug', document: false do
+              assert_status 200
+              expect(user.reload.first_name).to eq 'NewFirstName'
+              expect(user.reload.slug).to eq 'newfirstname-newlastname'
+            end
+          end
         end
       end
 

--- a/back/spec/models/user_spec.rb
+++ b/back/spec/models/user_spec.rb
@@ -1483,6 +1483,26 @@ RSpec.describe User do
     end
   end
 
+  describe 'slug generated from the name' do
+    it 'keeps markup in the name out of the slug' do
+      user = create(:user, slug: nil, first_name: '<b>Bob</b>', last_name: 'Smith')
+
+      expect(user.slug).to eq 'bob-smith'
+    end
+
+    it 'keeps a payload in the name out of the slug' do
+      user = create(:user, slug: nil, first_name: '<img src=x onerror=alert(1)>Bob', last_name: 'Smith')
+
+      expect(user.slug).to eq 'bob-smith'
+    end
+
+    it 'is still valid when the name is nothing but markup' do
+      user = create(:user, slug: nil, first_name: '<b></b>', last_name: '<i></i>')
+
+      expect(user.slug).to match(Sluggable::SLUG_REGEX)
+    end
+  end
+
   describe '#last_name' do
     it 'does not allow HTML in the name' do
       user = described_class.new

--- a/back/spec/services/user_slug_service_spec.rb
+++ b/back/spec/services/user_slug_service_spec.rb
@@ -39,6 +39,17 @@ describe UserSlugService do
 
       expect(unpersisted_users.map(&:slug)).to eq [nil]
     end
+
+    it 'leaves both invitees without a slug when neither name survives stripping' do
+      unpersisted_users = [
+        build(:user, invite_status: 'pending', first_name: '<b></b>', last_name: '<i></i>'),
+        build(:user, invite_status: 'pending', first_name: '<i></i>', last_name: '<b></b>')
+      ]
+
+      service.generate_slugs unpersisted_users
+
+      expect(unpersisted_users.map(&:slug)).to eq [nil, nil]
+    end
   end
 
   describe 'when Abbreviated User Names feature enabled' do

--- a/back/spec/services/user_slug_service_spec.rb
+++ b/back/spec/services/user_slug_service_spec.rb
@@ -5,6 +5,42 @@ require 'rails_helper'
 describe UserSlugService do
   let(:service) { described_class.new }
 
+  describe 'names carrying markup' do
+    it 'builds a slug from the name with its markup stripped' do
+      user = build(:user, first_name: '<b>Jose</b>', last_name: 'Moura')
+
+      expect(service.generate_slug(user, user.full_name)).to eq 'jose-moura'
+    end
+
+    it 'keeps none of a payload in the slug' do
+      user = build(:user, first_name: '<img src=x onerror=alert(1)>Jose', last_name: 'Moura')
+
+      expect(service.generate_slug(user, user.full_name)).to eq 'jose-moura'
+    end
+
+    it 'strips markup when bulk generating slugs' do
+      unpersisted_users = [build(:user, first_name: '<b>Jose</b>', last_name: 'Moura')]
+
+      service.generate_slugs unpersisted_users
+
+      expect(unpersisted_users.map(&:slug)).to eq %w[jose-moura]
+    end
+
+    it 'falls back to a uuid when the name is nothing but markup' do
+      user = build(:user, first_name: '<b></b>', last_name: '<i></i>')
+
+      expect(service.generate_slug(user, user.full_name)).to match(Sluggable::SLUG_REGEX)
+    end
+
+    it 'leaves an invitee whose name is nothing but markup without a slug' do
+      unpersisted_users = [build(:user, invite_status: 'pending', first_name: '<b></b>', last_name: '<i></i>')]
+
+      service.generate_slugs unpersisted_users
+
+      expect(unpersisted_users.map(&:slug)).to eq [nil]
+    end
+  end
+
   describe 'when Abbreviated User Names feature enabled' do
     before { SettingsService.new.activate_feature! 'abbreviated_user_names' }
 


### PR DESCRIPTION
# Changelog
## Technical
- [TAN-8413] Strip markup from names before the user slug is built
