### PR TITLE
Bump css_parser to 3.0.0 (CVE-2026-53727)

### DIFF
--- a/back/Gemfile.lock
+++ b/back/Gemfile.lock
@@ -492,8 +492,9 @@ GEM
     crass (1.0.7)
     crawler_detect (1.2.9)
       qonfig (>= 0.24)
-    css_parser (1.22.0)
+    css_parser (3.0.0)
       addressable
+      ssrf_filter (~> 1.5)
     csv (3.3.0)
     dalli (3.2.8)
     database_cleaner (2.1.0)


### PR DESCRIPTION
# Changelog

## Technical
- Bump `css_parser` 1.22.0 → 3.0.0, clearing the `bundler-audit` failure for CVE-2026-53727 / GHSA-9pmc-p236-855h (SSRF and local file disclosure in `CssParser::Parser#read_remote_file`). Not reachable in our setup — the only consumer is `premailer` (via `premailer-rails`), which strips `<link rel="stylesheet">` tags itself and passes no `base_url`, so `load_uri!` and `@import` following never run.
- No new gems enter the tree: `ssrf_filter`, the new `css_parser` dependency, was already locked at 1.5.0 via `carrierwave`.
- Low-risk despite crossing two majors: `rule_set.rb` is byte-identical between 1.22.0 and 3.0.0 and the API `premailer` uses (`Parser.new`, `RuleSet.new`, `merge`, `convert_uris`, `add_block!`) is unchanged. Outside the remote-fetch path the only behaviour change is that `rgb()`/`rgba()`/`hsl()`/`hsla()` values with an omitted integer part (e.g. `.1`) are no longer silently dropped. `bundle-audit` is clean and the mailer specs pass (813 examples, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)