### PR TITLE
[TAN-8555] Don't render the Spaces filter on BO folders list view when the feature is inactive

### DIFF
--- a/front/app/containers/Admin/projects/all/Folders/Filters/index.test.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Filters/index.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+import { render, screen } from 'utils/testUtils/rtl';
+
+import Filters from '.';
+
+let mockSpacesEnabled = true;
+jest.mock('hooks/useFeatureFlag', () => () => mockSpacesEnabled);
+
+// The filters read the admin projects search params; there is no router here.
+jest.mock('utils/router', () => ({
+  ...jest.requireActual('utils/router'),
+  useSearch: () => ({}),
+}));
+
+jest.mock('api/users/useUsers');
+jest.mock('api/spaces/useSpaces', () => () => ({
+  data: undefined,
+  isLoading: false,
+}));
+
+describe('Folders Filters — spaces filter', () => {
+  beforeEach(() => {
+    mockSpacesEnabled = true;
+  });
+
+  it('shows the spaces filter when the spaces feature flag is enabled', () => {
+    render(<Filters />);
+
+    expect(screen.getByText('Spaces')).toBeInTheDocument();
+  });
+
+  it('does not show the spaces filter when the spaces feature flag is disabled', () => {
+    mockSpacesEnabled = false;
+    render(<Filters />);
+
+    expect(screen.queryByText('Spaces')).not.toBeInTheDocument();
+    // The other filters are unaffected.
+    expect(screen.getByText('Status')).toBeInTheDocument();
+  });
+});

--- a/front/app/containers/Admin/projects/all/Folders/Filters/index.tsx
+++ b/front/app/containers/Admin/projects/all/Folders/Filters/index.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 
 import { Box } from '@citizenlab/cl2-component-library';
 
+import useFeatureFlag from 'hooks/useFeatureFlag';
+
 import Manager from '../../_shared/FilterBar/Filters/Manager';
 import Spaces from '../../_shared/FilterBar/Filters/Spaces';
 import Status from '../../_shared/FilterBar/Filters/Status';
 
 const Filters = () => {
+  const spacesEnabled = useFeatureFlag({ name: 'spaces' });
+
   return (
     <Box
       display="flex"
@@ -17,7 +21,7 @@ const Filters = () => {
       <Box display="flex" alignItems="center" w="100%">
         <Manager mr="8px" />
         <Status mr="8px" />
-        <Spaces mr="8px" />
+        {spacesEnabled && <Spaces mr="8px" />}
       </Box>
     </Box>
   );


### PR DESCRIPTION
# Changelog
## Fixed
- [TAN-8555] Don't render the Spaces filter on BO folders list view when the feature is inactive
