### PR TITLE
Imlement same expire or delete behavior for phone

### DIFF
--- a/back/app/jobs/expire_confirmation_code_or_delete_job.rb
+++ b/back/app/jobs/expire_confirmation_code_or_delete_job.rb
@@ -9,6 +9,11 @@ class ExpireConfirmationCodeOrDeleteJob < ApplicationJob
     'NewPhoneConfirmation' => :new_phone_confirmation
   }.freeze
 
+  # The signup flows: the code is the user's only way to prove they own the identity
+  # they registered with, so an expired code means the signup never completed. The
+  # new_* flows change an identity on an already-existing user and never delete.
+  SIGNUP_ASSOCIATION_NAMES = %i[email_confirmation phone_confirmation].freeze
+
   def run(user_id, confirmation_type, code_to_expire)
     user = User.find_by(id: user_id)
     return unless user
@@ -24,8 +29,11 @@ class ExpireConfirmationCodeOrDeleteJob < ApplicationJob
     confirmation.expire_code!
 
     # Garbage-collect freshly-signed-up users who never finished confirming.
-    # Only applies to the email-confirmation (signup) flow.
-    if association_name == :email_confirmation && user.no_password? && !user.registration_completed_at
+    # A password or a completed registration means the user has another way into
+    # the account (registration_completed_at is only stamped once the user has
+    # authenticated at least once - confirmed email, confirmed phone, or SSO), so
+    # for those we only expire the code.
+    if SIGNUP_ASSOCIATION_NAMES.include?(association_name) && user.no_password? && !user.registration_completed_at
       DeleteUserJob.perform_later(user)
     end
   end

--- a/back/spec/jobs/expire_confirmation_code_or_delete_job_spec.rb
+++ b/back/spec/jobs/expire_confirmation_code_or_delete_job_spec.rb
@@ -60,6 +60,70 @@ RSpec.describe ExpireConfirmationCodeOrDeleteJob do
     end
   end
 
+  # The phone signup flow (POST /users/phone) is the mirror of the email one:
+  # a user who never confirms the number they signed up with is garbage-collected.
+  context 'unconfirmed phone users' do
+    let(:user) do
+      user = create(:unconfirmed_phone_user)
+      RequestPhoneConfirmationCodeJob.issue_code!(user)
+      user
+    end
+
+    it 'changes the confirmation code and deletes a user requiring confirmation' do
+      old_code = user.phone_confirmation.code
+      described_class.perform_now(user.id, 'PhoneConfirmation', old_code)
+      expect(user.phone_confirmation.reload.code).not_to eq(old_code)
+      expect(DeleteUserJob).to have_been_enqueued
+    end
+
+    it 'does nothing when the code to expire is not the current code' do
+      RequestPhoneConfirmationCodeJob.issue_code!(user)
+      old_code = user.phone_confirmation.reload.code
+      described_class.perform_now(user.id, 'PhoneConfirmation', '12345')
+      expect(user.phone_confirmation.reload.code).to eq(old_code)
+      expect(DeleteUserJob).not_to have_been_enqueued
+    end
+
+    it 'does nothing when the user has already confirmed their phone number' do
+      user.phone_confirmation.confirm!
+      described_class.perform_now(user.id, 'PhoneConfirmation', user.phone_confirmation.reload.code)
+      expect(user.phone_confirmation.reload.code).to be_nil
+      expect(DeleteUserJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'full users with an unconfirmed phone number' do
+    let(:user) do
+      user = create(:user, phone: '+14155552671')
+      RequestPhoneConfirmationCodeJob.issue_code!(user)
+      user
+    end
+
+    it 'expires the code but keeps a user who has a password and completed registration' do
+      old_code = user.phone_confirmation.code
+      described_class.perform_now(user.id, 'PhoneConfirmation', old_code)
+      expect(user.phone_confirmation.reload.code).not_to eq(old_code)
+      expect(DeleteUserJob).not_to have_been_enqueued
+    end
+  end
+
+  # Changing the number on an existing account must never delete that account,
+  # however incomplete the account itself is.
+  context 'users with a pending new phone number' do
+    let(:user) do
+      user = create(:unconfirmed_phone_user)
+      RequestNewPhoneConfirmationCodeJob.issue_code!(user, new_phone: '+14155552671')
+      user
+    end
+
+    it 'expires the code without deleting the user' do
+      old_code = user.new_phone_confirmation.code
+      described_class.perform_now(user.id, 'NewPhoneConfirmation', old_code)
+      expect(user.new_phone_confirmation.reload.code).not_to eq(old_code)
+      expect(DeleteUserJob).not_to have_been_enqueued
+    end
+  end
+
   context 'confirmed users with no password' do
     let(:user) do
       user = create(:unconfirmed_user)


### PR DESCRIPTION
# Changelog
## Technical
- Make sure that empty phone-only users get cleaned up after 24 hours, same as email
