### PR TITLE
TAN-8591-a11y/footer-logo-screen-reader

### DIFF
--- a/front/app/components/CityLogoSection/index.tsx
+++ b/front/app/components/CityLogoSection/index.tsx
@@ -57,7 +57,7 @@ const CityLogoSection = () => {
   const tenantImage = (
     <Image
       src={currentTenantLogo}
-      alt={localizedOrgName}
+      alt=""
       height="100px"
       marginBottom="20px"
       width="100%"
@@ -75,7 +75,8 @@ const CityLogoSection = () => {
           aria-label={formatMessage(
             isExternalSite
               ? messages.logoLinkAriaLabelExternal
-              : messages.logoLinkAriaLabelInternal
+              : messages.logoLinkAriaLabelInternal,
+            { orgName: localizedOrgName }
           )}
         >
           {tenantImage}


### PR DESCRIPTION
# Changelog
## A11y 
- Mark the footer logo decorative so screen readers skip it

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
