### PR TITLE
Tan 8492 pending review approved when project is published

### DIFF
--- a/back/app/models/project_review.rb
+++ b/back/app/models/project_review.rb
@@ -63,8 +63,6 @@ class ProjectReview < ApplicationRecord
   # Who may approve this review: admins, moderators of the project's space, and moderators of
   # the project's folder (which includes moderators of that folder's own space).
   # Project moderators are excluded on purpose: they are the ones requesting the review.
-  # The `present?` guards matter: `space_moderator?(nil)` / `project_folder_moderator?(nil)`
-  # answer "moderates any space/folder", which would let an unrelated moderator through.
   def approvable_by?(user)
     return false if user.nil?
     return true if user.admin?

--- a/back/app/models/project_review.rb
+++ b/back/app/models/project_review.rb
@@ -60,13 +60,26 @@ class ProjectReview < ApplicationRecord
     self.updated_at = now
   end
 
+  # Who may approve this review: admins, moderators of the project's space, and moderators of
+  # the project's folder (which includes moderators of that folder's own space).
+  # Project moderators are excluded on purpose: they are the ones requesting the review.
+  # The `present?` guards matter: `space_moderator?(nil)` / `project_folder_moderator?(nil)`
+  # answer "moderates any space/folder", which would let an unrelated moderator through.
+  def approvable_by?(user)
+    return false if user.nil?
+    return true if user.admin?
+
+    role_service = UserRoleService.new
+    (project.space.present? && role_service.can_moderate?(project.space, user)) ||
+      (project.folder.present? && role_service.can_moderate?(project.folder, user)) ||
+      false
+  end
+
   private
 
   def validate_reviewer
     return if reviewer.nil?
-    return if reviewer.admin?
-    return if reviewer.space_moderator?(project.space_id)
-    return if reviewer.project_folder_moderator?(project.folder_id)
+    return if approvable_by?(reviewer)
 
     errors.add(:reviewer, 'must be an admin, a moderator of the project space, or a moderator of the project folder')
   end

--- a/back/app/policies/project_review_policy.rb
+++ b/back/app/policies/project_review_policy.rb
@@ -28,20 +28,10 @@ class ProjectReviewPolicy < ApplicationPolicy
   private
 
   def can_approve?
-    admin? || can_moderate_space? || can_moderate_folder?
+    record.approvable_by?(user)
   end
 
   def can_moderate_project?
     UserRoleService.new.can_moderate?(record.project, user)
-  end
-
-  def can_moderate_space?
-    space = record.project.space
-    space.present? && UserRoleService.new.can_moderate?(space, user)
-  end
-
-  def can_moderate_folder?
-    folder = record.project.folder
-    folder.present? && UserRoleService.new.can_moderate?(folder, user)
   end
 end

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -74,8 +74,10 @@ class SideFxProjectService
     CheckProjectPublicationConsistencyJob.perform_later(project.id)
 
     after_folder_changed project, user if @folder_id_was != project.folder_id
-    # Publishing a project (draft or archived) directly implicitly approves a review that is still pending
-    approve_pending_review(project, user) if project.admin_publication.published? && @publication_status_was != 'published'
+    # Publishing a project (draft or archived) directly implicitly approves a review that is still pending.
+    # Both sides read the raw column: `published?` also reports a due but not yet applied scheduled
+    # transition as published, which would approve the review on any unrelated update.
+    approve_pending_review(project, user) if project.admin_publication.publication_status == 'published' && @publication_status_was != 'published'
     # We don't want to send out the "project published" campaign when e.g. changing from "archived" to "published"
     after_publish project, user if project.admin_publication.published? && @publication_status_was == 'draft'
     enqueue_scheduled_transition(project.admin_publication)
@@ -165,7 +167,7 @@ class SideFxProjectService
     # A reviewer is mandatory to approve, so we cannot approve on behalf of nobody
     # (e.g. a scheduled transition whose scheduler has since been deleted).
     return if user.nil? || review.nil? || review.approved?
-    return unless user.admin? || user.space_moderator?(project.space_id) || user.project_folder_moderator?(project.folder_id)
+    return unless review.approvable_by?(user)
 
     review.approve!(user)
     SideFxProjectReviewService.new.after_update(review, user)

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -74,6 +74,8 @@ class SideFxProjectService
     CheckProjectPublicationConsistencyJob.perform_later(project.id)
 
     after_folder_changed project, user if @folder_id_was != project.folder_id
+    # Publishing a project (draft or archived) directly implicitly approves a review that is still pending
+    approve_pending_review(project, user) if project.admin_publication.published? && @publication_status_was != 'published'
     # We don't want to send out the "project published" campaign when e.g. changing from "archived" to "published"
     after_publish project, user if project.admin_publication.published? && @publication_status_was == 'draft'
     enqueue_scheduled_transition(project.admin_publication)
@@ -156,6 +158,17 @@ class SideFxProjectService
   def after_folder_changed(project, current_user)
     # Defined in core app to eliminate dependency between
     # idea assignment and folder engine.
+  end
+
+  def approve_pending_review(project, user)
+    review = project.review
+    # A reviewer is mandatory to approve, so we cannot approve on behalf of nobody
+    # (e.g. a scheduled transition whose scheduler has since been deleted).
+    return if user.nil? || review.nil? || review.approved?
+    return unless user.admin? || user.space_moderator?(project.space_id) || user.project_folder_moderator?(project.folder_id)
+
+    review.approve!(user)
+    SideFxProjectReviewService.new.after_update(review, user)
   end
 end
 

--- a/back/app/services/side_fx_project_service.rb
+++ b/back/app/services/side_fx_project_service.rb
@@ -74,6 +74,8 @@ class SideFxProjectService
     CheckProjectPublicationConsistencyJob.perform_later(project.id)
 
     after_folder_changed project, user if @folder_id_was != project.folder_id
+    # Changing a project from published to draft or archived implicitly deletes an approved review.
+    delete_approved_review(project, user) if project.admin_publication.publication_status != 'published' && @publication_status_was == 'published'
     # Publishing a project (draft or archived) directly implicitly approves a review that is still pending.
     # Both sides read the raw column: `published?` also reports a due but not yet applied scheduled
     # transition as published, which would approve the review on any unrelated update.
@@ -171,6 +173,14 @@ class SideFxProjectService
 
     review.approve!(user)
     SideFxProjectReviewService.new.after_update(review, user)
+  end
+
+  def delete_approved_review(project, user)
+    review = project.review
+    return if review.nil? || !review.approved?
+
+    review.destroy!
+    SideFxProjectReviewService.new.after_destroy(review, user)
   end
 end
 

--- a/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
+++ b/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Publishing a project used to bypass its pending review instead of resolving it, so projects
+# published straight from draft kept a review pending forever: it still shows as pending in the
+# admin UI, so this task removes the ones left behind.
+
+namespace :single_use do
+  desc 'Remove pending reviews for published projects'
+  task :remove_pending_reviews_for_published_projects, %i[execute host] => :environment do |_t, args|
+    execute = args[:execute] == 'execute'
+
+    puts "---------- STARTING TASK: Remove pending reviews for published projects ----------\n\n"
+    puts "Mode: #{execute ? 'EXECUTE - changes WILL be applied' : 'Dry run - no changes will be applied'}\n\n"
+
+    TenantScript.run(
+      'remove_pending_reviews_for_published_projects',
+      args: args,
+      description: 'remove pending reviews for published projects'
+    ) do |tenant, script|
+        ProjectReview.where(approved_at: nil)
+                     .joins(project: :admin_publication)
+                     .where.not(admin_publications: { first_published_at: nil })
+                     .find_each do |review|
+                        puts "Removing pending review #{review.id} for project #{review.project_id}"
+                        script.reporter.add_delete('ProjectReview', review.id, context: { tenant: tenant.host, project_id: review.project_id })
+                        review.destroy! if script.execute?
+                     end
+    end
+
+    puts "\n---------- FINISHED TASK: Remove pending reviews for published projects ----------\n\n"
+  end
+end

--- a/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
+++ b/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
@@ -19,7 +19,7 @@ namespace :single_use do
     ) do |tenant, script|
       ProjectReview.where(approved_at: nil)
         .joins(project: :admin_publication)
-        .where.not(admin_publications: { first_published_at: nil })
+        .where(admin_publications: { publication_status: 'published' })
         .find_each do |review|
         puts "Removing pending review #{review.id} for project #{review.project_id}"
         script.reporter.add_delete('ProjectReview', review.id, context: { tenant: tenant.host, project_id: review.project_id })

--- a/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
+++ b/back/lib/tasks/single_use/20260821_remove_pending_reviews_for_published_projects.rake
@@ -17,14 +17,14 @@ namespace :single_use do
       args: args,
       description: 'remove pending reviews for published projects'
     ) do |tenant, script|
-        ProjectReview.where(approved_at: nil)
-                     .joins(project: :admin_publication)
-                     .where.not(admin_publications: { first_published_at: nil })
-                     .find_each do |review|
-                        puts "Removing pending review #{review.id} for project #{review.project_id}"
-                        script.reporter.add_delete('ProjectReview', review.id, context: { tenant: tenant.host, project_id: review.project_id })
-                        review.destroy! if script.execute?
-                     end
+      ProjectReview.where(approved_at: nil)
+        .joins(project: :admin_publication)
+        .where.not(admin_publications: { first_published_at: nil })
+        .find_each do |review|
+        puts "Removing pending review #{review.id} for project #{review.project_id}"
+        script.reporter.add_delete('ProjectReview', review.id, context: { tenant: tenant.host, project_id: review.project_id })
+        review.destroy! if script.execute?
+      end
     end
 
     puts "\n---------- FINISHED TASK: Remove pending reviews for published projects ----------\n\n"

--- a/back/spec/models/project_review_spec.rb
+++ b/back/spec/models/project_review_spec.rb
@@ -41,8 +41,8 @@ RSpec.describe ProjectReview do
       end
 
       it 'valid if the reviewer is a moderator of the project folder' do
-        project = build_stubbed(:project)
-        folder = build_stubbed(:project_folder, projects: [project])
+        project = create(:project)
+        folder = create(:project_folder, projects: [project])
         project_review = build(:project_review, project: project)
         project_review.reviewer = create(:project_folder_moderator, project_folders: [folder])
         expect(project_review).to be_valid
@@ -106,6 +106,77 @@ RSpec.describe ProjectReview do
     it 'can be approved' do
       project_review.approved_at = Time.current
       expect(project_review).to be_approved
+    end
+  end
+
+  describe '#approvable_by?' do
+    context 'when the project is neither in a folder nor in a space' do
+      let(:review) { create(:project_review) }
+
+      it 'is false without a user' do
+        expect(review.approvable_by?(nil)).to be false
+      end
+
+      it 'is true for an admin' do
+        expect(review.approvable_by?(create(:admin))).to be true
+      end
+
+      it 'is false for a normal user' do
+        expect(review.approvable_by?(create(:user))).to be false
+      end
+
+      it 'is false for a moderator of the project itself' do
+        moderator = create(:project_moderator, projects: [review.project])
+        expect(review.approvable_by?(moderator)).to be false
+      end
+      
+      it 'is false for a moderator of an unrelated folder' do
+        expect(review.approvable_by?(create(:project_folder_moderator))).to be false
+      end
+
+      it 'is false for a moderator of an unrelated space' do
+        expect(review.approvable_by?(create(:space_moderator))).to be false
+      end
+    end
+
+    context 'when the project is in a folder' do
+      let(:project) { create(:project) }
+      let!(:folder) { create(:project_folder, projects: [project]) }
+      let(:review) { create(:project_review, project: project) }
+
+      it 'is true for a moderator of that folder' do
+        moderator = create(:project_folder_moderator, project_folders: [folder])
+        expect(review.approvable_by?(moderator)).to be true
+      end
+
+      it 'is false for a moderator of another folder' do
+        expect(review.approvable_by?(create(:project_folder_moderator))).to be false
+      end
+
+      context 'and the folder belongs to a space' do
+        let(:space) { create(:space) }
+        let!(:folder) { create(:project_folder, projects: [project], space: space) }
+
+        it 'is true for a moderator of that space' do
+          moderator = create(:space_moderator, spaces: [space])
+          expect(review.approvable_by?(moderator)).to be true
+        end
+      end
+    end
+
+    context 'when the project belongs to a space' do
+      let(:space) { create(:space) }
+      let(:project) { create(:project, space: space) }
+      let(:review) { create(:project_review, project: project) }
+
+      it 'is true for a moderator of that space' do
+        moderator = create(:space_moderator, spaces: [space])
+        expect(review.approvable_by?(moderator)).to be true
+      end
+
+      it 'is false for a moderator of another space' do
+        expect(review.approvable_by?(create(:space_moderator))).to be false
+      end
     end
   end
 

--- a/back/spec/models/project_review_spec.rb
+++ b/back/spec/models/project_review_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe ProjectReview do
         moderator = create(:project_moderator, projects: [review.project])
         expect(review.approvable_by?(moderator)).to be false
       end
-      
+
       it 'is false for a moderator of an unrelated folder' do
         expect(review.approvable_by?(create(:project_folder_moderator))).to be false
       end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -172,7 +172,7 @@ describe SideFxProjectService do
         create(:project_review, project: project, approved_at: nil)
       end
 
-      it 'approves the pending review when the project is published form draft' do
+      it 'approves the pending review when the project is published from draft' do
         project.admin_publication.update!(publication_status: 'draft')
 
         project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
@@ -184,7 +184,7 @@ describe SideFxProjectService do
         expect(project.review.reload.approved_at).not_to be_nil
       end
 
-      it 'approves the pending review when the project is published form archived' do
+      it 'approves the pending review when the project is published from archived' do
         project.admin_publication.update!(publication_status: 'archived')
 
         project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -165,8 +165,9 @@ describe SideFxProjectService do
         .not_to have_enqueued_job(ProcessScheduledPublicationTransitionsJob)
     end
 
-    context "when the project has a pending review" do
+    context 'when the project has a pending review' do
       let(:admin) { create(:admin) }
+
       before do
         create(:project_review, project: project, approved_at: nil)
       end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -164,6 +164,77 @@ describe SideFxProjectService do
       expect { service.after_update(project, user) }
         .not_to have_enqueued_job(ProcessScheduledPublicationTransitionsJob)
     end
+
+    context "when the project has a pending review" do
+      let(:admin) { create(:admin) }
+      before do
+        create(:project_review, project: project, approved_at: nil)
+      end
+
+      it 'approves the pending review when the project is published form draft' do
+        project.admin_publication.update!(publication_status: 'draft')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+        expect(project.review.reload.approved_at).not_to be_nil
+      end
+
+      it 'approves the pending review when the project is published form archived' do
+        project.admin_publication.update!(publication_status: 'archived')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+        expect(project.review.reload.approved_at).not_to be_nil
+      end
+
+      it 'does not approve the pending review when the project is already published' do
+        project.admin_publication.update!(publication_status: 'published')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+        expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'does not approve the pending review when there is no publisher' do
+        # Happens on a scheduled publication whose `scheduled_by` user has been deleted
+        project.admin_publication.update!(publication_status: 'draft')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, nil)
+
+        project.save!
+        expect { service.after_update(project, nil) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+
+        expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'does not approve the pending review when the publisher cannot review' do
+        moderator = create(:project_moderator, projects: [project])
+        project.admin_publication.update!(publication_status: 'archived')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, moderator)
+
+        project.save!
+        expect { service.after_update(project, moderator) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+
+        expect(project.review.reload.approved_at).to be_nil
+      end
+    end
   end
 
   describe 'after_destroy' do

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -217,9 +217,42 @@ describe SideFxProjectService do
 
         project.save!
         expect { service.after_update(project, nil) }
-          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', nil, anything, anything)
 
         expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'does not approve the pending review when a due scheduled publication has not been applied yet' do
+        project.admin_publication.update!(publication_status: 'draft')
+        # The transition is due, but the job has not materialized it yet, so the column is still 'draft'.
+        project.admin_publication.update_columns(
+          scheduled_status: 'published',
+          scheduled_at: 1.hour.ago,
+          scheduled_by_id: admin.id
+        )
+
+        project.assign_attributes(title_multiloc: { 'en' => 'An unrelated title change' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+        expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'approves the pending review when the scheduled publication is applied' do
+        project.admin_publication.update!(publication_status: 'draft')
+        project.admin_publication.update_columns(
+          scheduled_status: 'published',
+          scheduled_at: 1.hour.ago,
+          scheduled_by_id: admin.id
+        )
+
+        ProcessScheduledPublicationTransitionsJob.perform_now(project.admin_publication)
+
+        review = project.review.reload
+        expect(review.approved_at).not_to be_nil
+        expect(review.reviewer_id).to eq(admin.id)
       end
 
       it 'does not approve the pending review when the publisher cannot review' do
@@ -231,9 +264,79 @@ describe SideFxProjectService do
 
         project.save!
         expect { service.after_update(project, moderator) }
-          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', admin, anything, anything)
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', moderator, anything, anything)
 
         expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'does not approve the pending review when the publisher only moderates an unrelated folder' do
+        moderator = create(:project_folder_moderator)
+        project.admin_publication.update!(publication_status: 'draft')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, moderator)
+
+        project.save!
+        expect { service.after_update(project, moderator) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', moderator, anything, anything)
+
+        expect(project.review.reload.approved_at).to be_nil
+      end
+
+      it 'does not approve the pending review when the publisher only moderates an unrelated space' do
+        moderator = create(:space_moderator)
+        project.admin_publication.update!(publication_status: 'draft')
+
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+        service.before_update(project, moderator)
+
+        project.save!
+        expect { service.after_update(project, moderator) }
+          .not_to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', moderator, anything, anything)
+
+        expect(project.review.reload.approved_at).to be_nil
+      end
+
+      context 'when the project is in a folder' do
+        let(:folder) { create(:project_folder) }
+        let(:project) { create(:project, admin_publication_attributes: { parent_id: folder.admin_publication.id }) }
+
+        it 'approves the pending review when the publisher moderates that folder' do
+          moderator = create(:project_folder_moderator, project_folders: [folder])
+          project.admin_publication.update!(publication_status: 'draft')
+
+          project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+          service.before_update(project, moderator)
+
+          project.save!
+          expect { service.after_update(project, moderator) }
+            .to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', moderator, anything, anything)
+
+          review = project.review.reload
+          expect(review.approved_at).not_to be_nil
+          expect(review.reviewer_id).to eq(moderator.id)
+        end
+      end
+
+      context 'when the project belongs to a space' do
+        let(:space) { create(:space) }
+        let(:project) { create(:project, space: space) }
+
+        it 'approves the pending review when the publisher moderates that space' do
+          moderator = create(:space_moderator, spaces: [space])
+          project.admin_publication.update!(publication_status: 'draft')
+
+          project.assign_attributes(admin_publication_attributes: { publication_status: 'published' })
+          service.before_update(project, moderator)
+
+          project.save!
+          expect { service.after_update(project, moderator) }
+            .to have_enqueued_job(LogActivityJob).with(project, 'project_review_approved', moderator, anything, anything)
+
+          review = project.review.reload
+          expect(review.approved_at).not_to be_nil
+          expect(review.reviewer_id).to eq(moderator.id)
+        end
       end
     end
   end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -167,10 +167,7 @@ describe SideFxProjectService do
 
     context 'when the project has a pending review' do
       let(:admin) { create(:admin) }
-
-      before do
-        create(:project_review, project: project, approved_at: nil)
-      end
+      let!(:review) { create(:project_review, project: project, approved_at: nil) }
 
       it 'approves the pending review when the project is published from draft' do
         project.admin_publication.update!(publication_status: 'draft')
@@ -297,6 +294,19 @@ describe SideFxProjectService do
         expect(project.review.reload.approved_at).to be_nil
       end
 
+      it 'does not delete the pending review when the project is set back to draft' do
+        project.admin_publication.update!(publication_status: 'published')
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'draft' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .not_to have_enqueued_job(LogActivityJob)
+                    .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+
+        expect(project.reload.review).to eq(review)
+      end
+
       context 'when the project is in a folder' do
         let(:folder) { create(:project_folder) }
         let(:project) { create(:project, admin_publication_attributes: { parent_id: folder.admin_publication.id }) }
@@ -337,6 +347,39 @@ describe SideFxProjectService do
           expect(review.approved_at).not_to be_nil
           expect(review.reviewer_id).to eq(moderator.id)
         end
+      end
+    end
+
+    context 'when the project has an approved review' do
+      let(:admin) { create(:admin) }
+      let!(:review) { create(:project_review, project: project, approved_at: Time.current, reviewer: admin) }
+
+      before do
+        project.admin_publication.update!(publication_status: 'published')
+      end
+
+      it 'deletes the approved review when the project is set back to draft' do
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'draft' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .to have_enqueued_job(LogActivityJob)
+                .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+
+        expect(project.reload.review).to be_nil
+      end
+
+      it 'deletes the approved review when the project is set back to archived' do
+        project.assign_attributes(admin_publication_attributes: { publication_status: 'archived' })
+        service.before_update(project, admin)
+
+        project.save!
+        expect { service.after_update(project, admin) }
+          .to have_enqueued_job(LogActivityJob)
+                .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+
+        expect(project.reload.review).to be_nil
       end
     end
   end

--- a/back/spec/services/side_fx_project_service_spec.rb
+++ b/back/spec/services/side_fx_project_service_spec.rb
@@ -302,7 +302,7 @@ describe SideFxProjectService do
         project.save!
         expect { service.after_update(project, admin) }
           .not_to have_enqueued_job(LogActivityJob)
-                    .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+          .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
 
         expect(project.reload.review).to eq(review)
       end
@@ -365,7 +365,7 @@ describe SideFxProjectService do
         project.save!
         expect { service.after_update(project, admin) }
           .to have_enqueued_job(LogActivityJob)
-                .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+          .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
 
         expect(project.reload.review).to be_nil
       end
@@ -377,7 +377,7 @@ describe SideFxProjectService do
         project.save!
         expect { service.after_update(project, admin) }
           .to have_enqueued_job(LogActivityJob)
-                .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
+          .with(encode_frozen_resource(review), 'deleted', admin, anything, anything)
 
         expect(project.reload.review).to be_nil
       end

--- a/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
+++ b/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
@@ -64,5 +64,18 @@ describe 'single_use:remove_pending_reviews_for_published_projects rake task' do
       expect(report['deletes']).to be_empty
     end
   end
+
+  context 'when a published project is back to draft and has now a pending review' do
+    before do
+      project.admin_publication.update!(publication_status: 'published')
+      project.admin_publication.update!(publication_status: 'draft')
+    end
+
+    it 'leaves it alone' do
+      run_task
+      expect(ProjectReview.where(id: review.id)).to exist
+      expect(report['deletes']).to be_empty
+    end
+  end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
+++ b/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+describe 'single_use:remove_pending_reviews_for_published_projects rake task' do
+  before { load_rake_tasks_if_not_loaded }
+
+  after do
+    Rake::Task[task_name].reenable
+    FileUtils.rm_f(report_path)
+    FileUtils.rm_f(dry_run_report_path)
+  end
+
+  let(:task_name) { 'single_use:remove_pending_reviews_for_published_projects' }
+  let(:report_path) { Rails.root.join('remove_pending_reviews_for_published_projects.json') }
+  let(:dry_run_report_path) do
+    Rails.root.join('remove_pending_reviews_for_published_projects_dry_run.json')
+  end
+
+  let(:project) { create(:project) }
+  let!(:review) { create(:project_review, project: project, approved_at: nil) }
+
+  # The task writes only when passed 'execute', so most examples want it; `dry_run: true` drops it.
+  def run_task(dry_run: false, host: nil)
+    Rake::Task[task_name].invoke(dry_run ? nil : 'execute', host)
+  end
+
+  def report(path = report_path)
+    JSON.parse(File.read(path))
+  end
+
+  context 'when a published project has a pending review' do
+    before do
+      project.admin_publication.update!(publication_status: 'published')
+    end
+
+    it 'deletes it' do
+      run_task
+      expect(ProjectReview.where(id: review.id)).not_to exist
+    end
+
+    it 'records the deletion in the report' do
+      run_task
+      delete = report['deletes'].first
+      expect(delete['model_name']).to eq 'ProjectReview'
+      expect(delete['id']).to eq review.id
+      expect(delete['context']).to include('tenant' => Tenant.current.host, 'project_id'=> project.id)
+    end
+
+    it 'leaves it in place on a dry run, but still reports it' do
+      run_task(dry_run: true)
+      expect(ProjectReview.where(id: review.id)).to exist
+      expect(report(dry_run_report_path)['deletes'].first['id']).to eq review.id
+    end
+  end
+
+  context 'when a project  has an approved review' do
+    let!(:review) { create(:project_review, :approved, project: project) }
+
+    it 'leaves it alone' do
+      run_task
+      expect(ProjectReview.where(id: review.id)).to exist
+      expect(report['deletes']).to be_empty
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
+++ b/back/spec/tasks/single_use/remove_pending_reviews_for_published_projects_spec.rb
@@ -45,7 +45,7 @@ describe 'single_use:remove_pending_reviews_for_published_projects rake task' do
       delete = report['deletes'].first
       expect(delete['model_name']).to eq 'ProjectReview'
       expect(delete['id']).to eq review.id
-      expect(delete['context']).to include('tenant' => Tenant.current.host, 'project_id'=> project.id)
+      expect(delete['context']).to include('tenant' => Tenant.current.host, 'project_id' => project.id)
     end
 
     it 'leaves it in place on a dry run, but still reports it' do
@@ -55,7 +55,7 @@ describe 'single_use:remove_pending_reviews_for_published_projects rake task' do
     end
   end
 
-  context 'when a project  has an approved review' do
+  context 'when a project has an approved review' do
     let!(:review) { create(:project_review, :approved, project: project) }
 
     it 'leaves it alone' do

--- a/front/app/api/projects/useUpdateProject.ts
+++ b/front/app/api/projects/useUpdateProject.ts
@@ -1,5 +1,7 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CLErrorsWrapper } from 'typings';
+
+import projectReviewsKeys from 'api/project_reviews/keys';
 
 import fetcher from 'utils/cl-react-query/fetcher';
 
@@ -17,10 +19,17 @@ export const updateProject = async ({
   });
 
 const useUpdateProject = () => {
+  const queryClient = useQueryClient();
+
   return useMutation<IProject, CLErrorsWrapper, IUpdatedProjectProperties>({
     mutationFn: updateProject,
-    onSuccess: async (_data) => {
+    onSuccess: async (project) => {
       invalidateOnCRUD();
+      // A publication status change can delete or approve the project's review
+      // server-side, so the cached review no longer reflects the project.
+      queryClient.invalidateQueries({
+        queryKey: projectReviewsKeys.item({ projectId: project.data.id }),
+      });
     },
   });
 };

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ReviewFlow/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/ReviewFlow/index.tsx
@@ -32,9 +32,10 @@ const ReviewFlow = ({ project }: Props) => {
 
   const approvalPending = projectReview?.data.attributes.state === 'pending';
   const approvalGranted = projectReview?.data.attributes.state === 'approved';
+  const isPublished = project.attributes.publication_status === 'published';
 
   const showProjectApprovalButton = approvalPending && canReview;
-  const showReviewRequestButton = !canReview && !approvalGranted;
+  const showReviewRequestButton = !canReview && !approvalGranted && !isPublished;
 
   return (
     <>

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/index.tsx
@@ -54,6 +54,8 @@ const PublicationButtons = ({ project }: { project: IProjectData }) => {
     context: projectReview?.data.attributes.state === 'approved',
   });
 
+  const isPublished = project.attributes.publication_status === 'published';
+
   const [scheduleModalOpen, setScheduleModalOpen] = useState(false);
   const [changeStatusModalOpen, setChangeStatusModalOpen] = useState(false);
 
@@ -77,9 +79,12 @@ const PublicationButtons = ({ project }: { project: IProjectData }) => {
     }
   };
 
-  const showPublishButton = !isProjectReviewEnabled || canPublish;
+  // if the project is published, we show the publish button to allow unpublishing, even if the user cannot publish
+  const showPublishButton =
+    !isProjectReviewEnabled || isPublished || canPublish;
   const publishButtonDisabled =
     !canPublish && !project.attributes.first_published_at;
+
   return (
     <Box display="flex" gap="8px">
       {showPublishButton && (
@@ -106,7 +111,9 @@ const PublicationButtons = ({ project }: { project: IProjectData }) => {
         </Tooltip>
       )}
 
-      {isProjectReviewEnabled && <ReviewFlow project={project} />}
+      {isProjectReviewEnabled && !isPublished &&
+        (<ReviewFlow project={project} />
+        )}
 
       <ScheduleLaunchModal
         opened={scheduleModalOpen}

--- a/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectHeader/PublicationButtons/index.tsx
@@ -111,7 +111,7 @@ const PublicationButtons = ({ project }: { project: IProjectData }) => {
         </Tooltip>
       )}
 
-      {isProjectReviewEnabled && !isPublished &&
+      {isProjectReviewEnabled &&
         (<ReviewFlow project={project} />
         )}
 

--- a/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
@@ -96,7 +96,7 @@ describe('Admin publishing a project without approving it first', () => {
     before(() => {
       cy.apiCreateProject({
         title: randomString(),
-        description: randomString(30),
+        descriptionPreview: randomString(30),
         publicationStatus: 'draft',
       }).then((project) => {
         projectId = project.body.data.id;
@@ -152,7 +152,7 @@ describe('Admin publishing a project without approving it first', () => {
     before(() => {
       cy.apiCreateProject({
         title: randomString(),
-        description: randomString(30),
+        descriptionPreview: randomString(30),
         publicationStatus: 'draft',
       }).then((project) => {
         projectId = project.body.data.id;
@@ -195,5 +195,152 @@ describe('Admin publishing a project without approving it first', () => {
       cy.dataCy('e2e-request-approval').should('not.exist');
       cy.dataCy('e2e-request-approval-pending').should('not.exist');
     });
+  });
+});
+
+describe('Taking a published project out of publication', () => {
+  const managerPassword = randomString();
+
+  // Moving a published project back to draft or archived deletes its approved
+  // review, so the project manager has to go through the approval flow again.
+  (['draft', 'archived'] as const).forEach((newStatus) => {
+    describe(`when the project manager moves it to ${newStatus}`, () => {
+      const managerEmail = randomEmail();
+      let projectId: string;
+      let userId: string;
+
+      before(() => {
+        cy.apiCreateProject({
+          title: randomString(),
+          descriptionPreview: randomString(30),
+          publicationStatus: 'draft',
+        }).then((project) => {
+          projectId = project.body.data.id;
+
+          cy.apiCreateModeratorForProject({
+            firstName: 'Joan',
+            lastName: 'Doe',
+            email: managerEmail,
+            password: managerPassword,
+            projectId,
+          }).then((moderator) => {
+            userId = moderator.body.data.id;
+
+            // The manager requests approval, and the admin publishing the project
+            // implicitly approves the pending review.
+            cy.apiRequestProjectReview(
+              projectId,
+              managerEmail,
+              managerPassword
+            );
+            cy.apiEditProject({ projectId, publicationStatus: 'published' });
+          });
+        });
+      });
+
+      after(() => {
+        if (projectId && userId) {
+          cy.apiRemoveProject(projectId);
+          cy.apiRemoveUser(userId);
+        }
+      });
+
+      it('asks the project manager to request approval again', () => {
+        cy.setLoginCookie(managerEmail, managerPassword);
+
+        cy.intercept('GET', `**/projects/${projectId}/review`).as('getReview');
+        cy.intercept('GET', `**/projects/${projectId}/phases`).as('getPhases');
+        cy.intercept('PATCH', `**/projects/${projectId}`).as('updateProject');
+
+        cy.visit(`admin/projects/${projectId}`);
+        cy.wait(['@getReview', '@getPhases']);
+
+        cy.get('#e2e-publish').click();
+        cy.get(`.e2e-projectstatus-${newStatus}`).click();
+        cy.get('#e2e-change-status-submit').click();
+        cy.wait('@updateProject');
+
+        // The project update deletes the approved review server-side and
+        // invalidates the review query, so the buttons update without a reload.
+        cy.wait('@getReview');
+
+        cy.dataCy('e2e-request-approval').should('be.visible');
+        cy.dataCy('e2e-request-approval-pending').should('not.exist');
+        cy.get('#e2e-approve-project').should('not.exist');
+        // Without an approved review, the manager can no longer publish.
+        cy.get('#e2e-publish').should('not.exist');
+      });
+    });
+  });
+});
+
+// for a published project, an admin should still be able to fix a stuck review by clicking 'Approve'
+// while the project moderator will not see the approval button
+describe('A published project with a pending review', () => {
+  const managerEmail = randomEmail();
+  const managerPassword = randomString();
+  let projectId: string;
+  let userId: string;
+
+  before(() => {
+    cy.apiCreateProject({
+      title: randomString(),
+      descriptionPreview: randomString(30),
+      publicationStatus: 'draft',
+    }).then((project) => {
+      projectId = project.body.data.id;
+
+      cy.apiCreateModeratorForProject({
+        firstName: 'Jules',
+        lastName: 'Doe',
+        email: managerEmail,
+        password: managerPassword,
+        projectId,
+      }).then((moderator) => {
+        userId = moderator.body.data.id;
+
+        // The project is published first, so requesting approval afterwards leaves
+        // the review pending instead of it being implicitly approved.
+        cy.apiEditProject({ projectId, publicationStatus: 'published' });
+        cy.apiRequestProjectReview(projectId, managerEmail, managerPassword);
+      });
+    });
+  });
+
+  after(() => {
+    if (projectId && userId) {
+      cy.apiRemoveProject(projectId);
+      cy.apiRemoveUser(userId);
+    }
+  });
+
+  it('hides the approval buttons from the project manager', () => {
+    cy.setLoginCookie(managerEmail, managerPassword);
+
+    cy.intercept('GET', `**/projects/${projectId}/review`).as('getReview');
+    cy.intercept('GET', `**/projects/${projectId}/phases`).as('getPhases');
+
+    cy.visit(`admin/projects/${projectId}`);
+    cy.wait(['@getReview', '@getPhases']);
+
+    cy.get('#e2e-publish').should('be.visible').and('contain', 'Published');
+    cy.get('#e2e-approve-project').should('not.exist');
+    cy.dataCy('e2e-request-approval').should('not.exist');
+    cy.dataCy('e2e-request-approval-pending').should('not.exist');
+  });
+
+  // Runs after the test above, which leaves the review pending.
+  it('lets an admin approve it', () => {
+    cy.setLoginCookie('admin@govocal.com', 'democracy2.0');
+
+    cy.intercept('GET', `**/projects/${projectId}/review`).as('getReview');
+    cy.intercept('GET', `**/projects/${projectId}/phases`).as('getPhases');
+
+    cy.visit(`admin/projects/${projectId}`);
+    cy.wait(['@getReview', '@getPhases']);
+
+    cy.get('#e2e-approve-project').should('be.visible').click();
+    cy.get('#e2e-approve-project').should('not.exist');
+    cy.get('#e2e-publish').should('be.visible').and('contain', 'Published');
   });
 });

--- a/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
@@ -111,17 +111,7 @@ describe('Admin publishing a project without approving it first', () => {
           userId = moderator.body.data.id;
 
           // The manager requests approval, so the project has a pending review.
-          cy.apiLogin(managerEmail, managerPassword).then((response) => {
-            cy.request({
-              headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${response.body.jwt}`,
-              },
-              method: 'POST',
-              url: `web_api/v1/projects/${projectId}/review`,
-              body: {},
-            });
-          });
+          cy.apiRequestProjectReview(projectId, managerEmail, managerPassword);
         });
       });
     });
@@ -129,6 +119,7 @@ describe('Admin publishing a project without approving it first', () => {
     after(() => {
       if (projectId && userId) {
         cy.apiRemoveProject(projectId);
+        cy.apiRemoveUser(userId);
       }
     });
 
@@ -181,6 +172,7 @@ describe('Admin publishing a project without approving it first', () => {
     after(() => {
       if (projectId && userId) {
         cy.apiRemoveProject(projectId);
+        cy.apiRemoveUser(userId);
       }
     });
 

--- a/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
+++ b/front/cypress/e2e/admin/projects/project_approval_flow.cy.ts
@@ -84,3 +84,124 @@ describe('Admin project approval flow', () => {
     cy.get('#e2e-publish').should('contain', 'Published');
   });
 });
+
+describe('Admin publishing a project without approving it first', () => {
+  const managerPassword = randomString();
+
+  describe('when the project manager has requested approval', () => {
+    const managerEmail = randomEmail();
+    let projectId: string;
+    let userId: string;
+
+    before(() => {
+      cy.apiCreateProject({
+        title: randomString(),
+        description: randomString(30),
+        publicationStatus: 'draft',
+      }).then((project) => {
+        projectId = project.body.data.id;
+
+        cy.apiCreateModeratorForProject({
+          firstName: 'Jane',
+          lastName: 'Doe',
+          email: managerEmail,
+          password: managerPassword,
+          projectId,
+        }).then((moderator) => {
+          userId = moderator.body.data.id;
+
+          // The manager requests approval, so the project has a pending review.
+          cy.apiLogin(managerEmail, managerPassword).then((response) => {
+            cy.request({
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${response.body.jwt}`,
+              },
+              method: 'POST',
+              url: `web_api/v1/projects/${projectId}/review`,
+              body: {},
+            });
+          });
+        });
+      });
+    });
+
+    after(() => {
+      if (projectId && userId) {
+        cy.apiRemoveProject(projectId);
+      }
+    });
+
+    it('shows the Published button to the project manager', () => {
+      // The admin publishes the project without approving the pending review first.
+      cy.apiEditProject({ projectId, publicationStatus: 'published' });
+
+      cy.setLoginCookie(managerEmail, managerPassword);
+
+      cy.intercept('GET', `**/projects/${projectId}/review`).as('getReview');
+      cy.intercept('GET', `**/projects/${projectId}/phases`).as('getPhases');
+
+      cy.visit(`admin/projects/${projectId}`);
+      cy.wait(['@getReview', '@getPhases']);
+
+      cy.get('#e2e-publish')
+        .should('be.visible')
+        .and('contain', 'Published')
+        .and('not.be.disabled');
+      cy.dataCy('e2e-request-approval-pending').should('not.exist');
+      cy.dataCy('e2e-request-approval').should('not.exist');
+    });
+  });
+
+  describe('when the project manager has not requested approval', () => {
+    const managerEmail = randomEmail();
+    let projectId: string;
+    let userId: string;
+
+    before(() => {
+      cy.apiCreateProject({
+        title: randomString(),
+        description: randomString(30),
+        publicationStatus: 'draft',
+      }).then((project) => {
+        projectId = project.body.data.id;
+
+        cy.apiCreateModeratorForProject({
+          firstName: 'Jack',
+          lastName: 'Doe',
+          email: managerEmail,
+          password: managerPassword,
+          projectId,
+        }).then((moderator) => {
+          userId = moderator.body.data.id;
+        });
+      });
+    });
+
+    after(() => {
+      if (projectId && userId) {
+        cy.apiRemoveProject(projectId);
+      }
+    });
+
+    it('shows the Published button to the project manager', () => {
+      // The admin publishes the project, which was never submitted for review.
+      cy.apiEditProject({ projectId, publicationStatus: 'published' });
+
+      cy.setLoginCookie(managerEmail, managerPassword);
+
+      cy.intercept('GET', `**/projects/${projectId}/review`).as('getReview');
+      cy.intercept('GET', `**/projects/${projectId}/phases`).as('getPhases');
+
+      cy.visit(`admin/projects/${projectId}`);
+      cy.wait(['@getReview', '@getPhases']);
+
+      cy.get('#e2e-publish')
+        .should('be.visible')
+        .and('contain', 'Published')
+        .and('not.be.disabled');
+      cy.dataCy('e2e-request-approval').should('not.exist');
+      cy.dataCy('e2e-request-approval-pending').should('not.exist');
+    });
+  });
+});

--- a/front/cypress/support/commands.ts
+++ b/front/cypress/support/commands.ts
@@ -120,6 +120,7 @@ declare global {
       apiCreateInputTopic: typeof apiCreateInputTopic;
       deleteEventAttendances: typeof deleteEventAttendances;
       apiRemoveIdeas: typeof apiRemoveIdeas;
+      apiRequestProjectReview: typeof apiRequestProjectReview;
     }
   }
 }
@@ -2335,6 +2336,24 @@ function createProjectWithIdeationPhase({
     });
 }
 
+function apiRequestProjectReview(
+  projectId: string,
+  email: string,
+  password: string
+) {
+  return cy.apiLogin(email, password).then((response) => {
+    return cy.request({
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${response.body.jwt}`,
+      },
+      method: 'POST',
+      url: `web_api/v1/projects/${projectId}/review`,
+      body: {},
+    });
+  });
+}
+
 /**
  * Get an element by its data-cy attribute.
  * This is a utility function to make it easier to find elements by their data-cy attribute.
@@ -2567,3 +2586,4 @@ Cypress.Commands.add(
   createProjectWithIdeationPhase
 );
 Cypress.Commands.add('apiCreateInputTopic', apiCreateInputTopic);
+Cypress.Commands.add('apiRequestProjectReview', apiRequestProjectReview);


### PR DESCRIPTION
🎩 **What? Why?**
When the admin directly published the project, the project_manager still sees 'waiting approval' in the back office of the project, even though the project has already been published.
Now the pending review if it exists is approved in this case. 
Published button is also displayed for the project manager when an admin publishes a project for which no review was ever requested.
If a published project with an approved review is set to draft or archived, the approved review is deleted, so the project moderator will have to ask for approval before re-publishing the project.

This PR also contains a new method in project_review model, approvable_by?, to refactor the code.


✅ **Tasks**
- [X] add rake task to remove pending reviews for published projects
- [X] add tests

# Changelog
## Fixed
- approve pending review if admin directly publishes the project
- display published button for project manager when admin publishes a project for which no review was ever requested
- approval will be needed again if a published project with approved review is set back to draft or archived