### PR TITLE
[TAN-8553] Handle existing white space widgets causing extra space

### DIFF
--- a/back/lib/tasks/single_use/20260821_remove_redundant_white_space_widgets.rake
+++ b/back/lib/tasks/single_use/20260821_remove_redundant_white_space_widgets.rake
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require_relative 'services/redundant_white_space_remover'
+
+# Project pages got automatic spacing between widgets (TAN-8489). Spacers admins had
+# inserted by hand to compensate for the old cramped layout now stack their own height
+# on top of the automatic gap, roughly doubling the space around them. This removes the
+# spacers the rhythm made redundant: every WhiteSpace in a `project_page` layout with a
+# widget on both sides. Divider, large, leading and trailing spacers are kept and
+# printed for review (see RedundantWhiteSpaceRemover).
+#
+# The report holds each layout's craftjs_json before and after, so any removal can be
+# restored from it.
+#
+#     rake single_use:remove_redundant_white_space_widgets                     # dry run, all tenants
+#     rake 'single_use:remove_redundant_white_space_widgets[execute]'          # write, all tenants
+#     rake 'single_use:remove_redundant_white_space_widgets[execute,foo.com]'  # write, one tenant
+namespace :single_use do
+  desc "Remove WhiteSpace widgets made redundant by the project page vertical rhythm. Dry run unless passed 'execute'."
+  task :remove_redundant_white_space_widgets, %i[execute host] => [:environment] do |_t, args|
+    remover = Tasks::SingleUse::Services::RedundantWhiteSpaceRemover.new
+    review_lines = []
+
+    print_review = lambda do |_script|
+      next if review_lines.empty?
+
+      # rubocop:disable Rails/Output -- run by hand at a terminal, like TenantScript itself.
+      puts "\n   📋 Kept spacers to review by hand:"
+      review_lines.each { |line| puts "      #{line}" }
+      # rubocop:enable Rails/Output
+    end
+
+    TenantScript.run(
+      'remove_redundant_white_space_widgets',
+      args: args,
+      description: 'removing WhiteSpace widgets made redundant by the vertical rhythm',
+      summary: print_review
+    ) do |tenant, script|
+      layouts = ContentBuilder::Layout
+        .where(code: ContentBuilder::ProjectPageLayoutService::CODE)
+        .with_widget_type(Tasks::SingleUse::Services::RedundantWhiteSpaceRemover::WHITE_SPACE)
+
+      layouts.find_each do |layout|
+        result = remover.call(layout.craftjs_json)
+        context = {
+          tenant: tenant.host,
+          layout_id: layout.id,
+          project_id: layout.content_buildable_id,
+          enabled: layout.enabled
+        }
+
+        result.review.each do |item|
+          review_lines << "#{tenant.host} project #{layout.content_buildable_id}: " \
+                          "#{item[:reason]} #{item[:size]} spacer (node #{item[:id]})"
+        end
+
+        next if result.removed.empty?
+
+        result.removed.each do |item|
+          script.reporter.add_delete('WhiteSpace node', item[:id], context: context.merge(item.except(:id)))
+        end
+        script.reporter.add_change(layout.craftjs_json, result.json, context: context.merge(removed_count: result.removed.size))
+        # update_column: sanitization/validation callbacks are for admin input, and must
+        # not be able to block or alter a removal on legacy layouts.
+        layout.update_column(:craftjs_json, result.json) if script.execute?
+      end
+    end
+  end
+end

--- a/back/lib/tasks/single_use/services/redundant_white_space_remover.rb
+++ b/back/lib/tasks/single_use/services/redundant_white_space_remover.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Tasks
+  module SingleUse
+    module Services
+      # Removes WhiteSpace nodes made redundant by the automatic vertical rhythm on
+      # project pages (front: components/admin/ContentBuilder/verticalRhythm.ts).
+      # A spacer sitting between two widgets now stacks its own height on top of the
+      # automatic gap, roughly doubling the space admins complained about.
+      #
+      # Removable: a spacer (or run of consecutive spacers) with a kept sibling on
+      # both sides. Kept, and returned for human review instead:
+      # - `withDivider: true` — renders a visible divider line: content, not spacing;
+      # - size `large` — tall enough that it likely marks deliberate separation;
+      # - leading/trailing spacers — page padding the rhythm does not replace;
+      # - anything unexpectedly carrying children.
+      #
+      # Pure JSON-in/JSON-out so the rake task owns all reporting and writing.
+      class RedundantWhiteSpaceRemover
+        WHITE_SPACE = 'WhiteSpace'
+
+        Result = Struct.new(:json, :removed, :review, keyword_init: true)
+
+        def call(craftjs_json)
+          json = deep_copy(craftjs_json)
+          removed = []
+          review = []
+
+          json.each do |parent_id, parent|
+            children = parent['nodes']
+            next unless children.is_a?(Array) && children.any? { |id| white_space?(json[id]) }
+
+            removable_runs(json, children, review, parent_id).each do |run|
+              run.each do |id|
+                removed << removal_entry(json, children, id, parent_id)
+              end
+              children -= run
+              run.each { |id| json.delete(id) }
+            end
+            parent['nodes'] = children
+          end
+
+          Result.new(json: json, removed: removed, review: review)
+        end
+
+        private
+
+        def white_space?(node)
+          node.is_a?(Hash) && node.dig('type', 'resolvedName') == WHITE_SPACE
+        end
+
+        def removable?(node)
+          white_space?(node) &&
+            !node.dig('props', 'withDivider') &&
+            node.dig('props', 'size') != 'large' &&
+            node['nodes'].blank? &&
+            node['linkedNodes'].blank?
+        end
+
+        def kept_reason(node)
+          return 'has_children' if node['nodes'].present? || node['linkedNodes'].present?
+          return 'divider' if node.dig('props', 'withDivider')
+
+          'large' if node.dig('props', 'size') == 'large'
+        end
+
+        # Maximal runs of consecutive removable spacers, bounded on both sides by a
+        # kept sibling. Unbounded runs (touching the start or end of the children
+        # array) and kept spacers land on the review list.
+        def removable_runs(json, children, review, parent_id)
+          runs = children.slice_when { |a, b| removable?(json[a]) != removable?(json[b]) }.to_a
+
+          runs.filter_map do |run|
+            if removable?(json[run.first])
+              next run if run.first != children.first && run.last != children.last
+
+              reason = run.first == children.first ? 'leading' : 'trailing'
+              run.each { |id| review << review_entry(json, id, parent_id, reason) }
+            else
+              run.each do |id|
+                reason = white_space?(json[id]) && kept_reason(json[id])
+                review << review_entry(json, id, parent_id, reason) if reason
+              end
+            end
+            nil
+          end
+        end
+
+        def removal_entry(json, children, id, parent_id)
+          index = children.index(id)
+          {
+            id: id,
+            parent_id: parent_id,
+            size: json[id].dig('props', 'size').presence || 'small',
+            previous_widget: nearest_kept_widget(json, children, index, -1),
+            next_widget: nearest_kept_widget(json, children, index, 1)
+          }
+        end
+
+        # The nearest sibling in `direction` that will survive the removal, named for
+        # the report so a run can be checked against the page.
+        def nearest_kept_widget(json, children, index, direction)
+          cursor = index + direction
+          while cursor.between?(0, children.size - 1)
+            node = json[children[cursor]]
+            return node.dig('type', 'resolvedName') || node['type'] unless removable?(node)
+
+            cursor += direction
+          end
+          nil
+        end
+
+        def review_entry(json, id, parent_id, reason)
+          {
+            id: id,
+            parent_id: parent_id,
+            size: json[id].dig('props', 'size').presence || 'small',
+            reason: reason
+          }
+        end
+
+        def deep_copy(json)
+          JSON.parse(JSON.generate(json))
+        end
+      end
+    end
+  end
+end

--- a/back/spec/tasks/single_use/remove_redundant_white_space_widgets_spec.rb
+++ b/back/spec/tasks/single_use/remove_redundant_white_space_widgets_spec.rb
@@ -1,0 +1,344 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require Rails.root.join('lib/tasks/single_use/services/redundant_white_space_remover')
+
+# NOTE: single-use task specs are excluded from the suite (see spec_helper's `config.pattern`).
+# rubocop:disable RSpec/DescribeClass
+describe 'single_use:remove_redundant_white_space_widgets' do
+  def widget(name, parent, props: {}, nodes: [], linked_nodes: {})
+    {
+      'type' => { 'resolvedName' => name },
+      'nodes' => nodes,
+      'props' => props,
+      'custom' => {},
+      'hidden' => false,
+      'parent' => parent,
+      'isCanvas' => false,
+      'displayName' => name,
+      'linkedNodes' => linked_nodes
+    }
+  end
+
+  # A minimal project page: ROOT holding a body region with the given children.
+  def page_json(children)
+    {
+      'ROOT' => {
+        'type' => { 'resolvedName' => 'ProjectPageRoot' },
+        'nodes' => ['BODY'],
+        'props' => {},
+        'custom' => { 'region' => true },
+        'hidden' => false,
+        'parent' => nil,
+        'isCanvas' => true,
+        'displayName' => 'ProjectPageRoot',
+        'linkedNodes' => {}
+      },
+      'BODY' => {
+        'type' => { 'resolvedName' => 'ProjectPageBody' },
+        'nodes' => children.keys,
+        'props' => {},
+        'custom' => { 'region' => true },
+        'hidden' => false,
+        'parent' => 'ROOT',
+        'isCanvas' => true,
+        'displayName' => 'ProjectPageBody',
+        'linkedNodes' => {}
+      }
+    }.merge(children.transform_values { |node| node.merge('parent' => 'BODY') })
+  end
+
+  def white_space(props = {})
+    widget('WhiteSpace', 'BODY', props: props)
+  end
+
+  describe Tasks::SingleUse::Services::RedundantWhiteSpaceRemover do
+    subject(:result) { described_class.new.call(json) }
+
+    context 'with a spacer between two accordions' do
+      let(:json) do
+        page_json(
+          'ACC1' => widget('AccordionMultiloc', 'BODY'),
+          'WS' => white_space('size' => 'medium'),
+          'ACC2' => widget('AccordionMultiloc', 'BODY')
+        )
+      end
+
+      it 'removes the spacer node and its reference' do
+        expect(result.json).not_to have_key('WS')
+        expect(result.json['BODY']['nodes']).to eq %w[ACC1 ACC2]
+      end
+
+      it 'names the spacer and its neighbours' do
+        expect(result.removed).to contain_exactly(
+          hash_including(id: 'WS', size: 'medium', previous_widget: 'AccordionMultiloc', next_widget: 'AccordionMultiloc')
+        )
+      end
+
+      it 'leaves the other nodes untouched' do
+        expect(result.json['ACC1']).to eq json['ACC1']
+        expect(result.json.keys).to match_array(json.keys - ['WS'])
+      end
+
+      it 'does not mutate its input' do
+        expect { result }.not_to change { JSON.generate(json) }
+      end
+    end
+
+    context 'with a spacer between two buttons' do
+      let(:json) do
+        page_json(
+          'BTN1' => widget('ButtonMultiloc', 'BODY'),
+          'WS' => white_space,
+          'BTN2' => widget('ButtonMultiloc', 'BODY')
+        )
+      end
+
+      it 'removes the spacer' do
+        expect(result.json).not_to have_key('WS')
+        expect(result.removed.size).to eq 1
+      end
+    end
+
+    context 'with a spacer between a text widget and an accordion' do
+      let(:json) do
+        page_json(
+          'TEXT' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space,
+          'ACC' => widget('AccordionMultiloc', 'BODY')
+        )
+      end
+
+      it 'removes the spacer' do
+        expect(result.json).not_to have_key('WS')
+      end
+    end
+
+    context 'with a run of consecutive spacers between widgets' do
+      let(:json) do
+        page_json(
+          'BTN1' => widget('ButtonMultiloc', 'BODY'),
+          'WS1' => white_space,
+          'WS2' => white_space('size' => 'medium'),
+          'BTN2' => widget('ButtonMultiloc', 'BODY')
+        )
+      end
+
+      it 'removes the whole run' do
+        expect(result.json.keys).not_to include('WS1', 'WS2')
+        expect(result.json['BODY']['nodes']).to eq %w[BTN1 BTN2]
+      end
+
+      it 'reports neighbours across the run' do
+        expect(result.removed).to contain_exactly(
+          hash_including(id: 'WS1', previous_widget: 'ButtonMultiloc', next_widget: 'ButtonMultiloc'),
+          hash_including(id: 'WS2', previous_widget: 'ButtonMultiloc', next_widget: 'ButtonMultiloc')
+        )
+      end
+    end
+
+    context 'with a spacer next to a full-width section' do
+      let(:json) do
+        page_json(
+          'TEXT' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space,
+          'PHASES' => widget('PhasesWidget', 'BODY')
+        )
+      end
+
+      it 'removes the spacer' do
+        expect(result.json).not_to have_key('WS')
+      end
+    end
+
+    context 'with a divider spacer' do
+      let(:json) do
+        page_json(
+          'TEXT1' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space('withDivider' => true),
+          'TEXT2' => widget('TextMultiloc', 'BODY')
+        )
+      end
+
+      it 'keeps it and lists it for review' do
+        expect(result.json).to have_key('WS')
+        expect(result.removed).to be_empty
+        expect(result.review).to contain_exactly(hash_including(id: 'WS', reason: 'divider'))
+      end
+    end
+
+    context 'with a large spacer' do
+      let(:json) do
+        page_json(
+          'TEXT1' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space('size' => 'large'),
+          'TEXT2' => widget('TextMultiloc', 'BODY')
+        )
+      end
+
+      it 'keeps it and lists it for review' do
+        expect(result.json).to have_key('WS')
+        expect(result.review).to contain_exactly(hash_including(id: 'WS', reason: 'large'))
+      end
+    end
+
+    context 'with leading and trailing spacers' do
+      let(:json) do
+        page_json(
+          'WS1' => white_space,
+          'TEXT' => widget('TextMultiloc', 'BODY'),
+          'WS2' => white_space
+        )
+      end
+
+      it 'keeps both and lists them for review' do
+        expect(result.json.keys).to include('WS1', 'WS2')
+        expect(result.removed).to be_empty
+        expect(result.review).to contain_exactly(
+          hash_including(id: 'WS1', reason: 'leading'),
+          hash_including(id: 'WS2', reason: 'trailing')
+        )
+      end
+    end
+
+    context 'with a spacer bounded by a divider spacer and a widget' do
+      let(:json) do
+        page_json(
+          'TEXT' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space,
+          'DIVIDER' => white_space('withDivider' => true),
+          'ACC' => widget('AccordionMultiloc', 'BODY')
+        )
+      end
+
+      it 'removes the plain spacer and keeps the divider' do
+        expect(result.json).not_to have_key('WS')
+        expect(result.json).to have_key('DIVIDER')
+        expect(result.removed).to contain_exactly(
+          hash_including(id: 'WS', previous_widget: 'TextMultiloc', next_widget: 'WhiteSpace')
+        )
+      end
+    end
+
+    context 'with a spacer inside a column container' do
+      let(:json) do
+        page_json(
+          'COLS' => widget('TwoColumn', 'BODY', linked_nodes: { 'left' => 'LEFT' })
+        ).merge(
+          'LEFT' => {
+            'type' => { 'resolvedName' => 'Container' },
+            'nodes' => %w[TEXT1 COL_WS TEXT2],
+            'props' => {},
+            'custom' => {},
+            'hidden' => false,
+            'parent' => 'COLS',
+            'isCanvas' => true,
+            'displayName' => 'Container',
+            'linkedNodes' => {}
+          },
+          'TEXT1' => widget('TextMultiloc', 'LEFT'),
+          'COL_WS' => widget('WhiteSpace', 'LEFT'),
+          'TEXT2' => widget('TextMultiloc', 'LEFT')
+        )
+      end
+
+      it 'removes the spacer from the column' do
+        expect(result.json).not_to have_key('COL_WS')
+        expect(result.json['LEFT']['nodes']).to eq %w[TEXT1 TEXT2]
+      end
+    end
+
+    context 'with a spacer unexpectedly carrying children' do
+      let(:json) do
+        page_json(
+          'TEXT1' => widget('TextMultiloc', 'BODY'),
+          'WS' => white_space.merge('nodes' => ['CHILD']),
+          'TEXT2' => widget('TextMultiloc', 'BODY')
+        ).merge('CHILD' => widget('TextMultiloc', 'WS'))
+      end
+
+      it 'keeps it and lists it for review' do
+        expect(result.json).to have_key('WS')
+        expect(result.review).to contain_exactly(hash_including(id: 'WS', reason: 'has_children'))
+      end
+    end
+
+    context 'with a page that only has spacers' do
+      let(:json) { page_json('WS1' => white_space, 'WS2' => white_space) }
+
+      it 'removes nothing' do
+        expect(result.removed).to be_empty
+        expect(result.json.keys).to include('WS1', 'WS2')
+      end
+    end
+
+    context 'without any spacer' do
+      let(:json) { page_json('TEXT' => widget('TextMultiloc', 'BODY')) }
+
+      it 'returns the layout unchanged' do
+        expect(result.json).to eq json
+        expect(result.removed).to be_empty
+        expect(result.review).to be_empty
+      end
+    end
+  end
+
+  describe 'the rake task' do
+    subject(:run) { task.invoke('execute') }
+
+    before { load_rake_tasks_if_not_loaded }
+
+    let(:task) { Rake::Task['single_use:remove_redundant_white_space_widgets'] }
+    let(:json) do
+      page_json(
+        'ACC1' => widget('AccordionMultiloc', 'BODY'),
+        'WS' => white_space,
+        'ACC2' => widget('AccordionMultiloc', 'BODY')
+      )
+    end
+    let!(:layout) { create(:layout, code: 'project_page', craftjs_json: json) }
+
+    after do
+      task.reenable
+      FileUtils.rm_f('remove_redundant_white_space_widgets.json')
+      FileUtils.rm_f('remove_redundant_white_space_widgets_dry_run.json')
+    end
+
+    it 'removes the spacer from the stored layout' do
+      run
+
+      expect(layout.reload.craftjs_json).not_to have_key('WS')
+      expect(layout.craftjs_json['BODY']['nodes']).to eq %w[ACC1 ACC2]
+    end
+
+    it 'leaves layouts with another code alone' do
+      other = create(:layout, code: 'about_page', craftjs_json: json, project: create(:project))
+
+      run
+
+      expect(other.reload.craftjs_json).to have_key('WS')
+    end
+
+    it 'changes nothing on a dry run' do
+      task.invoke
+
+      expect(layout.reload.craftjs_json).to have_key('WS')
+    end
+
+    # The report is the rollback artifact: it must hold the layout as it was.
+    it 'snapshots the layout before and after in the report' do
+      run
+
+      report = JSON.parse(File.read('remove_redundant_white_space_widgets.json'))
+      change = report['changes'].sole
+      expect(change['old_value']).to have_key('WS')
+      expect(change['new_value']).not_to have_key('WS')
+      expect(change['context']).to include('layout_id' => layout.id, 'removed_count' => 1)
+      expect(report['deletes'].sole['context']).to include(
+        'previous_widget' => 'AccordionMultiloc',
+        'next_widget' => 'AccordionMultiloc'
+      )
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/front/app/components/DescriptionBuilder/Editor/Editor.tsx
+++ b/front/app/components/DescriptionBuilder/Editor/Editor.tsx
@@ -6,6 +6,7 @@ import {
   SerializedNodes,
   Resolver,
 } from '@craftjs/core';
+import styled from 'styled-components';
 
 import RenderNode from 'containers/Admin/pagesAndMenu/containers/ContentBuilder/components/Editor/RenderNode';
 
@@ -18,11 +19,22 @@ type EditorProps = {
   children?: React.ReactNode;
 };
 
+// A widget can render nothing (e.g. events on a project without events) while its
+// wrapper stays in the DOM; collapsing the empty wrapper stops its rhythm margin
+// from showing up as a phantom gap.
+const CollapsingWhenEmptyBox = styled(Box)`
+  &:empty {
+    display: none;
+  }
+`;
+
 // Without a wrapper element, craftjs crashes.
 const PlainDiv = ({ render }) => {
   const marginTop = useVerticalRhythmMargin();
 
-  return <Box mt={marginTop}>{render}</Box>;
+  return (
+    <CollapsingWhenEmptyBox mt={marginTop}>{render}</CollapsingWhenEmptyBox>
+  );
 };
 
 const Editor: React.FC<EditorProps> = ({


### PR DESCRIPTION
# Changelog

## Fixed
- Project pages no longer show doubled gaps where admins had inserted White space widgets before the automatic vertical spacing existed: a single-use task removes spacers that sit between two widgets (divider, large, and leading/trailing spacers are kept and listed for review). Dry run by default; the report holds each layout's before/after state.
- A widget that renders nothing (e.g. events on a project without events) no longer leaves its automatic spacing behind as a phantom gap.