### PR TITLE
Flaky E2E Fix: idea_reacting_permissions.cy.ts — cover the full auth chain gating the built-in-fields form

### DIFF
--- a/front/cypress/support/auth.ts
+++ b/front/cypress/support/auth.ts
@@ -99,7 +99,13 @@ export const enterUserInfo = (
     password = randomString(),
   } = {}
 ) => {
-  cy.get('#firstName').type(firstName);
+  // The built-in-fields form is gated by two sequential requests: the
+  // confirmation POST, and the permissions-requirements GET that decides which
+  // step comes next. The verify button stays in its processing state for both,
+  // so awaiting the POST alone is not enough. On a loaded backend the pair can
+  // outlast the default 15s command timeout, hence the longer leash on the
+  // first field of the form.
+  cy.get('#firstName', { timeout: 60000 }).type(firstName);
   cy.get('#lastName').type(lastName);
   cy.get('#password').type(password);
 

--- a/front/cypress/support/auth.ts
+++ b/front/cypress/support/auth.ts
@@ -56,6 +56,7 @@ export const confirmEmail = (cy: Cypress.Chainable) => {
   // The request fires on click, so only the response needs the long leash.
   cy.intercept('POST', '**/user/confirm_code_*').as('confirmCode');
   cy.get('#e2e-verify-email-button > button').click({ force: true });
+  cy.wait('@confirmCode', { responseTimeout: 60000 });
 };
 
 export const confirmPhone = (cy: Cypress.Chainable) => {


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

## Context

`cypress/e2e/idea_reacting_permissions.cy.ts` — "sends signed out user to log in and doesn't ask for verification" has been failing intermittently on the nightly e2e run (2026-07-10, 07-16, 08-19), always with the same assertion:

```
AssertionError: Timed out retrying after 15000ms:
Expected to find element: `#firstName`, but never found it.
    at enterUserInfo (cypress/support/auth.ts)
```

### Root cause

`#firstName` (the built-in-fields step) is gated by **two sequential requests**, not one. In `preAuthSteps.ts`:

```js
SUBMIT_CODE: async (email, code) => {
  await confirmCodeEmail(email, code);                                // POST /user/confirm_code_email
  setCurrentStep((await getRemainingRequirementStep()) ?? 'success');  // GET  …/permissions/<action>/requirements
}
```

`useSteps/index.ts` wraps the whole transition in `setLoading(true)` / `setLoading(false)`, so the verify button stays in its processing state until **both** requests resolve, and the built-in-fields step only renders after the second one.

`enterUserInfo` then queried `#firstName` on Cypress's default 15s command timeout. On a loaded backend that two-request chain can exceed 15s, so the assertion fails while the confirmation modal is still open and the verify button is still spinning — which is exactly what the CI failure screenshot shows, with the confirmation response already returned.

### The fix

Two commits:

1. **Restore a dropped wait on the confirmation response.** #14487 added `cy.wait('@confirmCode', …)` to `confirmEmail`; the phone-auth merge `b8840281fa2` (master via #14560) resolved a conflict by keeping the explanatory comment and the `cy.intercept` while dropping the wait itself, so the helper still read as though it awaited the response. Restored — it covers the first request in the chain.

2. **Give the built-in-fields form a timeout that covers the whole chain.** `cy.get('#firstName', { timeout: 60000 })`. This is assertion-based retry on the element the chain actually gates — the form must still appear, it is simply given a leash that matches the work it waits on, rather than racing a two-request chain against a 15s default.

Why not intercept the requirements request inside `confirmEmail`: not every caller proceeds to the built-in-fields step (the SSO and change-email flows do not), so a `cy.wait` there would hang for 60s in flows where that request never fires. It also cannot be registered from `enterUserInfo`, since the intercept has to precede the click.

Commit 1 alone was verified insufficient — it was pushed first and the spec still failed with the identical signature, which is what led to the full chain being traced.

### Stability evidence

- **Local:** not possible on this machine (Cypress cannot launch here), so validation was done in CI.
- **Failing baseline:** with commit 1 only, a concurrent run reproduced the failure at **2 / 16 repetitions** (~12%).
- **After commit 2:** 3 concurrent pipelines at `e2e_parallelism: 6` — **18 / 18 repetitions green**, 90 / 90 test records passing, no failure screenshots on any node. Per-run times (21–38s) match the failing run's spread, so the load was comparable.
  - [#347916](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347916) · [#347917](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347917) · [#347918](https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/347918)

At the observed ~12% failure rate, 18 consecutive passes would occur by chance about 9% of the time — good evidence, not proof. The nightly trend over the coming days is the real verdict.

Follow-up, deliberately not in this PR: `confirmPhone` has the same shape — it clicks confirm without awaiting the response, and its transition runs the same requirements fetch. It has not flaked yet, so I kept it out of scope.

# Changelog

## Technical
- Fix a flaky e2e signup helper that raced the two-request auth chain gating the built-in-fields form.
