### PR TITLE
Deleting select answers

### DIFF
--- a/back/spec/models/area_spec.rb
+++ b/back/spec/models/area_spec.rb
@@ -83,6 +83,22 @@ RSpec.describe Area do
     end
   end
 
+  describe '#destroy' do
+    context 'when domicile field exist' do
+      before { create(:custom_field_domicile) }
+
+      it 'deletes the domicile values referencing the area' do
+        area = create(:area)
+        user = create(:user, domicile: area.id)
+
+        area.destroy!
+
+        expect(user.reload.custom_field_values).not_to have_key('domicile')
+        expect(user.custom_field_answers).to be_empty
+      end
+    end
+  end
+
   describe '#recreate_custom_field_options!' do
     let!(:domicile) { create(:custom_field_domicile) }
 


### PR DESCRIPTION
Intentionally failing: the cleanup lives in SideFxAreaService, so any destroy that does not pass through the controller leaves user domiciles referencing the deleted area.


# Changelog
<!-- Replace this comment by a bullet list. More info: https://www.notion.so/citizenlab/Changelog-How-it-works-f418426c75994454a332bf067634f3f1 -->

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
