### PR TITLE
Fix stale "Extra surveys" label and flag the spotlight surveys widget as new

### DIFF
--- a/front/app/components/ProjectPageBuilder/Toolbox/index.tsx
+++ b/front/app/components/ProjectPageBuilder/Toolbox/index.tsx
@@ -10,6 +10,7 @@ import EventsWidget from 'components/ProjectPageBuilder/Widgets/Events';
 import widgetMessages from 'components/ProjectPageBuilder/Widgets/messages';
 import PhasesWidget from 'components/ProjectPageBuilder/Widgets/Phases';
 import SpotlightSurveysWidget from 'components/ProjectPageBuilder/Widgets/SpotlightSurveys';
+import NewLabel from 'components/UI/NewLabel';
 
 import { useIntl } from 'utils/cl-intl';
 
@@ -41,6 +42,7 @@ const ProjectPageBuilderToolbox = () => {
             component={<SpotlightSurveysWidget />}
             icon="survey"
             label={formatMessage(widgetMessages.extraSurveysWidgetTitle)}
+            labelSuffix={<NewLabel expiryDate={new Date('2026-11-24')} />}
           />
         )}
       </Section>

--- a/front/app/components/ProjectPageBuilder/defaultLayout.ts
+++ b/front/app/components/ProjectPageBuilder/defaultLayout.ts
@@ -244,6 +244,10 @@ const CANONICAL_CUSTOM: Record<string, Record<string, unknown>> = {
     title: widgetMessages.eventsWidgetTitle,
     noPointerEvents: true,
   },
+  ExtraSurveysWidget: {
+    title: widgetMessages.extraSurveysWidgetTitle,
+    noPointerEvents: true,
+  },
 };
 
 const REMOVED_WIDGETS = [


### PR DESCRIPTION
# Changelog

## Fixed
- Project pages built before the rename kept showing the old "Extra surveys" name in the page builder. They now use the updated "Spotlight surveys" label, without having to re-add the block.

## Added
- The Spotlight surveys block in the page builder toolbox now carries a "New" badge, like the HTML block. It disappears on 24 November 2026.
