### PR TITLE
Flaky E2E Fix: profile_page.cy.ts — invalid aria-expanded on Tooltip

### DIFF
--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -151,6 +151,13 @@ const Tooltip = ({
         plugins={PLUGINS}
         interactive={true}
         role={role}
+        // Tippy adds `aria-expanded` to its reference element whenever
+        // `interactive` is set. That reference is the wrapper <span> below,
+        // which has no role, and `aria-expanded` is not allowed there
+        // (axe rule: aria-allowed-attr). Triggers that really do expand
+        // something declare `aria-expanded` themselves — see InputContainer's
+        // `ariaExpanded` prop — so suppress tippy's automatic one here.
+        aria={{ expanded: false }}
         visible={isFocused}
         // Ensures tippy works with both keyboard and mouse
         onHidden={handleOnHidden}
@@ -172,6 +179,8 @@ const Tooltip = ({
           plugins={PLUGINS}
           interactive={true}
           role={role}
+          // See the comment on the wrapped branch above.
+          aria={{ expanded: false }}
           visible={isFocused}
           // Ensures tippy works with both keyboard and mouse
           onHidden={handleOnHidden}

--- a/front/app/component-library/components/Tooltip/index.tsx
+++ b/front/app/component-library/components/Tooltip/index.tsx
@@ -151,12 +151,6 @@ const Tooltip = ({
         plugins={PLUGINS}
         interactive={true}
         role={role}
-        // Tippy adds `aria-expanded` to its reference element whenever
-        // `interactive` is set. That reference is the wrapper <span> below,
-        // which has no role, and `aria-expanded` is not allowed there
-        // (axe rule: aria-allowed-attr). Triggers that really do expand
-        // something declare `aria-expanded` themselves — see InputContainer's
-        // `ariaExpanded` prop — so suppress tippy's automatic one here.
         aria={{ expanded: false }}
         visible={isFocused}
         // Ensures tippy works with both keyboard and mouse
@@ -179,7 +173,6 @@ const Tooltip = ({
           plugins={PLUGINS}
           interactive={true}
           role={role}
-          // See the comment on the wrapped branch above.
           aria={{ expanded: false }}
           visible={isFocused}
           // Ensures tippy works with both keyboard and mouse

--- a/front/cypress/e2e/profile_page.cy.ts
+++ b/front/cypress/e2e/profile_page.cy.ts
@@ -73,6 +73,14 @@ describe('Profile Page', () => {
     cy.get('#e2e-usersshowpage-fullname').contains(
       `${newUserName} ${newUserSurname}`
     );
+
+    // The idea cards render after the page container appears, so wait for the
+    // card the before() hook created before scanning. Otherwise the scan races
+    // the card and silently passes by running against a half-rendered page.
+    cy.get('#e2e-ideas-container')
+      .find('.e2e-idea-card')
+      .should('have.length', 1);
+
     cy.checkA11y(undefined, {
       includedImpacts: ['critical', 'serious'],
     });


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

## Context

**Spec:** `front/cypress/e2e/profile_page.cy.ts` — `Profile Page › shows the page, and main infos`
(5 failures across the last 9 nightly runs, 3 consecutive; every failure the same `cy.checkA11y`
assertion — 1 critical `aria-allowed-attr` violation.)

**Root cause.** `Tooltip` renders its children inside a wrapper `<span>` and hands that span to
Tippy as the reference element, with `interactive` hardcoded on. Tippy's default
`aria.expanded: 'auto'` then writes `aria-expanded` onto that reference. The wrapper `<span>`
has no role, so `aria-expanded` is not permitted there — a critical violation on every rendered
tooltip (~182 usages on the default wrapper path).

This is a regression. 63d50da1afb ("Remove aria-expanded from tippy and move it to trigger",
2026-05-04) deleted `aria={{ expanded: false }}` from both Tippy instances. That line was what
*suppressed* Tippy's automatic attribute, so deleting it did the opposite of the commit's intent.
The intended half of that commit — declaring `aria-expanded` explicitly on the real trigger —
landed correctly and is untouched here (`InputContainer`'s `ariaExpanded`, used by `DateSinglePicker`).

**Why the test looked flaky.** The idea-card title is wrapped in a `Tooltip`. The spec scanned
about a second after the page container appeared, racing the card render: scan before the card
mounts → green, after → red. The green runs were false passes. The violation has been present
since May; nothing on the profile page's render path changed around 2026-08-10. The nightly suite
grew from ~506 to ~571 tests over the window, which shifted the timing enough to start losing the race.

**Why this fixes rather than suppresses.**
- The product change removes the invalid attribute at its source, so screen readers stop being told
  a plain `<span>` is a collapsible widget. No assertion loosened or deleted, no retries added,
  no `{ force: true }`, no bare `cy.wait` introduced.
- The spec change makes the scan *stricter*, not weaker: it waits for the idea card before scanning,
  so `checkA11y` always runs against the settled page. Against unfixed code this test would now fail
  every run rather than half the time.

**Stability evidence.**
- CI: `profile_page.cy.ts` ×3 nodes — 12/12 green, a11y test 3/3.
  https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347633
- axe-core 4.10.2 against the exact captured node: `<span aria-expanded="false">` → 1
  `aria-allowed-attr` violation; same markup without the attribute → 0.
- No local Cypress runs — the bundled binary does not launch on this machine, so repro and
  validation were done on CI.

Final verdict is the nightly trend over the next 2–3 weeks.

# Changelog

## Fixed
- Tooltips no longer expose an invalid expand/collapse state to screen readers.
