### PR TITLE
[TAN-8535] Stop the AI-insights refetch loop causing 429 blank pages

### DIFF
--- a/front/app/api/analysis_background_tasks/useAnalysisBackgroundTask.test.ts
+++ b/front/app/api/analysis_background_tasks/useAnalysisBackgroundTask.test.ts
@@ -1,0 +1,123 @@
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import insightsKeys from 'api/analysis_insights/keys';
+
+import { renderHook, waitFor, act } from 'utils/testUtils/rtl';
+
+import backgroundTasksKeys from './keys';
+import useAnalysisBackgroundTask from './useAnalysisBackgroundTask';
+
+const apiPath = '*analyses/:analysisId/background_tasks/:id';
+
+const backgroundTaskData = {
+  id: 'task-1',
+  type: 'background_task',
+  attributes: {
+    progress: null,
+    type: 'summarization',
+    auto_tagging_method: null,
+    created_at: '2026-08-18T08:00:00.000Z',
+    ended_at: '2026-08-18T08:01:00.000Z',
+    state: 'succeeded',
+  },
+};
+
+const server = setupServer(
+  http.get(apiPath, () => {
+    return HttpResponse.json({ data: backgroundTaskData }, { status: 200 });
+  })
+);
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return { queryClient, wrapper };
+};
+
+describe('useAnalysisBackgroundTask', () => {
+  beforeAll(() => server.listen());
+  afterAll(() => server.close());
+
+  it('returns data correctly', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useAnalysisBackgroundTask('analysis-1', 'task-1'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.data).toEqual(backgroundTaskData);
+  });
+
+  it('invalidates the insights of the analysis after its own fetch', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useAnalysisBackgroundTask('analysis-1', 'task-1'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: insightsKeys.list({ analysisId: 'analysis-1' }),
+      })
+    );
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression test for TAN-8535: the insights response side-loads the task,
+  // which `fetcher` writes into the cache with setQueryData. Reacting to that
+  // write by invalidating insights again made the two queries refetch each
+  // other forever.
+  it('does not invalidate insights when the task is written into the cache by another response', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useAnalysisBackgroundTask('analysis-1', 'task-1'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(invalidateQueries).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      queryClient.setQueryData(backgroundTasksKeys.item({ id: 'task-1' }), {
+        data: { ...backgroundTaskData },
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.dataUpdatedAt).toBeGreaterThan(0)
+    );
+    expect(invalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invalidate insights for a task that is already in the cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(backgroundTasksKeys.item({ id: 'task-1' }), {
+      data: backgroundTaskData,
+    });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useAnalysisBackgroundTask('analysis-1', 'task-1'),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.isFetching).toBe(false);
+    expect(invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/front/app/api/analysis_background_tasks/useAnalysisBackgroundTask.ts
+++ b/front/app/api/analysis_background_tasks/useAnalysisBackgroundTask.ts
@@ -3,7 +3,7 @@ import { CLErrors } from 'typings';
 
 import insightsKeys from 'api/analysis_insights/keys';
 
-import useOnQuerySuccess from 'hooks/useOnQuerySuccess';
+import useOnQueryFetched from 'hooks/useOnQueryFetched';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 
@@ -40,7 +40,11 @@ const useAnalysisBackgroundTask = (
     },
   });
 
-  useOnQuerySuccess(result, () => {
+  // Refresh the insight text after every poll. This must only run after the
+  // task's own fetch: the insights response side-loads this very task, which
+  // `fetcher` writes into the cache, and reacting to that write would refetch
+  // insights in an endless loop (TAN-8535).
+  useOnQueryFetched(result, () => {
     queryClient.invalidateQueries({
       queryKey: insightsKeys.list({ analysisId }),
     });

--- a/front/app/api/analysis_background_tasks/useAnalysisBackgroundTasks.ts
+++ b/front/app/api/analysis_background_tasks/useAnalysisBackgroundTasks.ts
@@ -6,7 +6,7 @@ import insightsKeys from 'api/analysis_insights/keys';
 import taggingKeys from 'api/analysis_taggings/keys';
 import tagsKeys from 'api/analysis_tags/keys';
 
-import useOnQuerySuccess from 'hooks/useOnQuerySuccess';
+import useOnQueryFetched from 'hooks/useOnQueryFetched';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 import { NO_PLACEHOLDER_DATA } from 'utils/cl-react-query/queryClient';
@@ -45,7 +45,8 @@ const useAnalysisBackgroundTasks = (analysisId?: string) => {
     enabled: !!analysisId,
   });
 
-  useOnQuerySuccess(result, () => {
+  // Only after the list's own fetch, see useAnalysisBackgroundTask (TAN-8535).
+  useOnQueryFetched(result, () => {
     queryClient.invalidateQueries({ queryKey: tagsKeys.lists() });
     queryClient.invalidateQueries({ queryKey: taggingKeys.lists() });
     queryClient.invalidateQueries({ queryKey: insightsKeys.lists() });

--- a/front/app/hooks/useOnQueryFetched.test.ts
+++ b/front/app/hooks/useOnQueryFetched.test.ts
@@ -1,0 +1,103 @@
+import { renderHook } from 'utils/testUtils/rtl';
+
+import useOnQueryFetched from './useOnQueryFetched';
+
+const fetching = { isFetching: true, isSuccess: false };
+const fetched = { isFetching: false, isSuccess: true };
+const refetching = { isFetching: true, isSuccess: true };
+const failed = { isFetching: false, isSuccess: false };
+
+describe('useOnQueryFetched', () => {
+  it('does not call the callback while the query is fetching', () => {
+    const callback = jest.fn();
+    renderHook(() => useOnQueryFetched(fetching, callback));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls the callback once the initial fetch succeeds', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      (state) => useOnQueryFetched(state, callback),
+      { initialProps: fetching }
+    );
+
+    rerender(fetched);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the callback for data that came straight from the cache', () => {
+    const callback = jest.fn();
+    renderHook(() => useOnQueryFetched(fetched, callback));
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not call the callback when the fetch fails', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      (state) => useOnQueryFetched(state, callback),
+      { initialProps: fetching }
+    );
+
+    rerender(failed);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls the callback again after each refetch', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      (state) => useOnQueryFetched(state, callback),
+      { initialProps: fetched }
+    );
+
+    rerender(refetching);
+    expect(callback).not.toHaveBeenCalled();
+    rerender(fetched);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender(refetching);
+    rerender(fetched);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not call the callback when the data changed without a fetch', () => {
+    const callback = jest.fn();
+    const { rerender } = renderHook(
+      (state) => useOnQueryFetched(state, callback),
+      { initialProps: fetched }
+    );
+
+    // e.g. setQueryData from another response's `included` resources
+    rerender({ ...fetched });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest callback, without firing when only its identity changed', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    const { rerender } = renderHook(
+      ({ state, callback }) => useOnQueryFetched(state, callback),
+      { initialProps: { state: fetched, callback: first } }
+    );
+
+    rerender({ state: fetched, callback: second });
+    expect(second).not.toHaveBeenCalled();
+
+    rerender({ state: refetching, callback: second });
+    rerender({ state: fetched, callback: second });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when no callback is passed', () => {
+    const { rerender } = renderHook((state) => useOnQueryFetched(state), {
+      initialProps: fetching,
+    });
+
+    expect(() => rerender(fetched)).not.toThrow();
+  });
+});

--- a/front/app/hooks/useOnQueryFetched.ts
+++ b/front/app/hooks/useOnQueryFetched.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+
+interface QueryFetchState {
+  isFetching: boolean;
+  isSuccess: boolean;
+}
+
+/**
+ * Runs `callback` each time the query's *own* fetch completes successfully,
+ * and only then (react-query v4's `onSuccess` semantics). Cached data, whether
+ * it was already there on mount or is written later by `setQueryData` (for
+ * example the `included` resources `fetcher` seeds from other responses), does
+ * not trigger it.
+ *
+ * Prefer this over `useOnQuerySuccess` when the callback invalidates queries
+ * whose responses side-load this query's own resource type: with
+ * `useOnQuerySuccess` that seeding bumps `dataUpdatedAt`, re-fires the
+ * callback, and the two queries refetch each other forever.
+ */
+const useOnQueryFetched = (
+  { isFetching, isSuccess }: QueryFetchState,
+  callback?: () => void
+) => {
+  const callbackRef = useRef(callback);
+  const wasFetchingRef = useRef(isFetching);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  useEffect(() => {
+    if (wasFetchingRef.current && !isFetching && isSuccess) {
+      callbackRef.current?.();
+    }
+    wasFetchingRef.current = isFetching;
+  }, [isFetching, isSuccess]);
+};
+
+export default useOnQueryFetched;


### PR DESCRIPTION
- Root cause: the react-query v5 port (#14559) replaced `useQuery`'s removed `onSuccess` in `useAnalysisBackgroundTask(s)` with `useOnQuerySuccess`, which also fires when the task is written into the cache. The insights response side-loads `insightable.background_task`, and `fetcher` seeds every `included` resource with `setQueryData`, so each insights fetch bumped the task's `dataUpdatedAt`, re-fired the callback, invalidated insights, and so on: `GET /analyses/:id/insights` went from ~3K to ~204K requests/day on the UK cluster alone (measured from the ALB access logs).
- Adds `hooks/useOnQueryFetched`, which runs its callback only when the query's own fetch completes (the v4 `onSuccess` semantics), and uses it in `useAnalysisBackgroundTask` and `useAnalysisBackgroundTasks`. Polling while a task is queued or in progress still refreshes insights after every poll.
- Adds a regression test that seeds the task into the cache via `setQueryData` and asserts insights are not invalidated; it fails against the previous hook.

# Changelog

## Fixed
- Since Tuesday morning (18 Aug), admin pages that show AI-analysis insights (the survey results page, the AI analysis explore page, and the report builder) requested the insights of every analysis several times per second, non-stop. This quickly exhausted the platform's per-IP request limit, after which every request from that admin's network failed for up to 3 minutes: pages went blank and people appeared to be logged out, in all their tabs and for colleagues on the same office network. The insights are now only refreshed after a real update check, so this no longer happens.
