### PR TITLE
TAN-8543: Fix the 'See upcoming events' button linking to nowhere

### DIFF
--- a/front/app/components/ParticipationCTABars/EventsCTABar/index.tsx
+++ b/front/app/components/ParticipationCTABars/EventsCTABar/index.tsx
@@ -9,6 +9,8 @@ import { getCurrentPhase } from 'api/phases/utils';
 
 import ParticipationCTAContent from 'components/ParticipationCTABars/ParticipationCTAContent';
 import { CTABarProps } from 'components/ParticipationCTABars/utils';
+import { EVENTS_WIDGET_ANCHOR_ID } from 'components/ProjectPageBuilder/Widgets/Events';
+import useHasEventsWidget from 'components/ProjectPageBuilder/Widgets/Events/useHasEventsWidget';
 
 import { FormattedMessage } from 'utils/cl-intl';
 import { scrollToElement } from 'utils/scroll';
@@ -29,8 +31,9 @@ const EventsCTABar = ({ phases, project }: CTABarProps) => {
   });
   const theme = useTheme();
   const currentPhase = getCurrentPhase(phases);
+  const hasEventsWidget = useHasEventsWidget(project.id);
 
-  const showCTABar = !!events?.data.length;
+  const showCTABar = !!events?.data.length && hasEventsWidget;
 
   if (!showCTABar) return null;
 
@@ -40,9 +43,7 @@ const EventsCTABar = ({ phases, project }: CTABarProps) => {
       CTAButton={
         <Button
           id="e2e-cta-bar-see-events"
-          onClick={() =>
-            scrollToElement({ id: 'e2e-events-section-project-page' })
-          }
+          onClick={() => scrollToElement({ id: EVENTS_WIDGET_ANCHOR_ID })}
           fontWeight="500"
           bgColor={theme.colors.white}
           textColor={theme.colors.tenantText}

--- a/front/app/components/ProjectPageBuilder/Widgets/Events/index.tsx
+++ b/front/app/components/ProjectPageBuilder/Widgets/Events/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Box, Text, Title } from '@citizenlab/cl2-component-library';
 import { UserComponent, useEditor } from '@craftjs/core';
@@ -12,7 +12,8 @@ import useCraftComponentDefaultPadding from 'components/admin/ContentBuilder/use
 import { FormattedMessage } from 'utils/cl-intl';
 import Link from 'utils/cl-router/Link';
 import sharedMessages from 'utils/messages';
-import { useParams } from 'utils/router';
+import { useLocation, useParams } from 'utils/router';
+import { scrollToElement } from 'utils/scroll';
 
 import EditModeHeightCap from '../EditModeHeightCap';
 import messages from '../messages';
@@ -25,6 +26,8 @@ import useWidgetProjectId from '../useWidgetProjectId';
 
 import EmptyEvents from './EmptyEvents';
 import EventsSection from './EventsSection';
+
+export const EVENTS_WIDGET_ANCHOR_ID = 'e2e-project-page-events';
 
 const PUBLICATION_STATUSES = ['published', 'draft', 'archived'] as const;
 const PAGE_SIZE = 15;
@@ -62,6 +65,19 @@ const EventsWidget: UserComponent<Props> = ({ sectionBackground }) => {
     { ...eventsParams, pastOnly: true, pageNumber: pastPage },
     { enabled: !!projectId }
   );
+  const { hash } = useLocation();
+
+  const anchorRendered =
+    !!projectId &&
+    !!upcomingEvents &&
+    !!pastEvents &&
+    (upcomingEvents.data.length > 0 || pastEvents.data.length > 0);
+
+  useEffect(() => {
+    if (hash === EVENTS_WIDGET_ANCHOR_ID && anchorRendered) {
+      scrollToElement({ id: EVENTS_WIDGET_ANCHOR_ID });
+    }
+  }, [hash, anchorRendered]);
 
   if (!projectId || !upcomingEvents || !pastEvents) {
     return null;
@@ -79,7 +95,7 @@ const EventsWidget: UserComponent<Props> = ({ sectionBackground }) => {
         py="40px"
       >
         <Box
-          id="e2e-project-page-events"
+          id={EVENTS_WIDGET_ANCHOR_ID}
           mx="auto"
           maxWidth={`${maxPageWidth}px`}
           px={padding}

--- a/front/app/components/ProjectPageBuilder/Widgets/Events/useHasEventsWidget.ts
+++ b/front/app/components/ProjectPageBuilder/Widgets/Events/useHasEventsWidget.ts
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+
+import useProjectPageLayout from 'api/project_page_layout/useProjectPageLayout';
+
+import {
+  findNodeIdByName,
+  normalizeProjectPageLayout,
+} from 'components/ProjectPageBuilder/defaultLayout';
+
+// A project page can be laid out without an Events widget, so the events CTAs
+// have to ask whether there is anything on the page to scroll to.
+const useHasEventsWidget = (projectId: string) => {
+  const { data: layout } = useProjectPageLayout(projectId);
+
+  return useMemo(() => {
+    const nodes = normalizeProjectPageLayout(
+      layout?.data.attributes.craftjs_json
+    );
+    const nodeId = findNodeIdByName(nodes, 'EventsWidget');
+
+    return !!nodeId && !nodes[nodeId].hidden;
+  }, [layout]);
+};
+
+export default useHasEventsWidget;

--- a/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
+++ b/front/app/containers/ProjectsShowPage/shared/header/ProjectActionButtons.tsx
@@ -25,6 +25,8 @@ import messages from 'containers/ProjectsShowPage/messages';
 
 import IdeaButton from 'components/IdeaButton';
 import EmptyParticipationPreview from 'components/ProjectPageBuilder/Widgets/EmptyState/EmptyParticipationPreview';
+import { EVENTS_WIDGET_ANCHOR_ID } from 'components/ProjectPageBuilder/Widgets/Events';
+import useHasEventsWidget from 'components/ProjectPageBuilder/Widgets/Events/useHasEventsWidget';
 import SpotlightSurveyActionButton from 'components/ProjectPageBuilder/Widgets/SpotlightSurveys/ActionButton';
 import ButtonWithLink from 'components/UI/ButtonWithLink';
 
@@ -69,6 +71,7 @@ const ProjectActionButtons = memo<Props>(
       currentAndFutureOnly: true,
       sort: 'start_at',
     });
+    const hasEventsWidget = useHasEventsWidget(projectId);
 
     useEffect(() => {
       setCurrentPhase(
@@ -98,8 +101,14 @@ const ProjectActionButtons = memo<Props>(
 
     const canSeeEmptyState =
       isParallelParticipationEnabled && isAdmin(authUser);
+    const showEventsCTAButton = !!events?.data.length && hasEventsWidget;
 
-    if (!currentPhase && visibleOpenSurveys.length === 0 && !canSeeEmptyState) {
+    if (
+      !currentPhase &&
+      visibleOpenSurveys.length === 0 &&
+      !canSeeEmptyState &&
+      !showEventsCTAButton
+    ) {
       return null;
     }
 
@@ -247,9 +256,6 @@ const ProjectActionButtons = memo<Props>(
       !currentPhaseHidden &&
       participationMethod === 'document_annotation' &&
       !hasCurrentPhaseEnded;
-    // TODO: Fix this the next time the file is edited.
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    const showEventsCTAButton = !!events?.data?.length;
 
     const showMethodCTA =
       showPostIdeaButton ||
@@ -402,7 +408,7 @@ const ProjectActionButtons = memo<Props>(
             id="e2e-project-see-events-button"
             buttonStyle="secondary-outlined"
             onClick={() => {
-              scrollToElement({ id: 'e2e-events-section-project-page' });
+              scrollToElement({ id: EVENTS_WIDGET_ANCHOR_ID });
             }}
             fontWeight="500"
             mb="8px"

--- a/front/app/containers/SiteMap/Project.tsx
+++ b/front/app/containers/SiteMap/Project.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import useEvents from 'api/events/useEvents';
 import useProjectById from 'api/projects/useProjectById';
 
+import { EVENTS_WIDGET_ANCHOR_ID } from 'components/ProjectPageBuilder/Widgets/Events';
 import T from 'components/T';
 
 import { FormattedMessage } from 'utils/cl-intl';
@@ -49,7 +50,7 @@ const Project = ({ projectId, hightestTitle }: Props) => {
               <Link
                 to="/projects/$slug"
                 params={{ slug: project.data.attributes.slug }}
-                hash="e2e-events-section-project-page"
+                hash={EVENTS_WIDGET_ANCHOR_ID}
               >
                 <FormattedMessage {...messages.projectEvents} />
               </Link>

--- a/front/app/utils/cl-router/removeSearchParams.ts
+++ b/front/app/utils/cl-router/removeSearchParams.ts
@@ -17,5 +17,6 @@ export const removeSearchParams = (paramsToBeDeleted: readonly string[]) => {
   clHistory.replace({
     pathname: window.location.pathname,
     search: stringify(newSearchParams, { addQueryPrefix: true }),
+    hash: window.location.hash,
   });
 };

--- a/front/app/utils/cl-router/updateSearchParams.ts
+++ b/front/app/utils/cl-router/updateSearchParams.ts
@@ -29,5 +29,6 @@ export const updateSearchParams = (updatedParams: Record<string, any>) => {
   clHistory.replace({
     pathname: window.location.pathname,
     search: stringify(newSearchParams, { addQueryPrefix: true }),
+    hash: window.location.hash,
   });
 };


### PR DESCRIPTION
# Changelog
## Fixed
- The "See upcoming events" button in a project's Participation Box now jumps to the project's events again.
- When a project has upcoming events but no phase open for participation, visitors now see the events button. It was only showing for admins and project managers.
