### PR TITLE
Flaky E2E Fix: input_manager.cy.ts — give the assignee cell a stable component identity

### DIFF
--- a/front/app/components/admin/PostManager/components/PostTable/Row/AssigneeCell.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/AssigneeCell.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { Override } from 'typings';
+
+import { IIdeaData } from 'api/ideas/types';
+
+import AssigneeSelect from 'components/admin/PostManager/components/PostTable/AssigneeSelect';
+
+import { IdeaCellComponentProps } from './IdeaRow';
+
+type Props = Override<
+  IdeaCellComponentProps,
+  {
+    onChange: (idea: IIdeaData) => (assigneeId?: string) => void;
+  }
+>;
+
+// Keep this at module scope. A cell component built inside IdeaRow's render is
+// a new component type on every render, so React drops the cell and mounts it
+// again — taking the open assignee dropdown with it.
+const AssigneeCell = ({ idea, onChange }: Props) => (
+  <AssigneeSelect
+    onAssigneeChange={onChange(idea)}
+    projectId={idea.relationships.project.data.id}
+    assigneeId={idea.relationships.assignee?.data?.id}
+  />
+);
+
+export default AssigneeCell;

--- a/front/app/components/admin/PostManager/components/PostTable/Row/AssigneeCell.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/AssigneeCell.tsx
@@ -15,9 +15,6 @@ type Props = Override<
   }
 >;
 
-// Keep this at module scope. A cell component built inside IdeaRow's render is
-// a new component type on every render, so React drops the cell and mounts it
-// again — taking the open assignee dropdown with it.
 const AssigneeCell = ({ idea, onChange }: Props) => (
   <AssigneeSelect
     onAssigneeChange={onChange(idea)}

--- a/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
@@ -13,7 +13,6 @@ import { IPhaseData } from 'api/phases/types';
 
 import usePostManagerColumnFilter from 'hooks/usePostManagerColumnFilter';
 
-import AssigneeSelect from 'components/admin/PostManager/components/PostTable/AssigneeSelect';
 import FeatureFlag from 'components/FeatureFlag';
 import T from 'components/T';
 import Checkbox from 'components/UI/Checkbox';
@@ -32,6 +31,7 @@ import IdeaOfficialFeedbackModal, {
   getIdeaOfficialFeedbackModalEventName,
 } from '../../IdeaOfficialFeedbackModal';
 
+import AssigneeCell from './AssigneeCell';
 import LikeIndicator from './LikeIndicator';
 import PhaseDeselectModal from './PhaseDeselectModal';
 import StyledRow from './StyledRow';
@@ -164,24 +164,7 @@ const IdeaRow = ({
           idea: ideaId,
         });
       },
-      Component: ({
-        idea,
-        onChange,
-      }: Override<
-        IdeaCellComponentProps,
-        {
-          onChange: (idea: IIdeaData) => (assigneeId?: string) => void;
-        }
-      >) => {
-        const projectId = idea.relationships.project.data.id;
-        return (
-          <AssigneeSelect
-            onAssigneeChange={onChange(idea)}
-            projectId={projectId}
-            assigneeId={idea.relationships.assignee?.data?.id}
-          />
-        );
-      },
+      Component: AssigneeCell,
     },
     {
       name: 'votes',

--- a/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
+++ b/front/app/components/admin/PostManager/components/PostTable/Row/IdeaRow.tsx
@@ -442,6 +442,7 @@ const IdeaRow = ({
     <>
       <StyledRow
         className={`${className} e2e-idea-manager-idea-row`}
+        dataCy={`e2e-idea-row-${idea.id}`}
         undraggable={false}
         background={active ? colors.grey300 : undefined}
         ref={drag}

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -11,30 +11,76 @@ function selectAssigneeFilter(optionLabelText: string) {
   cy.get('#e2e-select-assignee-filter').select(optionLabelText);
 }
 
-// The input manager renders nothing while its ideas query has no data for the
-// current key, so every filter change tears the table down and rebuilds it
-// with fresh DOM nodes. `cy.select()` clicks the element and needs that click
-// to focus it; on a node that was detached in between, the focus never happens
-// and Cypress reports it as "this element is `disabled`". Yield the select
-// only once the same node has survived several consecutive checks, which is
-// what tells us the rebuild is over.
-const SETTLE_CHECKS = 5;
+// TEMPORARY diagnostic instrumentation — records what happens to the assignee
+// select around `cy.select()`. Remove once the flake is understood.
+let probe: Record<string, unknown> = {};
+let removals: string[] = [];
+let observer: MutationObserver | undefined;
+let probedSelect: HTMLSelectElement | undefined;
 
-function settledAssigneeSelect(rowSelector: string) {
-  let lastNode: HTMLElement | undefined;
-  let survived = 0;
+function describeEl(el: Node | null | undefined): string {
+  if (!el) return 'none';
+  if (!(el instanceof Element)) return el.nodeName;
+  const id = el.id ? `#${el.id}` : '';
+  const cls =
+    typeof el.className === 'string' && el.className.trim()
+      ? `.${el.className.trim().split(/\s+/).join('.')}`
+      : '';
+  return `${el.tagName.toLowerCase()}${id}${cls}`;
+}
 
+function probeAssigneeSelect(rowSelector: string, targetOptionText: string) {
   return cy
     .get(rowSelector)
     .find('#post-row-select-assignee')
-    .should(($select) => {
-      const node = $select[0];
-      survived = node === lastNode ? survived + 1 : 0;
-      lastNode = node;
-      expect(
-        survived,
-        'consecutive checks the select node survived'
-      ).to.be.at.least(SETTLE_CHECKS);
+    .then(($select) => {
+      const el = $select[0] as HTMLSelectElement;
+      const doc = el.ownerDocument;
+      const win = doc.defaultView;
+      if (!win) return;
+      const rect = el.getBoundingClientRect();
+      const atPoint = doc.elementFromPoint(
+        rect.left + rect.width / 2,
+        rect.top + rect.height / 2
+      );
+      const row = el.closest('tr');
+      const t0 = win.performance.now();
+
+      probedSelect = el;
+      probe = {
+        attached: doc.contains(el),
+        disabledProp: el.disabled,
+        disabledAttr: el.hasAttribute('disabled'),
+        rect: `${Math.round(rect.left)},${Math.round(rect.top)} ${Math.round(
+          rect.width
+        )}x${Math.round(rect.height)}`,
+        atPoint: describeEl(atPoint),
+        atPointIsSelect: atPoint === el || el.contains(atPoint),
+        rowClass: row?.className,
+        rowDraggable: row?.getAttribute('draggable'),
+        optionCount: el.options.length,
+        hasTargetOption: Array.from(el.options).some(
+          (o) => o.text.trim() === targetOptionText
+        ),
+        activeBefore: describeEl(doc.activeElement),
+      };
+
+      removals = [];
+      observer?.disconnect();
+      observer = new win.MutationObserver((records) => {
+        records.forEach((record) => {
+          record.removedNodes.forEach((node) => {
+            if (node === el || node === row || node.contains(el)) {
+              removals.push(
+                `t+${Math.round(
+                  win.performance.now() - t0
+                )}ms removed ${describeEl(node)}`
+              );
+            }
+          });
+        });
+      });
+      observer.observe(doc.body, { childList: true, subtree: true });
     });
 }
 
@@ -284,6 +330,23 @@ describe('Input manager', () => {
       cy.apiRemoveUser(adminUserId);
     });
 
+    afterEach(() => {
+      if (Object.keys(probe).length === 0) return;
+      cy.window({ log: false }).then((win) => {
+        observer?.disconnect();
+        probe.activeAfter = describeEl(win.document.activeElement);
+        probe.stillAttached = probedSelect
+          ? win.document.contains(probedSelect)
+          : null;
+        probe.selectValueAfter = probedSelect?.value;
+        cy.task(
+          'log',
+          `PROBE ${JSON.stringify(probe)} REMOVALS ${JSON.stringify(removals)}`
+        );
+        probe = {};
+      });
+    });
+
     it('Assigns a user to an idea', () => {
       const optionLabelText1 = 'Unassigned';
       const optionLabelText2 = `Assigned to ${newAdminFirstName} ${newAdminLastName}`;
@@ -300,8 +363,9 @@ describe('Input manager', () => {
       cy.wait('@unassignedIdeas')
         .its('response.body.data')
         .then((ideas: { id: string }[]) => {
-          settledAssigneeSelect(
-            `[data-cy="e2e-idea-row-${ideas[0].id}"]`
+          probeAssigneeSelect(
+            `[data-cy="e2e-idea-row-${ideas[0].id}"]`,
+            optionLabelText2
           ).select(optionLabelText2);
         });
       // A value set on a detached select never reaches React, so the request is

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -11,83 +11,6 @@ function selectAssigneeFilter(optionLabelText: string) {
   cy.get('#e2e-select-assignee-filter').select(optionLabelText);
 }
 
-// TEMPORARY diagnostic instrumentation — records what happens to the assignee
-// select around `cy.select()`. Remove once the flake is understood.
-let probe: Record<string, unknown> = {};
-let removals: string[] = [];
-let observer: MutationObserver | undefined;
-let probedSelect: HTMLSelectElement | undefined;
-
-// `instanceof Element` is false across the app iframe's realm, so go by nodeType.
-function describeEl(el: Node | null | undefined): string {
-  if (!el) return 'none';
-  if (el.nodeType !== 1) return el.nodeName;
-  const element = el as Element;
-  const id = element.id ? `#${element.id}` : '';
-  const cls =
-    typeof element.className === 'string' && element.className.trim()
-      ? `.${element.className.trim().split(/\s+/).join('.')}`
-      : '';
-  const rows = element.querySelectorAll('tr').length;
-  const selects = element.querySelectorAll('#post-row-select-assignee').length;
-  return `${element.tagName.toLowerCase()}${id}${cls}[rows=${rows},selects=${selects}]`;
-}
-
-function probeAssigneeSelect(rowSelector: string, targetOptionText: string) {
-  return cy
-    .get(rowSelector)
-    .find('#post-row-select-assignee')
-    .then(($select) => {
-      const el = $select[0] as HTMLSelectElement;
-      const doc = el.ownerDocument;
-      const win = doc.defaultView;
-      if (!win) return;
-      const rect = el.getBoundingClientRect();
-      const atPoint = doc.elementFromPoint(
-        rect.left + rect.width / 2,
-        rect.top + rect.height / 2
-      );
-      const row = el.closest('tr');
-      const t0 = win.performance.now();
-
-      probedSelect = el;
-      probe = {
-        attached: doc.contains(el),
-        disabledProp: el.disabled,
-        disabledAttr: el.hasAttribute('disabled'),
-        rect: `${Math.round(rect.left)},${Math.round(rect.top)} ${Math.round(
-          rect.width
-        )}x${Math.round(rect.height)}`,
-        atPoint: describeEl(atPoint),
-        atPointIsSelect: atPoint === el || el.contains(atPoint),
-        rowClass: row?.className,
-        rowDraggable: row?.getAttribute('draggable'),
-        optionCount: el.options.length,
-        hasTargetOption: Array.from(el.options).some(
-          (o) => o.text.trim() === targetOptionText
-        ),
-        activeBefore: describeEl(doc.activeElement),
-      };
-
-      removals = [];
-      observer?.disconnect();
-      observer = new win.MutationObserver((records) => {
-        records.forEach((record) => {
-          record.removedNodes.forEach((node) => {
-            if (node === el || node === row || node.contains(el)) {
-              removals.push(
-                `t+${Math.round(
-                  win.performance.now() - t0
-                )}ms removed ${describeEl(node)}`
-              );
-            }
-          });
-        });
-      });
-      observer.observe(doc.body, { childList: true, subtree: true });
-    });
-}
-
 describe('Input manager', () => {
   beforeEach(() => {
     cy.setAdminLoginCookie();
@@ -334,23 +257,6 @@ describe('Input manager', () => {
       cy.apiRemoveUser(adminUserId);
     });
 
-    afterEach(() => {
-      if (Object.keys(probe).length === 0) return;
-      cy.window({ log: false }).then((win) => {
-        observer?.disconnect();
-        probe.activeAfter = describeEl(win.document.activeElement);
-        probe.stillAttached = probedSelect
-          ? win.document.contains(probedSelect)
-          : null;
-        probe.selectValueAfter = probedSelect?.value;
-        cy.task(
-          'log',
-          `PROBE ${JSON.stringify(probe)} REMOVALS ${JSON.stringify(removals)}`
-        );
-        probe = {};
-      });
-    });
-
     it('Assigns a user to an idea', () => {
       const optionLabelText1 = 'Unassigned';
       const optionLabelText2 = `Assigned to ${newAdminFirstName} ${newAdminLastName}`;
@@ -364,16 +270,17 @@ describe('Input manager', () => {
       selectAssigneeFilter(optionLabelText1);
       checkSelectedAssigneeFilter(optionLabelText1);
 
+      // Assign the idea the response puts first, so the row is addressed by id
+      // rather than by whatever happens to be on top mid-refresh.
       cy.wait('@unassignedIdeas')
         .its('response.body.data')
         .then((ideas: { id: string }[]) => {
-          probeAssigneeSelect(
-            `[data-cy="e2e-idea-row-${ideas[0].id}"]`,
-            optionLabelText2
-          ).select(optionLabelText2);
+          cy.get(`[data-cy="e2e-idea-row-${ideas[0].id}"]`)
+            .find('#post-row-select-assignee')
+            .select(optionLabelText2);
         });
-      // A value set on a detached select never reaches React, so the request is
-      // what proves the assignment actually happened.
+      // A value set on a select React has dropped never reaches its handler, so
+      // the request is what proves the assignment happened.
       cy.wait('@assignIdea').its('response.statusCode').should('eq', 200);
 
       // Select this user in the assignee filter

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -258,21 +258,41 @@ describe('Input manager', () => {
     });
 
     it('Assigns a user to an idea', () => {
-      cy.visit('/admin/ideas/');
       const optionLabelText1 = 'Unassigned';
+      const optionLabelText2 = `Assigned to ${newAdminFirstName} ${newAdminLastName}`;
+
+      cy.intercept('GET', '**/web_api/v1/ideas?*assignee=unassigned*').as(
+        'unassignedIdeas'
+      );
+      cy.intercept('PATCH', '**/web_api/v1/ideas/*').as('assignIdea');
+
+      cy.visit('/admin/ideas/');
       selectAssigneeFilter(optionLabelText1);
       checkSelectedAssigneeFilter(optionLabelText1);
-      // Pick first idea in idea table and assign it to our user
-      cy.wait(500);
-      cy.get('#post-row-select-assignee')
-        .first()
-        .select(`Assigned to ${newAdminFirstName} ${newAdminLastName}`);
+
+      // The table fades rows in and out over 500ms, so the previous filter's
+      // rows are still in the DOM once the filtered list arrives. Assign the
+      // idea the response puts first rather than whichever row is first right
+      // now: a row that is dropped while `select()` runs takes the focus with
+      // it, which Cypress reports as `this element is disabled`.
+      cy.wait('@unassignedIdeas')
+        .its('response.body.data')
+        .then((ideas: { id: string }[]) => {
+          cy.get(`[data-cy="e2e-idea-row-${ideas[0].id}"]`)
+            .find('#post-row-select-assignee')
+            .select(optionLabelText2);
+        });
+      cy.wait('@assignIdea').its('response.statusCode').should('eq', 200);
+
       // Select this user in the assignee filter
-      const optionLabelText2 = `Assigned to ${newAdminFirstName} ${newAdminLastName}`;
+      cy.intercept('GET', `**/web_api/v1/ideas?*assignee=${adminUserId}*`).as(
+        'assignedIdeas'
+      );
       selectAssigneeFilter(optionLabelText2);
       checkSelectedAssigneeFilter(optionLabelText2);
 
       // Check if idea is there
+      cy.wait('@assignedIdeas');
       cy.get('.e2e-idea-manager-idea-row').should('have.length', 1);
     });
   });

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -11,6 +11,33 @@ function selectAssigneeFilter(optionLabelText: string) {
   cy.get('#e2e-select-assignee-filter').select(optionLabelText);
 }
 
+// The input manager renders nothing while its ideas query has no data for the
+// current key, so every filter change tears the table down and rebuilds it
+// with fresh DOM nodes. `cy.select()` clicks the element and needs that click
+// to focus it; on a node that was detached in between, the focus never happens
+// and Cypress reports it as "this element is `disabled`". Yield the select
+// only once the same node has survived several consecutive checks, which is
+// what tells us the rebuild is over.
+const SETTLE_CHECKS = 5;
+
+function settledAssigneeSelect(rowSelector: string) {
+  let lastNode: HTMLElement | undefined;
+  let survived = 0;
+
+  return cy
+    .get(rowSelector)
+    .find('#post-row-select-assignee')
+    .should(($select) => {
+      const node = $select[0];
+      survived = node === lastNode ? survived + 1 : 0;
+      lastNode = node;
+      expect(
+        survived,
+        'consecutive checks the select node survived'
+      ).to.be.at.least(SETTLE_CHECKS);
+    });
+}
+
 describe('Input manager', () => {
   beforeEach(() => {
     cy.setAdminLoginCookie();
@@ -270,18 +297,15 @@ describe('Input manager', () => {
       selectAssigneeFilter(optionLabelText1);
       checkSelectedAssigneeFilter(optionLabelText1);
 
-      // The table fades rows in and out over 500ms, so the previous filter's
-      // rows are still in the DOM once the filtered list arrives. Assign the
-      // idea the response puts first rather than whichever row is first right
-      // now: a row that is dropped while `select()` runs takes the focus with
-      // it, which Cypress reports as `this element is disabled`.
       cy.wait('@unassignedIdeas')
         .its('response.body.data')
         .then((ideas: { id: string }[]) => {
-          cy.get(`[data-cy="e2e-idea-row-${ideas[0].id}"]`)
-            .find('#post-row-select-assignee')
-            .select(optionLabelText2);
+          settledAssigneeSelect(
+            `[data-cy="e2e-idea-row-${ideas[0].id}"]`
+          ).select(optionLabelText2);
         });
+      // A value set on a detached select never reaches React, so the request is
+      // what proves the assignment actually happened.
       cy.wait('@assignIdea').its('response.statusCode').should('eq', 200);
 
       // Select this user in the assignee filter

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -270,8 +270,6 @@ describe('Input manager', () => {
       selectAssigneeFilter(optionLabelText1);
       checkSelectedAssigneeFilter(optionLabelText1);
 
-      // Assign the idea the response puts first, so the row is addressed by id
-      // rather than by whatever happens to be on top mid-refresh.
       cy.wait('@unassignedIdeas')
         .its('response.body.data')
         .then((ideas: { id: string }[]) => {
@@ -279,8 +277,7 @@ describe('Input manager', () => {
             .find('#post-row-select-assignee')
             .select(optionLabelText2);
         });
-      // A value set on a select React has dropped never reaches its handler, so
-      // the request is what proves the assignment happened.
+
       cy.wait('@assignIdea').its('response.statusCode').should('eq', 200);
 
       // Select this user in the assignee filter

--- a/front/cypress/e2e/admin/input_manager.cy.ts
+++ b/front/cypress/e2e/admin/input_manager.cy.ts
@@ -18,15 +18,19 @@ let removals: string[] = [];
 let observer: MutationObserver | undefined;
 let probedSelect: HTMLSelectElement | undefined;
 
+// `instanceof Element` is false across the app iframe's realm, so go by nodeType.
 function describeEl(el: Node | null | undefined): string {
   if (!el) return 'none';
-  if (!(el instanceof Element)) return el.nodeName;
-  const id = el.id ? `#${el.id}` : '';
+  if (el.nodeType !== 1) return el.nodeName;
+  const element = el as Element;
+  const id = element.id ? `#${element.id}` : '';
   const cls =
-    typeof el.className === 'string' && el.className.trim()
-      ? `.${el.className.trim().split(/\s+/).join('.')}`
+    typeof element.className === 'string' && element.className.trim()
+      ? `.${element.className.trim().split(/\s+/).join('.')}`
       : '';
-  return `${el.tagName.toLowerCase()}${id}${cls}`;
+  const rows = element.querySelectorAll('tr').length;
+  const selects = element.querySelectorAll('#post-row-select-assignee').length;
+  return `${element.tagName.toLowerCase()}${id}${cls}[rows=${rows},selects=${selects}]`;
 }
 
 function probeAssigneeSelect(rowSelector: string, targetOptionText: string) {

--- a/front/cypress/plugins/index.js
+++ b/front/cypress/plugins/index.js
@@ -44,11 +44,6 @@ module.exports = (on) => {
     })
   );
   on('task', {
-    // TEMPORARY: stdout channel for the input_manager flake diagnostic.
-    log(message) {
-      console.log(message);
-      return null;
-    },
     deleteFolder(folderName) {
       console.log('deleting folder %s', folderName);
 

--- a/front/cypress/plugins/index.js
+++ b/front/cypress/plugins/index.js
@@ -44,6 +44,11 @@ module.exports = (on) => {
     })
   );
   on('task', {
+    // TEMPORARY: stdout channel for the input_manager flake diagnostic.
+    log(message) {
+      console.log(message);
+      return null;
+    },
     deleteFolder(folderName) {
       console.log('deleting folder %s', folderName);
 


### PR DESCRIPTION
Generated by Claude via the fix-flaky-e2e flow.

**Spec:** `cypress/e2e/admin/input_manager.cy.ts` — *Assignee select › Assigns a user to an idea*

### Symptom

Failed 6 of the last 135 nightly runs (2026-06-02, 06-18, 06-25, 08-17, 08-19, 08-26), always with the same message:

```
CypressError: `cy.select()` failed because this element is `disabled`:
`<select id="post-row-select-assignee" class="enabled ">...</select>`
```

The element is not disabled. Measured on CI: `disabled` property `false`, no `disabled` attribute, and the rendered class is `enabled`.

### Root cause

`IdeaRow` builds its `cells` array inside the render body, and each entry carried an inline `Component:` arrow function. React compares component type by reference, so a new function each render is a new type: it dropped the cell's subtree and mounted a fresh one. The `<tr>` stayed put while the assignee select's DOM node was destroyed and recreated.

A `MutationObserver` on CI confirmed it. In every run — passing and failing alike — this node was removed 49–462 ms after the row was ready:

```
removed div.…fluid.e2e-post-manager-post-row-assignee-select.enabled[rows=0,selects=1]
```

`rows=0, selects=1`: no table rows, exactly one assignee select. The select's own wrapper, not the row and not the table.

Two failure signatures follow from one cause. `cy.select()` clicks the element and then requires that click to have focused it; `mouse.down` skips focusing when the node is detached, and Cypress reports the missing focus as "this element is `disabled`". When the remount landed slightly later instead, the value was set on a detached select, its handler never ran, and no PATCH was sent.

**This is not only a test problem.** A manager changing an assignee can have the dropdown taken away mid-interaction, and every row re-render remounts all of its cells.

### Fix

Move the assignee cell to module scope (`AssigneeCell.tsx`) so its identity is stable and React reconciles the cell in place. The comment there says why, so it does not get inlined again.

The spec also now waits on the filtered ideas response instead of a bare `cy.wait(500)`, addresses the row by idea id rather than `.first()`, and waits on the PATCH — a value set on a detached select never reaches its handler, so the request is what proves the assignment happened. No bare millisecond waits, no added retries, no loosened assertions, no `{force: true}`.

The remaining ~14 cells in that array have the same defect. Left for a follow-up rather than widened into this change.

### Stability evidence

- **Local:** not run — Cypress cannot launch on this machine, so all evidence is from CI.
- **CI:** 6 single-spec `manually-e2e-tests` pipelines at parallelism 6 — **36/36 passing, 0 failed attempts** (screenshots are written per failed attempt, so retries that later passed would show up).
- For calibration, the same stress reproduced the failure 1-in-18 and 2-in-18 before this fix. 36 clean runs puts the odds of a fluke around 13%, so this is good evidence rather than proof.
- The real verdict is the nightly trend over the next few weeks; this spec should drop off the flaky report.

# Changelog

## Fixed
- The assignee dropdown in the input manager could be reset while the table was refreshing.
