### PR TITLE
[TAN-8530] Bump mail to 2.9.1 to fix RFC 2047 address spoofing (GHSA-mvxr-6m87-mv2q)

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -736,7 +736,8 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.8.1)
+    mail (2.9.1)
+      logger
       mini_mime (>= 0.1.1)
       net-imap
       net-pop


### PR DESCRIPTION
Fixes GHSA-mvxr-6m87-mv2q (email address spoofing via malformed RFC 2047 encoded-words). Lockfile-only: mail 2.8.1 → 2.9.1 plus its new logger dep (already locked at 1.7.0). --conservative kept every other gem pinned.

Looks low risk because:
- mail is purely transitive — no Gemfile change, all dependents already accept 2.9.1, and no app code calls `Mail::` directly.
- Neither `Mail::CheckDeliveryParams` (removed in 2.9.0) nor `Mail::Field::FIELDS_MAP` (reshaped) is referenced by any other gem in the bundle — the only mention is mail's own internal use.
- The new `STARTTLS/TLS` conflict error can't trigger — we never pass `tls/ssl`, and the `custom_smtp` schema forbids it.
- Decoding is unchanged for well-formed mail; the fix only alters handling of the malformed input that is the attack.

Reviewer note: 2.9 relaxed `enable_starttls_auto` from a strict boolean to a truthiness check. Tenants are unaffected (schema types it boolean), but the global path reads it from ENV as a string, so "false" would now mean `STARTTLS-auto` rather than raising. Under 2.8.1 any string value raised `ArgumentError`, so no working SMTP deployment can have it set — the change is inert in practice.. 

# Changelog
## Technical
- [TAN-8530] Bump mail to 2.9.1 to fix RFC 2047 address spoofing (GHSA-mvxr-6m87-mv2q)
