### PR TITLE
[TAN-8536] Add label NEW to html block feature

### DIFF
--- a/front/app/components/DescriptionBuilder/DescriptionBuilderToolbox/DescriptionToolboxSections/index.tsx
+++ b/front/app/components/DescriptionBuilder/DescriptionBuilderToolbox/DescriptionToolboxSections/index.tsx
@@ -20,6 +20,7 @@ import ThreeColumn from 'components/admin/ContentBuilder/Widgets/ThreeColumn';
 import TwoColumn from 'components/admin/ContentBuilder/Widgets/TwoColumn';
 import WhiteSpace from 'components/admin/ContentBuilder/Widgets/WhiteSpace';
 import InfoWithAccordions from 'components/DescriptionBuilder/Widgets/InfoWithAccordions';
+import NewLabel from 'components/UI/NewLabel';
 
 import { useIntl } from 'utils/cl-intl';
 
@@ -81,6 +82,7 @@ const DescriptionToolboxSections = () => {
             component={<HtmlBlockMultiloc />}
             icon="code"
             label={formatMessage(HtmlBlockMultiloc.craft.custom.title)}
+            labelSuffix={<NewLabel expiryDate={new Date('2027-02-19')} />}
           />
         ) : null}
         <DraggableElement

--- a/front/app/components/DescriptionBuilder/DescriptionBuilderToolbox/FolderDescriptionBuilderToolbox/index.tsx
+++ b/front/app/components/DescriptionBuilder/DescriptionBuilderToolbox/FolderDescriptionBuilderToolbox/index.tsx
@@ -34,6 +34,7 @@ import FolderTitle, {
   folderTitleTitle,
 } from 'components/DescriptionBuilder/Widgets/FolderTitle';
 import InfoWithAccordions from 'components/DescriptionBuilder/Widgets/InfoWithAccordions';
+import NewLabel from 'components/UI/NewLabel';
 
 import {
   MessageDescriptor,
@@ -167,6 +168,7 @@ const FolderDescriptionBuilderToolbox = ({
             component={<HtmlBlockMultiloc />}
             icon="code"
             label={formatMessage(HtmlBlockMultiloc.craft.custom.title)}
+            labelSuffix={<NewLabel expiryDate={new Date('2027-02-19')} />}
           />
         )}
         <DraggableElement

--- a/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Toolbox/index.tsx
+++ b/front/app/containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Toolbox/index.tsx
@@ -262,6 +262,7 @@ const HomepageBuilderToolbox = () => {
             component={<HtmlBlockMultiloc html={{}} />}
             icon="code"
             label={formatMessage(htmlBlockMultilocTitle)}
+            labelSuffix={<NewLabel expiryDate={new Date('2027-02-19')} />}
           />
         )}
         <DraggableElement


### PR DESCRIPTION
# Changelog
## Changed
- add label NEW to Html block feature, with 6 months expiring date

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
