### PR TITLE
TAN-8538 Platform defaults view access rights

### DIFF
--- a/front/app/components/admin/ActionForm/PlatformDefaultsHeader.tsx
+++ b/front/app/components/admin/ActionForm/PlatformDefaultsHeader.tsx
@@ -1,20 +1,24 @@
 // The "inherited" state of the panel: the action has no permission of its own,
-// so the platform-wide defaults apply. The row is deliberately inert — there is
-// nothing to configure here until the admin overrides it, at which point the
-// regular panel takes over.
+// so the platform-wide defaults apply. The panel can be opened to read those
+// defaults, but nothing in it can be changed until the admin overrides it.
 
 import React, { ReactNode } from 'react';
 
 import {
   Box,
   Button,
+  Icon,
   Text,
   Title,
+  colors,
   fontSizes,
 } from '@citizenlab/cl2-component-library';
 
+import useAuthUser from 'api/me/useAuthUser';
+
 import { FormattedMessage, useIntl } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
+import { isAdmin } from 'utils/permissions/roles';
 
 import messages from './messages';
 
@@ -26,12 +30,24 @@ const TITLE_LINE_HEIGHT = `${fontSizes.l * 1.3}px`;
 
 interface Props {
   title: ReactNode;
+  action: string;
   processing: boolean;
+  isOpen: boolean;
+  onToggle: () => void;
   onOverride: () => void;
 }
 
-const PlatformDefaultsHeader = ({ title, processing, onOverride }: Props) => {
+const PlatformDefaultsHeader = ({
+  title,
+  action,
+  processing,
+  isOpen,
+  onToggle,
+  onOverride,
+}: Props) => {
   const { formatMessage } = useIntl();
+  const { data: authUser } = useAuthUser();
+  const userIsAdmin = isAdmin(authUser);
 
   return (
     <Box
@@ -43,8 +59,27 @@ const PlatformDefaultsHeader = ({ title, processing, onOverride }: Props) => {
       py="16px"
       flexWrap="wrap"
     >
-      {/* No expand chevron: there is nothing to open in this state. */}
-      <Box flex="0 0 auto">
+      <Box
+        className={`e2e-action-accordion-${action}`}
+        data-cy={`e2e-action-accordion-${action}`}
+        as="button"
+        type="button"
+        display="flex"
+        alignItems="center"
+        gap="12px"
+        p="0"
+        background="transparent"
+        border="none"
+        cursor="pointer"
+        style={{ textAlign: 'left' }}
+        onClick={onToggle}
+      >
+        <Icon
+          name={isOpen ? 'chevron-down' : 'chevron-right'}
+          width="20px"
+          height="20px"
+          fill={colors.coolGrey600}
+        />
         <Title variant="h4" as="h3" m="0" color="primary">
           {title}
         </Title>
@@ -62,9 +97,14 @@ const PlatformDefaultsHeader = ({ title, processing, onOverride }: Props) => {
         <FormattedMessage
           {...messages.usingPlatformDefaults}
           values={{
-            link: (chunks) => (
-              <Link to="/admin/settings/registration">{chunks}</Link>
-            ),
+            // Only admins can reach the platform-wide settings the link points
+            // at, so managers get the same sentence as plain text.
+            link: (chunks) =>
+              userIsAdmin ? (
+                <Link to="/admin/settings/registration">{chunks}</Link>
+              ) : (
+                <>{chunks}</>
+              ),
           }}
         />
       </Text>

--- a/front/app/components/admin/ActionForm/index.test.tsx
+++ b/front/app/components/admin/ActionForm/index.test.tsx
@@ -3,7 +3,15 @@ import React from 'react';
 import { IdMethodData } from 'api/id_methods/types';
 import { IPermissionData } from 'api/permissions/types';
 
-import { render, screen, within, userEvent } from 'utils/testUtils/rtl';
+import { Changes } from 'components/admin/ActionForm/types';
+
+import {
+  render,
+  screen,
+  within,
+  userEvent,
+  fireEvent,
+} from 'utils/testUtils/rtl';
 
 import ActionForm from '.';
 
@@ -50,6 +58,12 @@ jest.mock('api/id_methods/useVerificationMethod', () =>
       : null,
   }))
 );
+
+let mockUserRoles: { type: string }[] = [{ type: 'admin' }];
+
+jest.mock('api/me/useAuthUser', () => () => ({
+  data: { data: { id: 'user-1', attributes: { roles: mockUserRoles } } },
+}));
 
 jest.mock('api/phases/usePhase', () =>
   jest.fn(() => ({
@@ -111,13 +125,19 @@ const buildPermission = (
 
 type RenderOptions = {
   defaultOpen?: boolean;
+  onChange?: (changes: Changes) => Promise<void>;
   onOverride?: () => Promise<void>;
   onRevertToDefaults?: () => Promise<void>;
 };
 
 const renderForm = (
   attributes?: Partial<IPermissionData['attributes']>,
-  { defaultOpen = true, onOverride, onRevertToDefaults }: RenderOptions = {}
+  {
+    defaultOpen = true,
+    onChange = jest.fn(),
+    onOverride,
+    onRevertToDefaults,
+  }: RenderOptions = {}
 ) =>
   render(
     <ActionForm
@@ -125,7 +145,7 @@ const renderForm = (
       permissionData={buildPermission(attributes)}
       title="Commenting"
       defaultOpen={defaultOpen}
-      onChange={jest.fn()}
+      onChange={onChange}
       onOverride={onOverride}
       onRevertToDefaults={onRevertToDefaults}
     />
@@ -135,6 +155,7 @@ beforeEach(() => {
   mockPasswordLoginEnabled = true;
   mockIdMethods = [ssoMethod];
   mockVerificationMethodConfigured = true;
+  mockUserRoles = [{ type: 'admin' }];
 });
 
 describe('<ActionForm />', () => {
@@ -248,7 +269,7 @@ describe('<ActionForm />', () => {
   });
 
   describe('inheriting the platform defaults', () => {
-    it('locks the panel shut and offers to override it', () => {
+    it('shows the inherited settings and offers to override them', () => {
       renderForm({ inherited: true }, { onOverride: jest.fn() });
 
       expect(screen.getByText('Commenting')).toBeInTheDocument();
@@ -256,11 +277,55 @@ describe('<ActionForm />', () => {
       expect(
         screen.getByRole('button', { name: 'Override' })
       ).toBeInTheDocument();
-      // Nothing is configurable until the action has been overridden.
+      // The defaults can be read, but not changed.
+      expect(screen.getByText('Security requirements')).toBeInTheDocument();
+      expect(screen.getByText('What we collect')).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: 'Revert to platform defaults' })
+      ).not.toBeInTheDocument();
+    });
+
+    it('collapses and expands the panel', async () => {
+      renderForm({ inherited: true }, { onOverride: jest.fn() });
+
+      await userEvent.click(screen.getByText('Commenting'));
       expect(
         screen.queryByText('Security requirements')
       ).not.toBeInTheDocument();
-      expect(screen.queryByText('What we collect')).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByText('Commenting'));
+      expect(screen.getByText('Security requirements')).toBeInTheDocument();
+    });
+
+    it('opens a sub-expander without changing anything', async () => {
+      const onChange = jest.fn();
+      renderForm({ inherited: true }, { onOverride: jest.fn(), onChange });
+
+      await userEvent.click(screen.getByText('Security requirements'));
+      expect(
+        screen.getByText('Require user to set a password')
+      ).toBeInTheDocument();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not change the permission when the settings are inherited', () => {
+      const onChange = jest.fn();
+      renderForm({ inherited: true }, { onOverride: jest.fn(), onChange });
+
+      fireEvent.click(screen.getByText('Admin & managers only'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('links to the platform defaults for admins only', () => {
+      renderForm({ inherited: true }, { onOverride: jest.fn() });
+      expect(
+        screen.getByRole('link', { name: 'platform defaults' })
+      ).toHaveAttribute('href', '/en/admin/settings/registration');
+
+      mockUserRoles = [{ type: 'project_moderator' }];
+      renderForm({ inherited: true }, { onOverride: jest.fn() });
+      expect(screen.getAllByText(/Using/)).toHaveLength(2);
+      expect(screen.getAllByRole('link')).toHaveLength(1);
     });
 
     it('overrides the action and opens the panel', async () => {

--- a/front/app/components/admin/ActionForm/index.tsx
+++ b/front/app/components/admin/ActionForm/index.tsx
@@ -20,8 +20,8 @@ import { buildSummary, useVisibleSecurityRequirements } from './logic';
 import messages from './messages';
 import PlatformDefaultsHeader from './PlatformDefaultsHeader';
 import RevertToDefaultsModal from './RevertToDefaultsModal';
-import { Props } from './types';
-import { Chip } from './ui';
+import { Changes, Props } from './types';
+import { Chip, ReadOnlyOverlay } from './ui';
 
 const ActionForm = ({
   phaseId,
@@ -53,12 +53,21 @@ const ActionForm = ({
   const showAnyone = attributes.permitted_by_everyone_allowed;
   const isAdmins = attributes.permitted_by === 'admins_moderators';
 
+  // Nothing has been configured for this action: the platform defaults apply.
+  // They can be read here, but only overriding the action makes them editable.
+  const usingPlatformDefaults = attributes.inherited && !!onOverride;
+
   const summary = buildSummary(
     permissionData,
     customFields,
     formatMessage,
     visibleSecurityRequirements
   );
+
+  const handleChange = async (changes: Changes) => {
+    if (attributes.inherited) return;
+    await onChange(changes);
+  };
 
   const handleOverride = async () => {
     if (!onOverride) return;
@@ -82,33 +91,56 @@ const ActionForm = ({
     }
   };
 
-  // Nothing has been configured for this action: the platform defaults apply
-  // and the panel stays shut until the admin chooses to override it.
-  if (attributes.inherited && onOverride) {
-    return (
-      <Box
-        maxWidth="900px"
-        my="16px"
-        data-cy={`e2e-action-inherited-${action}`}
-      >
-        <Box
-          border={`1px solid ${colors.borderLight}`}
-          borderRadius={stylingConsts.borderRadius}
-          bgColor={colors.white}
-          style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}
-        >
-          <PlatformDefaultsHeader
-            title={title}
-            processing={processing}
-            onOverride={handleOverride}
+  const body = (
+    <>
+      <Divider mt="0" mb="20px" />
+
+      <AccessSection
+        permission={permissionData}
+        showAnyone={showAnyone}
+        onChange={handleChange}
+      />
+
+      {/* Admins-only is a closed gate — nothing else applies. For the
+          other modes, demographics can be collected (the account-only
+          parts hide themselves inside DataSection). */}
+      {!isAdmins && (
+        <>
+          <Divider my="24px" />
+          <DataSection
+            permission={permissionData}
+            phaseId={phaseId}
+            onChange={handleChange}
           />
+        </>
+      )}
+
+      {onRevertToDefaults && !usingPlatformDefaults && (
+        <Box mt="24px">
+          <Button
+            buttonStyle="text"
+            width="auto"
+            padding="0px"
+            dataCy={`e2e-revert-to-platform-defaults-${action}`}
+            onClick={() => setRevertModalOpened(true)}
+          >
+            <span style={{ textDecorationLine: 'underline' }}>
+              <FormattedMessage {...messages.revertToPlatformDefaults} />
+            </span>
+          </Button>
         </Box>
-      </Box>
-    );
-  }
+      )}
+    </>
+  );
 
   return (
-    <Box maxWidth="900px" my="16px">
+    <Box
+      maxWidth="900px"
+      my="16px"
+      data-cy={
+        usingPlatformDefaults ? `e2e-action-inherited-${action}` : undefined
+      }
+    >
       <Box
         border={`1px solid ${colors.borderLight}`}
         borderRadius={stylingConsts.borderRadius}
@@ -116,50 +148,61 @@ const ActionForm = ({
         style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}
       >
         {/* ---- Header (always visible, click to collapse/expand) ---- */}
-        <Box
-          className={`e2e-action-accordion-${action}`}
-          data-cy={`e2e-action-accordion-${action}`}
-          as="button"
-          type="button"
-          w="100%"
-          display="flex"
-          alignItems="center"
-          gap="12px"
-          px="20px"
-          py="16px"
-          background="transparent"
-          border="none"
-          cursor="pointer"
-          style={{ textAlign: 'left' }}
-          onClick={() => setIsOpen((open) => !open)}
-        >
-          <Icon
-            name={isOpen ? 'chevron-down' : 'chevron-right'}
-            width="20px"
-            height="20px"
-            fill={colors.coolGrey600}
+        {usingPlatformDefaults ? (
+          <PlatformDefaultsHeader
+            title={title}
+            action={action}
+            processing={processing}
+            isOpen={isOpen}
+            onToggle={() => setIsOpen((open) => !open)}
+            onOverride={handleOverride}
           />
-          <Box flex="0 0 auto">
-            <Title variant="h4" as="h3" m="0" color="primary">
-              {title}
-            </Title>
-          </Box>
-
-          {/* When collapsed, the summary chips stand in for the whole panel. */}
-          {!isOpen && (
-            <Box
-              display="flex"
-              alignItems="center"
-              gap="6px"
-              flexWrap="wrap"
-              ml="4px"
-            >
-              {summary.map((chip) => (
-                <Chip key={chip.key} chip={chip} />
-              ))}
+        ) : (
+          <Box
+            className={`e2e-action-accordion-${action}`}
+            data-cy={`e2e-action-accordion-${action}`}
+            as="button"
+            type="button"
+            w="100%"
+            display="flex"
+            alignItems="center"
+            gap="12px"
+            px="20px"
+            py="16px"
+            background="transparent"
+            border="none"
+            cursor="pointer"
+            style={{ textAlign: 'left' }}
+            onClick={() => setIsOpen((open) => !open)}
+          >
+            <Icon
+              name={isOpen ? 'chevron-down' : 'chevron-right'}
+              width="20px"
+              height="20px"
+              fill={colors.coolGrey600}
+            />
+            <Box flex="0 0 auto">
+              <Title variant="h4" as="h3" m="0" color="primary">
+                {title}
+              </Title>
             </Box>
-          )}
-        </Box>
+
+            {/* When collapsed, the summary chips stand in for the whole panel. */}
+            {!isOpen && (
+              <Box
+                display="flex"
+                alignItems="center"
+                gap="6px"
+                flexWrap="wrap"
+                ml="4px"
+              >
+                {summary.map((chip) => (
+                  <Chip key={chip.key} chip={chip} />
+                ))}
+              </Box>
+            )}
+          </Box>
+        )}
 
         {isOpen && (
           <Box
@@ -168,42 +211,12 @@ const ActionForm = ({
             className={`e2e-action-form-${action}`}
             data-cy={`e2e-action-form-${action}`}
           >
-            <Divider mt="0" mb="20px" />
-
-            <AccessSection
-              permission={permissionData}
-              showAnyone={showAnyone}
-              onChange={onChange}
-            />
-
-            {/* Admins-only is a closed gate — nothing else applies. For the
-                other modes, demographics can be collected (the account-only
-                parts hide themselves inside DataSection). */}
-            {!isAdmins && (
-              <>
-                <Divider my="24px" />
-                <DataSection
-                  permission={permissionData}
-                  phaseId={phaseId}
-                  onChange={onChange}
-                />
-              </>
-            )}
-
-            {onRevertToDefaults && (
-              <Box mt="24px">
-                <Button
-                  buttonStyle="text"
-                  width="auto"
-                  padding="0px"
-                  dataCy={`e2e-revert-to-platform-defaults-${action}`}
-                  onClick={() => setRevertModalOpened(true)}
-                >
-                  <span style={{ textDecorationLine: 'underline' }}>
-                    <FormattedMessage {...messages.revertToPlatformDefaults} />
-                  </span>
-                </Button>
-              </Box>
+            {usingPlatformDefaults ? (
+              <ReadOnlyOverlay data-cy={`e2e-read-only-overlay-${action}`}>
+                {body}
+              </ReadOnlyOverlay>
+            ) : (
+              body
             )}
           </Box>
         )}

--- a/front/app/components/admin/ActionForm/ui.tsx
+++ b/front/app/components/admin/ActionForm/ui.tsx
@@ -11,6 +11,8 @@ import {
   IconTooltip,
   colors,
 } from '@citizenlab/cl2-component-library';
+import { transparentize } from 'polished';
+import styled from 'styled-components';
 
 import { SummaryChip } from './logic';
 
@@ -141,6 +143,7 @@ export const Expander = ({
   return (
     <Box data-cy={dataCy}>
       <Box
+        data-expander-toggle
         as="button"
         type="button"
         w="100%"
@@ -188,3 +191,31 @@ export const Expander = ({
     </Box>
   );
 };
+
+/**
+ * Read-only view of a panel whose settings are not its own to change (they are
+ * inherited from the platform defaults). Everything inside is put under a grey
+ * wash and made inert, except the expander toggles: those only show and hide
+ * information, so they stay usable and are lifted above the wash.
+ */
+export const ReadOnlyOverlay = styled(Box)`
+  position: relative;
+
+  > * {
+    pointer-events: none;
+  }
+
+  [data-expander-toggle] {
+    position: relative;
+    z-index: 2;
+    pointer-events: auto;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background-color: ${transparentize(0.35, colors.grey200)};
+  }
+`;

--- a/front/app/components/admin/ActionForm/ui.tsx
+++ b/front/app/components/admin/ActionForm/ui.tsx
@@ -216,6 +216,6 @@ export const ReadOnlyOverlay = styled(Box)`
     position: absolute;
     inset: 0;
     z-index: 1;
-    background-color: ${transparentize(0.35, colors.grey200)};
+    background-color: ${transparentize(0.65, colors.grey200)};
   }
 `;

--- a/front/cypress/e2e/auth/permission_override.cy.ts
+++ b/front/cypress/e2e/auth/permission_override.cy.ts
@@ -84,10 +84,22 @@ describe('Access rights: overriding and inheriting the platform defaults', () =>
     cy.dataCy('e2e-confirm-revert-to-platform-defaults').click();
     cy.wait('@inherit');
 
-    // Back to the inherited state, and the overridden setting is gone with it.
-    cy.dataCy('e2e-action-form-posting_idea').should('not.exist');
-    cy.dataCy('e2e-action-inherited-posting_idea')
-      .find('[data-cy="e2e-platform-defaults-header"]')
-      .should('be.visible');
+    // Back to the inherited state: the settings are still there to be read,
+    // under the read-only overlay.
+    cy.dataCy('e2e-action-inherited-posting_idea').within(() => {
+      cy.dataCy('e2e-platform-defaults-header').should('be.visible');
+      cy.dataCy('e2e-read-only-overlay-posting_idea').should('be.visible');
+    });
+
+    // The overridden setting is gone with it: the panel shows the platform
+    // default again. Its expanders still open, they only show information.
+    cy.reload();
+    cy.dataCy('e2e-action-inherited-posting_idea').within(() => {
+      cy.dataCy('e2e-action-accordion-posting_idea').click();
+      cy.dataCy('e2e-personal-info-section').find('button').first().click();
+      cy.dataCy('e2e-require-name-toggle')
+        .find('input[type="checkbox"]')
+        .should('be.checked');
+    });
   });
 });


### PR DESCRIPTION
# Changelog
## Fixed
- Phase access rights: for managers, "platform defaults" link was not working. Now it's only a link for admins, and you can expand the whole thing to see what settings are active (but not change them until you override)