### PR TITLE
Flaky E2E Fix: custom_pages_widget.cy.ts — Wait for the homepage save instead of sleeping

### DIFF
--- a/front/cypress/e2e/homepage_builder/custom_pages_widget.cy.ts
+++ b/front/cypress/e2e/homepage_builder/custom_pages_widget.cy.ts
@@ -1,28 +1,64 @@
 import { randomString } from '../../support/commands';
 
+// craft.js renders the builder frame straight away and only deserializes the
+// saved layout into it once the layout request comes back, replacing whatever
+// the canvas held. Dropping a widget in before that happens loses it, and a
+// `not.exist` check before it passes for the wrong reason.
+function waitForLayoutToRender() {
+  cy.get('#e2e-content-builder-frame').children().should('have.length.gt', 0);
+}
+
+function goToHomepageBuilder() {
+  cy.setAdminLoginCookie();
+  cy.visit('en/admin/pages-menu/homepage-builder');
+  waitForLayoutToRender();
+}
+
+function goToHomepage() {
+  cy.goToLandingPage();
+  waitForLayoutToRender();
+}
+
+function saveHomepage() {
+  cy.intercept(
+    'POST',
+    '**/home_pages/content_builder_layouts/homepage/upsert'
+  ).as('updateHomepage');
+  cy.get('#e2e-content-builder-topbar-save').click();
+  cy.wait('@updateHomepage').its('response.statusCode').should('eq', 200);
+}
+
 describe('Custom Pages widget', () => {
   const pageTitle = randomString(8);
   let customPageId: string;
+  let homepageLayout: Record<string, unknown>;
 
   before(() => {
+    cy.apiGetHomepageLayout().then((layout) => {
+      homepageLayout = layout.body.data.attributes.craftjs_json;
+    });
     // Create a custom page so it can be selected in the widget
     cy.apiCreateCustomPage(pageTitle).then((page) => {
       customPageId = page.body.data.id;
     });
   });
 
+  beforeEach(() => {
+    // The widget this test adds is saved to the homepage, so it outlives the
+    // test. Without putting the layout back, a retry after a failed attempt
+    // finds two widgets, and cy.click() rejects a multi-element subject.
+    cy.apiUpdateHomepageLayout({ craftjs_json: homepageLayout });
+  });
+
   after(() => {
+    cy.apiUpdateHomepageLayout({ craftjs_json: homepageLayout });
     if (customPageId) {
       cy.apiRemoveCustomPage(customPageId);
     }
   });
 
   it('can be added', () => {
-    // Go to the homepage builder
-    cy.setAdminLoginCookie();
-    cy.visit('en/admin/pages-menu/homepage-builder');
-    cy.get('#e2e-content-builder-frame').should('exist');
-    cy.wait(1000);
+    goToHomepageBuilder();
 
     cy.get('#e2e-draggable-custom-pages').dragAndDrop(
       '#e2e-content-builder-frame',
@@ -30,7 +66,6 @@ describe('Custom Pages widget', () => {
         position: 'inside',
       }
     );
-    cy.wait(1000);
 
     // Add a custom page to the widget via its settings panel
     cy.get('#custom-page-search-input').type(pageTitle);
@@ -39,32 +74,24 @@ describe('Custom Pages widget', () => {
     // The widget now renders the selected page in the builder
     cy.get('.e2e-custom-pages-widget').should('exist');
 
-    // Save
-    cy.get('#e2e-content-builder-topbar-save').click();
+    saveHomepage();
 
     // Check if widget is displayed in homepage
-    cy.goToLandingPage();
+    goToHomepage();
     cy.get('.e2e-custom-pages-widget').should('exist');
     cy.get('.e2e-custom-page-card').should('contain', pageTitle);
 
     // Delete widget again
-    cy.setAdminLoginCookie();
-    cy.visit('en/admin/pages-menu/homepage-builder');
-    cy.get('#e2e-content-builder-frame').should('exist');
-    cy.wait(1000);
+    goToHomepageBuilder();
 
     cy.get('.e2e-custom-pages-widget').click('top', { force: true });
 
     cy.get('#e2e-delete-button').click();
 
-    // Save
-    cy.get('#e2e-content-builder-topbar-save').click();
-    cy.wait(1000);
+    saveHomepage();
 
     // Make sure it's not on homepage
-    cy.goToLandingPage();
-    cy.reload();
-    cy.wait(4000);
+    goToHomepage();
     cy.get('.e2e-custom-pages-widget').should('not.exist');
   });
 });

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -88,6 +88,7 @@ declare global {
       apiOverridePhasePermission: typeof apiOverridePhasePermission;
       intersectsViewport: typeof intersectsViewport;
       notIntersectsViewport: typeof notIntersectsViewport;
+      apiGetHomepageLayout: typeof apiGetHomepageLayout;
       apiUpdateHomepageLayout: typeof apiUpdateHomepageLayout;
       apiUpdateAppConfiguration: typeof apiUpdateAppConfiguration;
       clickLocaleSwitcherAndType: typeof clickLocaleSwitcherAndType;
@@ -1858,6 +1859,21 @@ function clickLocaleSwitcherAndType(title: string) {
   });
 }
 
+function apiGetHomepageLayout() {
+  return cy.apiLogin('admin@govocal.com', 'democracy2.0').then((response) => {
+    const adminJwt = response.body.jwt;
+
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${adminJwt}`,
+      },
+      method: 'GET',
+      url: `web_api/v1/home_pages/content_builder_layouts/homepage`,
+    });
+  });
+}
+
 function apiUpdateHomepageLayout({
   craftjs_json,
 }: {
@@ -2538,6 +2554,7 @@ Cypress.Commands.add(
   { prevSubject: true },
   notIntersectsViewport
 );
+Cypress.Commands.add('apiGetHomepageLayout', apiGetHomepageLayout);
 Cypress.Commands.add('apiUpdateHomepageLayout', apiUpdateHomepageLayout);
 Cypress.Commands.add('apiRemoveCustomPage', apiRemoveCustomPage);
 Cypress.Commands.add('apiCreateCustomPage', apiCreateCustomPage);


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

# Context

`cypress/e2e/homepage_builder/custom_pages_widget.cy.ts` — "Custom Pages
widget › can be added". First failure in 27 nightly runs, on 2026-08-21.

The reported error (`cy.click() can only be called on a single element.
Your subject contained 3 elements`) was a cascade, not the original
failure. The three failure screenshots show attempt 1 failing on the final
`should('not.exist')` with one widget on the homepage, then attempts 2 and
3 failing on the click with 2 and then 3 widgets in the canvas.

Two things combined:

1. The spec clicked Save and then did `cy.wait(1000)` before
   `cy.goToLandingPage()`, which is a full `cy.visit('/')`. That aborts the
   in-flight `POST /home_pages/content_builder_layouts/homepage/upsert`, so
   on a slow node the deletion was never persisted and the widget was still
   on the homepage. The same spec navigated away from the first save with no
   wait at all.
2. The widget is saved to the homepage, so it outlives the test, and the
   spec cleaned it up only inline at the end of the happy path. Each Cypress
   retry added another widget on top of the leftovers, so the class selector
   matched more elements every attempt.

There is a third race in the same family: the drag was gated only on
`#e2e-content-builder-frame` existing, but that element renders before the
layout arrives. `ContentBuilderFrame` calls `actions.deserialize(editorData)`
when the layout response lands, replacing the whole canvas, so a drop that
beats the response is discarded.

# Fix

Waiting on the upsert intercept is already the pattern in `areas_widget.cy.ts`
and every `project_description_builder` spec; this spec was the outlier using
fixed sleeps.

- `saveHomepage()` waits for `@updateHomepage` and asserts a 200 before
  navigating away.
- `waitForLayoutToRender()` gates on the frame actually holding nodes,
  replacing `cy.wait(1000)` and `cy.wait(4000)`. This also stops the final
  `not.exist` check from passing against a page that has not rendered yet.
- `beforeEach` restores the layout snapshot taken in `before()`, via a new
  `cy.apiGetHomepageLayout()` command, so every retry attempt starts from an
  identical homepage.

The `{ force: true }` click is unchanged: `CustomPages` is in
`WIDGETS_WITHOUT_POINTER_EVENTS`, so its content cannot take a real click,
and the click target was not part of the failure.

# Stability evidence

Local Cypress cannot run on this machine, so validation was on CI: three
concurrent pipelines at `e2e_parallelism: 6` — 18 repetitions under mutual
load — all green with zero failure screenshots.

- https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/348370
- https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/348371
- https://app.circleci.com/pipelines/github/CitizenLabDotCo/citizenlab/348372

# Changelog

## Technical
- Fixed the flaky `custom_pages_widget` e2e spec.
