### PR TITLE
[TAN-8413] Small tweaks to BE sanitisation

### DIFF
--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -11,6 +11,9 @@ class SanitizationService
 
   NBSP = "\u00A0"
 
+  # What `linkify` builds an href from, and so all `replace_links_with_urls` will put back.
+  LINKIFIABLE_HREF = %r{\A(https?://|mailto:)}i
+
   SANITIZER = Rails::Html::SafeListSanitizer.new
 
   private_constant :SANITIZER
@@ -93,6 +96,27 @@ class SanitizationService
     html = sanitize(html, features)
     html = remove_empty_trailing_tags(html)
     linkify(html)
+  end
+
+  # Replaces every link with its own URL as the text it shows.
+  #
+  # A pipeline without `:link` drops the anchors it is given and lets `linkify` build new ones out of
+  # the visible text, so a reader always sees the address they are about to follow. That holds only
+  # while the text is the address. Run this first where it is not - machine translation translates a
+  # link's label - and the rebuild has the URL to find again.
+  #
+  # Only the schemes `linkify` itself produces are restored; anything else keeps today's outcome, the
+  # anchor gone and its text left behind.
+  def replace_links_with_urls(html)
+    return html if html.blank?
+
+    doc = Nokogiri::HTML.fragment(html)
+    doc.css('a[href]').each do |link|
+      next unless link['href'].match?(LINKIFIABLE_HREF)
+
+      link.replace(Nokogiri::XML::Text.new(link['href'], link.document))
+    end
+    doc.to_s
   end
 
   def sanitize_body_multiloc(multiloc, features)

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -9,6 +9,8 @@ class SanitizationService
   # Each `strip_to_plain_text` pass peels one layer of entity encoding; real text settles in 1-3.
   PLAIN_TEXT_PASSES = 5
 
+  NBSP = "\u00A0"
+
   SANITIZER = Rails::Html::SafeListSanitizer.new
 
   private_constant :SANITIZER
@@ -102,13 +104,17 @@ class SanitizationService
   # `full_sanitizer` alone entity-encodes what it keeps ("Fish & chips" -> "Fish &amp; chips"), so
   # decode after each pass and repeat until the value settles - otherwise a payload survives by
   # hiding behind its own encoding (`&lt;script&gt;`).
+  #
+  # `CGI.unescapeHTML` decodes numeric references and the five XML names, but the HTML5 serializer
+  # also writes U+00A0 as `&nbsp;`, so that one needs decoding by hand. Callers render the result as
+  # text and slug it, so an entity left standing reaches the reader as six literal characters.
   def strip_to_plain_text(text)
     return nil if text.nil?
 
     full_sanitizer = ActionView::Base.full_sanitizer
 
     PLAIN_TEXT_PASSES.times do
-      decoded = CGI.unescapeHTML(full_sanitizer.sanitize(text))
+      decoded = CGI.unescapeHTML(full_sanitizer.sanitize(text)).gsub('&nbsp;', NBSP)
       return decoded if decoded == text
 
       text = decoded

--- a/back/app/services/sanitization_service.rb
+++ b/back/app/services/sanitization_service.rb
@@ -100,13 +100,9 @@ class SanitizationService
 
   # Replaces every link with its own URL as the text it shows.
   #
-  # A pipeline without `:link` drops the anchors it is given and lets `linkify` build new ones out of
-  # the visible text, so a reader always sees the address they are about to follow. That holds only
-  # while the text is the address. Run this first where it is not - machine translation translates a
-  # link's label - and the rebuild has the URL to find again.
-  #
-  # Only the schemes `linkify` itself produces are restored; anything else keeps today's outcome, the
-  # anchor gone and its text left behind.
+  # A pipeline without `:link` rebuilds links from the visible text, so a link always shows where it
+  # goes - but only while that text is the URL, which translating a label breaks. Run this first to
+  # give the rebuild its URL back. Only the schemes `linkify` builds are restored.
   def replace_links_with_urls(html)
     return html if html.blank?
 

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -26,7 +26,8 @@ module MachineTranslations
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
 
     # Provider HTML, rendered raw on the front end. Running the source field's own pipeline keeps a
-    # translation from being more permissive than the text it was translated from.
+    # translation from being more permissive than the text it was translated from. Links in a comment
+    # body are the one exception, for the reason given on that pipeline.
     before_validation :sanitize_translation, if: :translation
 
     PLAIN_TEXT_PIPELINE = ->(text) { SanitizationService.new.strip_to_plain_text(text) }
@@ -37,7 +38,14 @@ module MachineTranslations
     SOURCE_SANITIZE_PIPELINES = {
       %w[Idea title_multiloc] => PLAIN_TEXT_PIPELINE,
       %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
-      %w[Comment body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Comment::BODY_SANITIZE_FEATURES) }
+      # A comment body omits `:link`, so its own rule rebuilds every link from the visible text and a
+      # reader always sees where a link goes. A provider translates that text, leaving the rule
+      # nothing to find and the link deleted. Put each URL back as its own text first, so the same
+      # rule runs on a translation and still returns a link that shows its own address.
+      %w[Comment body_multiloc] => lambda { |html|
+        service = SanitizationService.new
+        service.sanitize_body(service.replace_links_with_urls(html), Comment::BODY_SANITIZE_FEATURES)
+      }
     }.freeze
 
     private

--- a/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
+++ b/back/engines/commercial/machine_translations/app/models/machine_translations/machine_translation.rb
@@ -26,8 +26,7 @@ module MachineTranslations
     validates :locale_to, presence: true, inclusion: { in: CL2_SUPPORTED_LOCALES.map(&:to_s) } # , message: :unsupported_locales }
 
     # Provider HTML, rendered raw on the front end. Running the source field's own pipeline keeps a
-    # translation from being more permissive than the text it was translated from. Links in a comment
-    # body are the one exception, for the reason given on that pipeline.
+    # translation from being more permissive than the text it was translated from.
     before_validation :sanitize_translation, if: :translation
 
     PLAIN_TEXT_PIPELINE = ->(text) { SanitizationService.new.strip_to_plain_text(text) }
@@ -38,10 +37,8 @@ module MachineTranslations
     SOURCE_SANITIZE_PIPELINES = {
       %w[Idea title_multiloc] => PLAIN_TEXT_PIPELINE,
       %w[Idea body_multiloc] => ->(html) { SanitizationService.new.sanitize_body(html, Idea::BODY_SANITIZE_FEATURES) },
-      # A comment body omits `:link`, so its own rule rebuilds every link from the visible text and a
-      # reader always sees where a link goes. A provider translates that text, leaving the rule
-      # nothing to find and the link deleted. Put each URL back as its own text first, so the same
-      # rule runs on a translation and still returns a link that shows its own address.
+      # A comment rebuilds its links from the visible text, which a provider translates. Restoring
+      # each URL as its own text first leaves the rule something to find, so the link survives.
       %w[Comment body_multiloc] => lambda { |html|
         service = SanitizationService.new
         service.sanitize_body(service.replace_links_with_urls(html), Comment::BODY_SANITIZE_FEATURES)

--- a/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
+++ b/back/engines/commercial/machine_translations/spec/models/machine_translations/machine_translation_spec.rb
@@ -30,15 +30,52 @@ describe MachineTranslations::MachineTranslation do
       expect(mt.translation).to eq '<a href="https://good.example" rel="nofollow">x</a>'
     end
 
-    # A comment body allows mentions only, but linkify runs after sanitize - so stored bodies do
-    # contain anchors, and a translation of one must keep them.
-    it 'keeps linkified URLs in a comment body translation' do
-      comment = create(:comment)
-      mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
-        translation: '<p>Voir <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a> ici</p>')
-      expect(mt.translation).to eq(
-        '<p>Voir <a href="https://example.com" target="_blank" rel="noreferrer noopener nofollow">https://example.com</a> ici</p>'
-      )
+    # Every example here translates one comment, spelled out rather than left to the factory. Its
+    # author typed a bare URL and `linkify` wrapped it on write, so the stored body - which is what a
+    # provider is handed - carries the URL as its own label. The comment pipeline rebuilds links by
+    # reading that label, and a provider breaks it by translating the label along with the prose.
+    context 'a comment body translation' do
+      let(:comment) { create(:comment, body_multiloc: { 'nl-BE' => 'Zie https://boerenvreugd.nl' }) }
+      let(:stored_link) { 'Zie <a href="https://boerenvreugd.nl" target="_blank" rel="noreferrer noopener nofollow">https://boerenvreugd.nl</a>' }
+
+      # Dutch comment, Serbian translation - the pairing that transliterates a URL rather than
+      # leaving it alone. Sanitizing does not read either locale; they are here to be read by people.
+      def translation_of(html)
+        create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
+          locale_to: 'sr-SP', translation: html).translation
+      end
+
+      it 'translates a comment whose link label is the URL itself' do
+        expect(comment.body_multiloc['nl-BE']).to eq stored_link
+      end
+
+      it 'keeps a link the provider returned untranslated' do
+        expect(translation_of(stored_link)).to eq stored_link
+      end
+
+      it 'puts back the URL a provider transliterated, as the text as well' do
+        translated = 'Видети <a href="https://boerenvreugd.nl" target="_blank" rel="noreferrer noopener nofollow">хттпс://боеренвреугд.нл</a>'
+        expect(translation_of(translated)).to eq 'Видети <a href="https://boerenvreugd.nl" target="_blank" rel="noreferrer noopener nofollow">https://boerenvreugd.nl</a>'
+      end
+
+      # The href is restored as the text, then the link is rebuilt from that text - so a translation
+      # shows the address it goes to, exactly as a comment does. A provider that sends an anchor
+      # pointing away from the label cannot hide behind it: the label becomes the real address.
+      it 'shows the address a link goes to, not the one its label claimed' do
+        expect(translation_of('<a href="https://evil.example">https://google.example</a>'))
+          .to eq '<a href="https://evil.example" target="_blank" rel="noreferrer noopener nofollow">https://evil.example</a>'
+      end
+
+      # Only the schemes `linkify` builds are put back, so this href is never restored as text and the
+      # anchor goes the way any other unsupported markup goes.
+      it 'still drops a javascript: href' do
+        expect(translation_of('<p>hi</p><a href="javascript:alert(1)">click</a>')).to eq '<p>hi</p>click'
+      end
+
+      it 'still strips markup a comment body may not carry, links aside' do
+        expect(translation_of('<p>hi</p><img src=y onerror=alert(1)><script>alert(1)</script>'))
+          .to eq '<p>hi</p>alert(1)'
+      end
     end
 
     context 'a field with no pipeline of its own' do
@@ -62,15 +99,6 @@ describe MachineTranslations::MachineTranslation do
       allow(ErrorReporter).to receive(:report_msg)
       create(:machine_translation, attribute_name: 'title_multiloc')
       expect(ErrorReporter).not_to have_received(:report_msg)
-    end
-
-    it 'rewrites a spoofed anchor in a comment body translation to its visible text' do
-      comment = create(:comment)
-      mt = create(:machine_translation, translatable: comment, attribute_name: 'body_multiloc',
-        translation: '<p>hi</p><a href="https://evil.example">https://google.example</a><img src=y onerror=alert(1)>')
-      expect(mt.translation).to eq(
-        '<p>hi</p><a href="https://google.example" target="_blank" rel="noreferrer noopener nofollow">https://google.example</a>'
-      )
     end
   end
 end

--- a/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
+++ b/back/lib/tasks/single_use/20260810_purge_stored_xss.rake
@@ -16,7 +16,8 @@
 #
 # A row is written only when processing actually changes it, so clean content is left untouched
 # and re-runs are no-ops. Writes use `update_columns` to avoid re-running unrelated validations on
-# legacy rows.
+# legacy rows. A row whose only change is the dead `data-user-slug` mention attribute is left alone
+# too, and counted in the summary.
 #
 # `TenantScript` owns the dry run, the tenant loop and the report. Deleted tenants stay out; every
 # other tenant can still serve content, so all of them are in scope.
@@ -45,6 +46,21 @@ namespace :single_use do
     ].freeze
 
     affected = [] # rows for the summary: { host:, model:, attribute: }
+    slug_only_skipped = 0
+
+    # `data-user-slug` left the mention allowlist in April 2026, so re-running the write path over a
+    # legacy row strips it. Nothing reads it - the front end finds a mention by `data-user-id`, and
+    # comments written since have gone without it - so removing it rewrites a row that carries no
+    # payload. Left in, these outnumber the real findings by seven to one and bury them.
+    slug_attribute = /\s*data-user-slug="[^"]*"/
+    slug_only = lambda do |old_value, new_value|
+      stripped = if old_value.is_a?(String)
+        old_value.gsub(slug_attribute, '')
+      else
+        old_value.transform_values { |value| value&.gsub(slug_attribute, '') }
+      end
+      stripped != old_value && stripped == new_value
+    end
 
     # Re-sanitises one attribute across a scope, reporting and writing only real changes.
     purge = lambda do |tenant, script, scope, attribute, sanitizer, model_label|
@@ -52,6 +68,11 @@ namespace :single_use do
         old_value = record.public_send(attribute)
         new_value = sanitizer.call(old_value)
         next if new_value == old_value
+
+        if slug_only.call(old_value, new_value)
+          slug_only_skipped += 1
+          next
+        end
 
         script.reporter.add_change(
           old_value, new_value,
@@ -70,6 +91,9 @@ namespace :single_use do
     end
 
     summary = lambda do |_script|
+      if slug_only_skipped.positive?
+        puts "\n   ⏭️  Left alone: #{slug_only_skipped} row(s) whose only change was the dead mention attribute."
+      end
       next if affected.empty?
 
       puts "\n   🧹 Purged rows by tenant:"
@@ -112,6 +136,11 @@ namespace :single_use do
         mt.send(:sanitize_translation)
         new_value = mt.translation
         next if new_value == old_value
+
+        if slug_only.call(old_value, new_value)
+          slug_only_skipped += 1
+          next
+        end
 
         script.reporter.add_change(
           old_value, new_value,

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -470,6 +470,10 @@ describe SanitizationService do
   end
 
   describe 'strip_to_plain_text' do
+    # Built by escape rather than pasted, so the character survives every editor this file passes
+    # through, and a failure message can be told apart from a plain space.
+    let(:nbsp) { "\u00A0" }
+
     it 'removes markup' do
       expect(service.strip_to_plain_text('<b>Bold</b> idea')).to eq 'Bold idea'
     end
@@ -495,6 +499,32 @@ describe SanitizationService do
       output = service.strip_to_plain_text('&amp;amp;amp;amp;amp;lt;script&amp;amp;amp;amp;amp;gt;')
       expect(output).not_to match(/<[a-zA-Z]/)
     end
+
+    # French typography puts a non-breaking space before ':' and inside numbers, so this is ordinary
+    # copy, and the HTML5 serializer writes it as `&nbsp;` every time it round-trips.
+    it 'keeps a non-breaking space as one character rather than its entity' do
+      title = "Analyse des options + vote#{nbsp}: 920#{nbsp}000 $"
+      expect(service.strip_to_plain_text(title)).to eq title
+    end
+
+    it 'is idempotent over a non-breaking space' do
+      once = service.strip_to_plain_text("vote#{nbsp}: la place")
+      expect(service.strip_to_plain_text(once)).to eq once
+    end
+
+    it 'decodes a non-breaking space that arrives already encoded' do
+      expect(service.strip_to_plain_text('vote&nbsp;: la place')).to eq "vote#{nbsp}: la place"
+    end
+
+    it 'strips a payload sitting next to a non-breaking space' do
+      expect(service.strip_to_plain_text("<img src=x onerror=alert(1)>vote#{nbsp}: la place"))
+        .to eq "vote#{nbsp}: la place"
+    end
+
+    it 'leaves no parsable tag when a payload is encoded around a non-breaking space' do
+      output = service.strip_to_plain_text("&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;#{nbsp}x")
+      expect(output).not_to match(/<[a-zA-Z]/)
+    end
   end
 
   describe 'strip_multiloc_to_plain_text' do
@@ -503,6 +533,16 @@ describe SanitizationService do
         { 'en' => '<b>Fish</b> & chips', 'fr-BE' => '<img src=x onerror=alert(1)>frites', 'nl-NL' => nil }
       )
       expect(output).to eq({ 'en' => 'Fish & chips', 'fr-BE' => 'frites', 'nl-NL' => nil })
+    end
+
+    # A row is sanitised as a whole, so a payload in one locale must not cost a clean locale its
+    # non-breaking spaces.
+    it 'leaves a clean locale untouched while stripping a payload from another' do
+      nbsp = "\u00A0"
+      output = service.strip_multiloc_to_plain_text(
+        { 'en' => '<img src=x onerror=alert(1)>frites', 'fr-BE' => "vote#{nbsp}: la place" }
+      )
+      expect(output).to eq({ 'en' => 'frites', 'fr-BE' => "vote#{nbsp}: la place" })
     end
   end
 end

--- a/back/spec/services/sanitization_service_spec.rb
+++ b/back/spec/services/sanitization_service_spec.rb
@@ -469,6 +469,36 @@ describe SanitizationService do
     end
   end
 
+  describe 'replace_links_with_urls' do
+    it 'replaces a link with the URL it points at' do
+      expect(service.replace_links_with_urls('<a href="https://example.com">click here</a>')).to eq 'https://example.com'
+    end
+
+    it 'replaces a mailto link with its address' do
+      expect(service.replace_links_with_urls('<a href="mailto:a@b.com">schrijf ons</a>')).to eq 'mailto:a@b.com'
+    end
+
+    # `linkify` never builds these, so putting one back as text would invent a link the pipeline
+    # would not have made. Left alone, the anchor is dropped downstream like any other markup.
+    it 'leaves a javascript: link alone' do
+      input = '<a href="javascript:alert(1)">click</a>'
+      expect(service.replace_links_with_urls(input)).to eq input
+    end
+
+    it 'leaves a relative link alone' do
+      input = '<a href="/somewhere">click</a>'
+      expect(service.replace_links_with_urls(input)).to eq input
+    end
+
+    it 'leaves text without links alone' do
+      expect(service.replace_links_with_urls('<p>no links here</p>')).to eq '<p>no links here</p>'
+    end
+
+    it 'returns nil for nil' do
+      expect(service.replace_links_with_urls(nil)).to be_nil
+    end
+  end
+
   describe 'strip_to_plain_text' do
     # Built by escape rather than pasted, so the character survives every editor this file passes
     # through, and a failure message can be told apart from a plain space.

--- a/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
+++ b/back/spec/tasks/single_use/purge_stored_xss_task_spec.ignore.rb
@@ -130,6 +130,34 @@ describe 'single_use:purge_stored_xss rake task' do
     end
   end
 
+  # Mentions stored before April 2026 carry a `data-user-slug` the write path no longer keeps.
+  # Nothing reads it, so stripping it would rewrite a row that carries no payload.
+  context 'a comment body whose only rewrite is the dead mention attribute' do
+    let!(:comment) { store_raw(create(:comment), :body_multiloc, { 'en' => '<p><span class="cl-mention-user" data-user-id="159cfd0a-44d1-4e87-9bdc-f158d7c0d16e" data-user-slug="tesha-bergstrom">@Tesha Bergstrom</span> hi</p>' }) }
+
+    it 'leaves the row alone' do
+      expect { run_task }.not_to(change { comment.reload.body_multiloc })
+    end
+
+    it 'reports no change for it' do
+      run_task
+      expect(report['changes']).to be_empty
+    end
+  end
+
+  context 'a comment body carrying the dead mention attribute alongside a payload' do
+    let!(:comment) do
+      store_raw(create(:comment), :body_multiloc, { 'en' => '<p><span class="cl-mention-user" data-user-id="159cfd0a-44d1-4e87-9bdc-f158d7c0d16e" data-user-slug="tesha-bergstrom">@Tesha Bergstrom</span> hi</p><script>alert(1)</script>' })
+    end
+
+    # Skipping is for rows that change in no other way; a row with a payload is purged, and the dead
+    # attribute goes with it because the write path no longer keeps it.
+    it 'purges it and drops the attribute too' do
+      run_task
+      expect(comment.reload.body_multiloc['en']).to eq '<p><span class="cl-mention-user" data-user-id="159cfd0a-44d1-4e87-9bdc-f158d7c0d16e">@Tesha Bergstrom</span> hi</p>alert(1)'
+    end
+  end
+
   # None of these contain an executable keyword, but the write path strips all of them - so the
   # pre-filter has to be wide enough to find them.
   context 'payloads that carry no executable keyword' do


### PR DESCRIPTION
- Avoid inserting literal characters '&nbsp' and actually insert the space character.
- Rebuild comment translation links from their URLs
- Purge rake task skips rewrites that only drop the dead mention attribute

# Changelog
## Technical
- [TAN-8413] Small tweaks to BE sanitisation
