### PR TITLE
TAN-8590-add-settings-modal-with-side-navigation

### DIFF
--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 import {
+  Box,
   media,
   colors,
   fontSizes,
@@ -214,33 +215,6 @@ const HeaderTitle = styled.h1`
   `}
 `;
 
-const HeaderContainer = styled.div`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
-  min-height: 65px;
-  padding: 14px 18px;
-  border-bottom: solid 1px ${colors.grey200};
-  background: transparent;
-`;
-
-const FooterContainer = styled.div`
-  width: 100%;
-  display: flex;
-  flex-shrink: 0;
-  flex-direction: row;
-  align-items: center;
-  padding: 12px 24px;
-  border-top: solid 1px ${colors.grey100};
-  background: ${colors.grey50};
-
-  ${media.phone`
-    padding: 12px 20px;
-  `}
-`;
-
 const Skip = styled.div`
   color: #fff;
   font-size: ${fontSizes.base}px;
@@ -438,6 +412,7 @@ const Modal: React.FC<Props> = ({
 
   const { windowHeight, windowWidth } = windowDimensions;
   const smallerThanSmallTablet = windowWidth <= viewportWidths.tablet;
+  const isPhone = windowWidth <= viewportWidths.phone;
   let calculatedPadding = padding;
 
   if (header !== undefined || footer !== undefined) {
@@ -478,10 +453,19 @@ const Modal: React.FC<Props> = ({
             role="dialog"
           >
             {header ? (
-              <HeaderContainer>
+              <Box
+                position="relative"
+                display="flex"
+                flexDirection="column"
+                alignItems="stretch"
+                justifyContent="center"
+                minHeight="65px"
+                padding="14px 18px"
+                borderBottom={`solid 1px ${colors.grey200}`}
+              >
                 <HeaderTitle id="modal-header">{header}</HeaderTitle>
                 {closeButton}
-              </HeaderContainer>
+              </Box>
             ) : (
               closeButton
             )}
@@ -490,7 +474,20 @@ const Modal: React.FC<Props> = ({
               {children}
             </ModalContentContainer>
 
-            {footer && <FooterContainer>{footer}</FooterContainer>}
+            {footer && (
+              <Box
+                w="100%"
+                display="flex"
+                flexShrink={0}
+                flexDirection="row"
+                alignItems="center"
+                padding={isPhone ? '12px 20px' : '12px 24px'}
+                borderTop={`solid 1px ${colors.grey100}`}
+                background={colors.grey50}
+              >
+                {footer}
+              </Box>
+            )}
 
             {hasSkipButton && skipText && (
               <Skip onClick={clickCloseButton}>{skipText}</Skip>

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -313,7 +313,7 @@ const Modal: React.FC<Props> = ({
   'data-testid': dataTestId,
   opened,
   fixedHeight = false,
-  width = 560,
+  width = 650,
   close,
   className,
   header,

--- a/front/app/components/UI/Modal/index.tsx
+++ b/front/app/components/UI/Modal/index.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 import {
-  Box,
   media,
   colors,
   fontSizes,
@@ -42,26 +41,29 @@ export const ModalContentContainer = styled.div<{
   overflow-y: auto;
   overflow-x: hidden;
   -webkit-overflow-scrolling: touch;
-  padding: ${({ padding }) => padding || '30px'};
+  padding: ${({ padding }) => padding || '8px 24px 24px'};
 
   ${media.phone`
-    padding: ${({ padding }) => padding || '20px'};
+    padding: ${({ padding }) => padding || '8px 20px 20px'};
   `}
 `;
 
 const StyledCloseIconButton = styled(CloseIconButton)`
   position: absolute;
-  top: 12px;
-  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  right: 18px;
   z-index: 2000;
-  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
   border: solid 1px transparent;
   transition: all 100ms ease-out;
   outline: none !important;
-  padding: 10px;
+  padding: 0px;
 
   &:hover {
-    background: #e0e0e0;
+    background: rgba(15, 20, 35, 0.05);
   }
 
   /* This button forces outline:none, so the global outline ring can't apply —
@@ -70,43 +72,22 @@ const StyledCloseIconButton = styled(CloseIconButton)`
     ${focusRingBorder}
   }
 
+  &.no-header {
+    top: 12px;
+    transform: none;
+
+    ${media.phone`
+      top: 13px;
+    `}
+  }
+
   ${isRtl`
     right: auto;
     left: 25px;
   `}
 
   ${media.phone`
-    top: 13px;
     right: 15px;
-  `}
-`;
-
-const StyledCloseIconButton2 = styled(CloseIconButton)`
-  position: absolute;
-  top: 17px;
-  z-index: 2000;
-  border-radius: 50%;
-  border: solid 1px transparent;
-  transition: all 100ms ease-out;
-  outline: none !important;
-  padding: 10px;
-  right: 22px;
-
-  ${media.phone`
-    right: 6px;
-  `}
-
-  &:hover {
-    background: #e0e0e0;
-  }
-
-  &.focus-visible {
-    ${focusRingBorder}
-  }
-
-  ${isRtl`
-    right: auto;
-    left: 25px;
   `}
 `;
 
@@ -125,9 +106,9 @@ const ModalContainer = styled(ClickOutside)<{
 }>`
   width: 100%;
   max-height: 85vh;
-  margin-top: 50px;
   background: #fff;
-  border-radius: ${({ theme }) => theme.borderRadius};
+  border-radius: 12px;
+  box-shadow: 0 24px 70px rgba(15, 20, 35, 0.35);
   display: flex;
   flex-direction: column;
   outline: none;
@@ -140,14 +121,9 @@ const ModalContainer = styled(ClickOutside)<{
     max-height: 600px;
   }
 
-  @media (min-height: 1200px) {
-    margin-top: 120px;
-  }
-
   ${media.phone`
     max-width: calc(100vw - 30px);
     max-height: calc(${({ windowHeight }) => windowHeight}px - 30px);
-    margin-top: 15px;
 
     &.fixedHeight {
       height: auto;
@@ -165,11 +141,10 @@ const Overlay = styled.div<{ zIndex?: number }>`
   right: 0;
   bottom: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.75);
-  padding-left: 30px;
-  padding-right: 30px;
+  background: rgba(15, 20, 35, 0.35);
+  padding: 24px 30px;
   overflow: hidden;
   will-change: opacity, transform;
 
@@ -214,47 +189,41 @@ const Overlay = styled.div<{ zIndex?: number }>`
   }
 `;
 
-const HeaderContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  padding-left: 28px;
-  padding-right: 28px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  border-bottom: solid 1px #e0e0e0;
-  background: transparent;
-
-  ${media.phone`
-    padding-top: 16px;
-    padding-bottom: 16px;
-    padding-left: 20px;
-    padding-right: 20px;
-  `}
-`;
-
 const HeaderTitle = styled.h1`
   color: ${({ theme }) => theme.colors.tenantText};
-  font-size: ${fontSizes.xl}px;
-  font-weight: 600;
-  line-height: normal;
+  font-size: ${fontSizes.l}px;
+  font-weight: 400;
+  letter-spacing: -0.25px;
+  line-height: 24px;
   margin: 0;
-  margin-right: 45px;
+  margin-right: 74px;
   padding: 0;
 
   ${media.phone`
-    margin-right: 35px;
+    margin-right: 74px;
   `}
 
   ${isRtl`
     text-align: right;
     margin: 0;
-    margin-left: 45px;
+    margin-left: 74px;
 
     ${media.phone`
-      margin-left: 35px;
+      margin-left: 74px;
     `}
   `}
+`;
+
+const HeaderContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  min-height: 65px;
+  padding: 14px 18px;
+  border-bottom: solid 1px ${colors.grey200};
+  background: transparent;
 `;
 
 const FooterContainer = styled.div`
@@ -263,18 +232,12 @@ const FooterContainer = styled.div`
   flex-shrink: 0;
   flex-direction: row;
   align-items: center;
-  padding-left: 28px;
-  padding-right: 28px;
-  padding-top: 16px;
-  padding-bottom: 16px;
-  border-top: solid 1px ${colors.divider};
-  background: #fff;
+  padding: 12px 24px;
+  border-top: solid 1px ${colors.grey100};
+  background: ${colors.grey50};
 
   ${media.phone`
-    padding-top: 10px;
-    padding-bottom: 10px;
-    padding-left: 20px;
-    padding-right: 20px;
+    padding: 12px 20px;
   `}
 `;
 
@@ -326,7 +289,6 @@ interface BaseProps {
   width?: number | string;
   close: () => void;
   className?: string;
-  niceHeader?: boolean;
   footer?: JSX.Element;
   hasSkipButton?: boolean;
   skipText?: JSX.Element;
@@ -351,11 +313,10 @@ const Modal: React.FC<Props> = ({
   'data-testid': dataTestId,
   opened,
   fixedHeight = false,
-  width = 650,
+  width = 560,
   close,
   className,
   header,
-  niceHeader,
   footer,
   hasSkipButton,
   skipText,
@@ -459,6 +420,22 @@ const Modal: React.FC<Props> = ({
     [close]
   );
 
+  const closeButtonClassName = `e2e-modal-close-button${
+    header ? '' : ' no-header'
+  }`;
+
+  const closeButton = hideCloseButton ? null : (
+    <StyledCloseIconButton
+      className={closeButtonClassName}
+      onClick={clickCloseButton}
+      iconColor={colors.textSecondary}
+      iconColorOnHover={colors.textSecondary}
+      iconWidth="20px"
+      iconHeight="20px"
+      a11y_buttonActionMessage={messages.closeWindow}
+    />
+  );
+
   const { windowHeight, windowWidth } = windowDimensions;
   const smallerThanSmallTablet = windowWidth <= viewportWidths.tablet;
   let calculatedPadding = padding;
@@ -500,58 +477,13 @@ const Modal: React.FC<Props> = ({
             isModal
             role="dialog"
           >
-            {!niceHeader && (
-              <>
-                {header && (
-                  <HeaderContainer>
-                    <HeaderTitle id="modal-header">{header}</HeaderTitle>
-                  </HeaderContainer>
-                )}
-
-                {!hideCloseButton && (
-                  <StyledCloseIconButton
-                    className="e2e-modal-close-button"
-                    onClick={clickCloseButton}
-                    iconColor={colors.textSecondary}
-                    iconColorOnHover={colors.grey800}
-                    a11y_buttonActionMessage={messages.closeWindow}
-                  />
-                )}
-              </>
-            )}
-
-            {header && niceHeader && (
-              <>
-                <Box
-                  display="flex"
-                  flexDirection="row"
-                  alignItems="center"
-                  w="100%"
-                  py="8px"
-                  borderBottom={`solid 1px ${colors.divider}`}
-                >
-                  <Box
-                    w="100%"
-                    h="100%"
-                    display="flex"
-                    alignItems="center"
-                    minHeight="66px"
-                  >
-                    {header}
-                  </Box>
-                </Box>
-                {!hideCloseButton && (
-                  <Box mr={smallerThanSmallTablet ? '0px' : '8px'}>
-                    <StyledCloseIconButton2
-                      className="e2e-modal-close-button"
-                      iconColor={colors.textSecondary}
-                      iconColorOnHover={colors.black}
-                      a11y_buttonActionMessage={messages.closeWindow}
-                      onClick={clickCloseButton}
-                    />
-                  </Box>
-                )}
-              </>
+            {header ? (
+              <HeaderContainer>
+                <HeaderTitle id="modal-header">{header}</HeaderTitle>
+                {closeButton}
+              </HeaderContainer>
+            ) : (
+              closeButton
             )}
 
             <ModalContentContainer padding={calculatedPadding}>

--- a/front/app/components/UI/SettingsModal/NavItem.tsx
+++ b/front/app/components/UI/SettingsModal/NavItem.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+
+import {
+  Box,
+  Icon,
+  IconNames,
+  Text,
+  colors,
+} from '@citizenlab/cl2-component-library';
+import styled from 'styled-components';
+
+import { MessageDescriptor, useIntl } from 'utils/cl-intl';
+
+const NavButton = styled(Box)`
+  .label {
+    font-size: 13px;
+    font-weight: 400;
+  }
+
+  &[aria-selected='true'] .label {
+    font-weight: 500;
+  }
+
+  &:not([aria-selected='true']):hover {
+    background: ${colors.grey100};
+
+    .label {
+      color: ${colors.textPrimary};
+    }
+
+    svg {
+      fill: ${colors.textPrimary};
+    }
+  }
+`;
+
+interface Props {
+  tabId: string;
+  panelId: string;
+  label: MessageDescriptor;
+  icon: IconNames;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+const NavItem = ({
+  tabId,
+  panelId,
+  label,
+  icon,
+  selected,
+  onSelect,
+}: Props) => {
+  const { formatMessage } = useIntl();
+
+  return (
+    <NavButton
+      as="button"
+      type="button"
+      id={tabId}
+      role="tab"
+      aria-selected={selected}
+      aria-controls={panelId}
+      tabIndex={selected ? 0 : -1}
+      onClick={onSelect}
+      display="flex"
+      alignItems="center"
+      gap="10px"
+      w="100%"
+      px="12px"
+      py="8px"
+      border="none"
+      borderRadius="8px"
+      background={selected ? colors.grey200 : 'transparent'}
+      cursor="pointer"
+    >
+      <Icon
+        name={icon}
+        width="16px"
+        height="16px"
+        fill={selected ? colors.textPrimary : colors.coolGrey700}
+      />
+      <Text
+        className="label"
+        as="span"
+        m="0px"
+        color={selected ? 'textPrimary' : 'coolGrey700'}
+      >
+        {formatMessage(label)}
+      </Text>
+    </NavButton>
+  );
+};
+
+export default NavItem;

--- a/front/app/components/UI/SettingsModal/SettingsModal.test.tsx
+++ b/front/app/components/UI/SettingsModal/SettingsModal.test.tsx
@@ -1,0 +1,153 @@
+import React from 'react';
+
+import { render, screen, userEvent } from 'utils/testUtils/rtl';
+
+import SettingsModal, { SettingsModalSection } from './index';
+
+const messages = {
+  moderation: {
+    id: 'app.components.UI.SettingsModal.test.moderation',
+    defaultMessage: 'Moderation',
+  },
+  notifications: {
+    id: 'app.components.UI.SettingsModal.test.notifications',
+    defaultMessage: 'Notifications',
+  },
+};
+
+const sections: SettingsModalSection[] = [
+  {
+    name: 'moderation',
+    label: messages.moderation,
+    icon: 'eye',
+    content: <div>How ideas are named and reviewed.</div>,
+  },
+  {
+    name: 'notifications',
+    label: messages.notifications,
+    icon: 'notification',
+    content: <div>Emails sent automatically to participants.</div>,
+  },
+];
+
+const renderModal = (
+  props: Partial<React.ComponentProps<typeof SettingsModal>> = {}
+) =>
+  render(
+    <SettingsModal
+      opened
+      close={jest.fn()}
+      header="Phase settings"
+      sections={sections}
+      {...props}
+    />
+  );
+
+beforeEach(() => {
+  const portal = document.createElement('div');
+  portal.id = 'modal-portal';
+  document.body.appendChild(portal);
+});
+
+afterEach(() => {
+  document.getElementById('modal-portal')?.remove();
+});
+
+describe('SettingsModal', () => {
+  it('shows one tab per section and selects the first by default', () => {
+    renderModal();
+
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+    expect(screen.getByRole('tab', { name: 'Moderation' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('marks the sections up as a vertical tab list', () => {
+    renderModal();
+
+    // Deliberately unnamed: screen readers announce the selected tab, and the
+    // component is not always a "settings" modal.
+    expect(screen.getByRole('tablist')).toHaveAttribute(
+      'aria-orientation',
+      'vertical'
+    );
+  });
+
+  it('renders only the selected section', () => {
+    renderModal();
+
+    expect(
+      screen.getByText('How ideas are named and reviewed.')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Emails sent automatically to participants.')
+    ).not.toBeInTheDocument();
+  });
+
+  it('switches section on click', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Notifications' }));
+
+    expect(
+      screen.getByText('Emails sent automatically to participants.')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('honours initialSection', () => {
+    renderModal({ initialSection: 'notifications' });
+
+    expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('moves between tabs with the arrow keys and wraps around', async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole('tab', { name: 'Moderation' }));
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(screen.getByRole('tab', { name: 'Notifications' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(screen.getByRole('tab', { name: 'Moderation' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+  });
+
+  it('renders a footer only when one is given', () => {
+    const { unmount } = renderModal({
+      footer: <button>Save changes</button>,
+    });
+
+    expect(
+      screen.getByRole('button', { name: 'Save changes' })
+    ).toBeInTheDocument();
+
+    unmount();
+    renderModal();
+
+    expect(
+      screen.queryByRole('button', { name: 'Save changes' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no sections', () => {
+    renderModal({ sections: [] });
+
+    expect(screen.queryByRole('tab')).not.toBeInTheDocument();
+  });
+});

--- a/front/app/components/UI/SettingsModal/index.tsx
+++ b/front/app/components/UI/SettingsModal/index.tsx
@@ -1,0 +1,148 @@
+import React, { KeyboardEvent, useId, useRef, useState } from 'react';
+
+import { Box, IconNames, colors } from '@citizenlab/cl2-component-library';
+
+import Modal from 'components/UI/Modal';
+
+import { MessageDescriptor } from 'utils/cl-intl';
+
+import NavItem from './NavItem';
+
+export interface SettingsModalSection {
+  name: string;
+  label: MessageDescriptor;
+  icon: IconNames;
+  content: React.ReactNode;
+}
+
+interface Props {
+  opened: boolean;
+  close: () => void;
+  header: string | JSX.Element;
+  sections: SettingsModalSection[];
+  initialSection?: string;
+  footer?: JSX.Element;
+  width?: number | string;
+}
+
+const SettingsModal = ({
+  opened,
+  close,
+  header,
+  sections,
+  initialSection,
+  footer,
+  width = 'min(866px, 94vw)',
+}: Props) => {
+  const idPrefix = useId();
+  const navRef = useRef<HTMLDivElement>(null);
+  const [selectedSection, setSelectedSection] = useState(
+    initialSection ?? sections[0]?.name
+  );
+
+  const selectedIndex = Math.max(
+    sections.findIndex(({ name }) => name === selectedSection),
+    0
+  );
+
+  const select = (index: number) => {
+    setSelectedSection(sections[index].name);
+
+    const tabs =
+      navRef.current?.querySelectorAll<HTMLButtonElement>('[role="tab"]');
+    tabs?.[index].focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    const lastIndex = sections.length - 1;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        select(selectedIndex === lastIndex ? 0 : selectedIndex + 1);
+        break;
+      case 'ArrowUp':
+        select(selectedIndex === 0 ? lastIndex : selectedIndex - 1);
+        break;
+      case 'Home':
+        select(0);
+        break;
+      case 'End':
+        select(lastIndex);
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+  };
+
+  if (sections.length === 0) return null;
+
+  const section = sections[selectedIndex];
+  const tabId = (name: string) => `${idPrefix}-tab-${name}`;
+  const panelId = (name: string) => `${idPrefix}-panel-${name}`;
+
+  return (
+    <Modal
+      opened={opened}
+      close={close}
+      header={header}
+      footer={
+        footer && (
+          <Box w="100%" display="flex" justifyContent="flex-end">
+            {footer}
+          </Box>
+        )
+      }
+      width={width}
+      fixedHeight
+    >
+      <Box display="flex" h="100%">
+        <Box
+          ref={navRef}
+          role="tablist"
+          aria-orientation="vertical"
+          onKeyDown={handleKeyDown}
+          display="flex"
+          flexDirection="column"
+          gap="3px"
+          flex="0 0 auto"
+          w="210px"
+          py="16px"
+          px="12px"
+          background={colors.grey50}
+          borderRight={`1px solid ${colors.grey200}`}
+          overflowY="auto"
+        >
+          {sections.map(({ name, label, icon }, index) => (
+            <NavItem
+              key={name}
+              tabId={tabId(name)}
+              panelId={panelId(name)}
+              label={label}
+              icon={icon}
+              selected={index === selectedIndex}
+              onSelect={() => select(index)}
+            />
+          ))}
+        </Box>
+        <Box
+          key={section.name}
+          role="tabpanel"
+          id={panelId(section.name)}
+          aria-labelledby={tabId(section.name)}
+          tabIndex={0}
+          flex="1 1 auto"
+          pt="32px"
+          px="32px"
+          pb="24px"
+          overflowY="auto"
+        >
+          {section.content}
+        </Box>
+      </Box>
+    </Modal>
+  );
+};
+
+export default SettingsModal;

--- a/front/app/components/admin/ActionForm/AccessSection/GroupsSection/ErrorMessageModal.tsx
+++ b/front/app/components/admin/ActionForm/AccessSection/GroupsSection/ErrorMessageModal.tsx
@@ -5,7 +5,6 @@ import React from 'react';
 
 import {
   Box,
-  Title,
   Text,
   Button,
   InputMultilocWithLocaleSwitcher,
@@ -43,13 +42,8 @@ const ErrorMessageModal = ({
     <Modal
       opened={opened}
       close={onClose}
-      niceHeader
       width="560px"
-      header={
-        <Title ml="20px" variant="h3" color="primary">
-          <FormattedMessage {...messages.modalTitle} />
-        </Title>
-      }
+      header={<FormattedMessage {...messages.modalTitle} />}
     >
       <Box p="24px">
         <Text mt="0" color="coolGrey600">

--- a/front/app/components/admin/ActionForm/AccessSection/IdMethodsModal/index.tsx
+++ b/front/app/components/admin/ActionForm/AccessSection/IdMethodsModal/index.tsx
@@ -12,7 +12,6 @@ import React from 'react';
 import {
   Accordion,
   Box,
-  Title,
   Text,
   IconTooltip,
 } from '@citizenlab/cl2-component-library';
@@ -82,15 +81,8 @@ const IdMethodsModal = ({ opened, onClose }: Props) => {
     <Modal
       opened={opened}
       close={onClose}
-      niceHeader
       width="620px"
-      header={
-        // The close button is absolutely positioned over the full-width header,
-        // so the title has to keep clear of it on the right.
-        <Title ml="20px" mr="56px" variant="h3" color="primary">
-          <FormattedMessage {...messages.identificationMethods} />
-        </Title>
-      }
+      header={<FormattedMessage {...messages.identificationMethods} />}
     >
       <Box p="24px">
         {activeMethods.length === 0 && (

--- a/front/app/components/admin/ActionForm/DataSection/DemographicSection/FieldSelectionModal/index.tsx
+++ b/front/app/components/admin/ActionForm/DataSection/DemographicSection/FieldSelectionModal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Title } from '@citizenlab/cl2-component-library';
+import { Box } from '@citizenlab/cl2-component-library';
 
 import { IPermissionsPhaseCustomFieldData } from 'api/permissions_phase_custom_fields/types';
 import { IUserCustomFieldData } from 'api/user_custom_fields/types';
@@ -54,15 +54,12 @@ const FieldSelectionModal = ({
       close={() => {
         setShowSelectionModal(false);
       }}
-      niceHeader={true}
       header={
-        <Title ml="20px" variant="h3" color="primary">
-          <FormattedMessage
-            {...(showAddFieldPage
-              ? messages.createAQuestion
-              : messages.addQuestion)}
-          />
-        </Title>
+        <FormattedMessage
+          {...(showAddFieldPage
+            ? messages.createAQuestion
+            : messages.addQuestion)}
+        />
       }
       closeOnClickOutside={false}
       width={'550px'}

--- a/front/app/components/admin/FormSync/PDFExportModal/index.tsx
+++ b/front/app/components/admin/FormSync/PDFExportModal/index.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   CollapsibleContainer,
   Text,
-  Title,
 } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
@@ -154,12 +153,7 @@ const PDFExportModal = ({
       width="580px"
       opened={open}
       close={onClose}
-      header={
-        <Title variant="h2" as="h1" color="primary" m="0" px="24px">
-          <FormattedMessage {...messages.exportAsPDF} />
-        </Title>
-      }
-      niceHeader
+      header={<FormattedMessage {...messages.exportAsPDF} />}
       // This is necessary to prevent the modal from closing when you e.g. select text in
       // the textarea and happen to arrive outside of the modal with your cursor.
       closeOnClickOutside={false}

--- a/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
+++ b/front/app/containers/Admin/ProjectImporter/ImportZipModal.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Button,
-  colors,
-  Text,
-  Title,
-} from '@citizenlab/cl2-component-library';
+import { Box, Button, colors, Text } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
 import { SupportedLocale } from 'typings';
@@ -85,12 +79,7 @@ const ImportZipModal = ({ open, onClose, onImport }: Props) => {
       width="780px"
       opened={open}
       close={onClose}
-      header={
-        <Title variant="h2" color="primary" px="24px" m="0">
-          Import projects from zip file
-        </Title>
-      }
-      niceHeader
+      header="Import projects from zip file"
     >
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(submitFile)}>

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportExcelModal.tsx
@@ -1,12 +1,6 @@
 import React from 'react';
 
-import {
-  Box,
-  Button,
-  colors,
-  Text,
-  Title,
-} from '@citizenlab/cl2-component-library';
+import { Box, Button, colors, Text } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider } from 'react-hook-form';
 import { SupportedLocale } from 'typings';
@@ -101,12 +95,7 @@ const ImportExcelModal = ({ open, onClose }: Props) => {
       width="780px"
       opened={open}
       close={onClose}
-      header={
-        <Title variant="h2" color="primary" px="24px" m="0">
-          <FormattedMessage {...messages.importExcelFileTitle} />
-        </Title>
-      }
-      niceHeader
+      header={<FormattedMessage {...messages.importExcelFileTitle} />}
     >
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(submitFile)}>

--- a/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
+++ b/front/app/containers/Admin/projects/project/inputImporter/ImportModal/ImportPdfModal.tsx
@@ -1,12 +1,6 @@
 import React, { useEffect } from 'react';
 
-import {
-  Box,
-  Text,
-  Title,
-  Button,
-  colors,
-} from '@citizenlab/cl2-component-library';
+import { Box, Text, Button, colors } from '@citizenlab/cl2-component-library';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm, FormProvider, Resolver } from 'react-hook-form';
 import { SupportedLocale } from 'typings';
@@ -143,12 +137,7 @@ const ImportPdfModal = ({ open, onClose }: Props) => {
         methods.reset();
         onClose();
       }}
-      header={
-        <Title variant="h2" color="primary" px="24px" m="0">
-          <FormattedMessage {...messages.importPDFFileTitle} />
-        </Title>
-      }
-      niceHeader
+      header={<FormattedMessage {...messages.importPDFFileTitle} />}
     >
       <FormProvider {...methods}>
         <form onSubmit={methods.handleSubmit(submitFile)}>

--- a/front/app/containers/Admin/users/index.tsx
+++ b/front/app/containers/Admin/users/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { media } from '@citizenlab/cl2-component-library';
+import { Button, media } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import { IGroupData, MembershipType } from 'api/groups/types';
@@ -8,7 +8,12 @@ import useAddGroup from 'api/groups/useAddGroup';
 
 import HelmetIntl from 'components/HelmetIntl';
 import Outlet from 'components/Outlet';
-import Modal from 'components/UI/Modal';
+// TEMP (TAN-8590): belongs to the original Modal, commented out at the bottom
+// of this file. Restore when reverting.
+// import Modal from 'components/UI/Modal';
+// This is a temproray to test the new SettingsModal component.
+// It will be removed before merge this branch
+import SettingsModal from 'components/UI/SettingsModal';
 
 import FormattedMessage from 'utils/cl-intl/FormattedMessage';
 import { Outlet as RouterOutlet } from 'utils/router';
@@ -109,6 +114,35 @@ const UsersPage = () => {
         </ChildWrapper>
       </Wrapper>
 
+      <SettingsModal
+        header={renderModalHeader()}
+        opened={groupCreationModal !== false}
+        close={closeGroupCreationModal}
+        footer={<Button buttonStyle="admin-dark">Save changes</Button>}
+        sections={[
+          {
+            name: 'manual',
+            label: messages.step1TypeNameNormal,
+            icon: 'database',
+            content: (
+              <NormalGroupForm
+                onSubmit={(values) =>
+                  handleSubmitForm({ ...values, membership_type: 'manual' })
+                }
+              />
+            ),
+          },
+          {
+            name: 'smart',
+            label: messages.step1TypeNameSmart,
+            icon: 'settings',
+            content: <GroupCreationStep1 onOpenStep2={openStep2} />,
+          },
+        ]}
+      />
+
+      {/* 
+
       <Modal
         header={renderModalHeader()}
         opened={groupCreationModal !== false}
@@ -134,6 +168,8 @@ const UsersPage = () => {
           />
         </>
       </Modal>
+
+      */}
     </>
   );
 };

--- a/front/app/containers/Admin/users/index.tsx
+++ b/front/app/containers/Admin/users/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Button, media } from '@citizenlab/cl2-component-library';
+import { media } from '@citizenlab/cl2-component-library';
 import styled from 'styled-components';
 
 import { IGroupData, MembershipType } from 'api/groups/types';
@@ -8,12 +8,7 @@ import useAddGroup from 'api/groups/useAddGroup';
 
 import HelmetIntl from 'components/HelmetIntl';
 import Outlet from 'components/Outlet';
-// TEMP (TAN-8590): belongs to the original Modal, commented out at the bottom
-// of this file. Restore when reverting.
-// import Modal from 'components/UI/Modal';
-// This is a temproray to test the new SettingsModal component.
-// It will be removed before merge this branch
-import SettingsModal from 'components/UI/SettingsModal';
+import Modal from 'components/UI/Modal';
 
 import FormattedMessage from 'utils/cl-intl/FormattedMessage';
 import { Outlet as RouterOutlet } from 'utils/router';
@@ -114,35 +109,6 @@ const UsersPage = () => {
         </ChildWrapper>
       </Wrapper>
 
-      <SettingsModal
-        header={renderModalHeader()}
-        opened={groupCreationModal !== false}
-        close={closeGroupCreationModal}
-        footer={<Button buttonStyle="admin-dark">Save changes</Button>}
-        sections={[
-          {
-            name: 'manual',
-            label: messages.step1TypeNameNormal,
-            icon: 'database',
-            content: (
-              <NormalGroupForm
-                onSubmit={(values) =>
-                  handleSubmitForm({ ...values, membership_type: 'manual' })
-                }
-              />
-            ),
-          },
-          {
-            name: 'smart',
-            label: messages.step1TypeNameSmart,
-            icon: 'settings',
-            content: <GroupCreationStep1 onOpenStep2={openStep2} />,
-          },
-        ]}
-      />
-
-      {/* 
-
       <Modal
         header={renderModalHeader()}
         opened={groupCreationModal !== false}
@@ -168,8 +134,6 @@ const UsersPage = () => {
           />
         </>
       </Modal>
-
-      */}
     </>
   );
 };

--- a/front/app/containers/Authentication/Modal/index.tsx
+++ b/front/app/containers/Authentication/Modal/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Box, Title, useBreakpoint } from '@citizenlab/cl2-component-library';
+import { Box, useBreakpoint } from '@citizenlab/cl2-component-library';
 import { useTheme } from 'styled-components';
 
 import useAppConfiguration from 'api/app_configuration/useAppConfiguration';
@@ -76,14 +76,7 @@ const AuthModal = () => {
       close={handleClose}
       hideCloseButton={!closable}
       closeOnClickOutside={false}
-      header={
-        headerMessage ? (
-          <Title variant="h3" as="h1" mt="0px" mb="0px" ml={marginX}>
-            {formatMessage(headerMessage)}
-          </Title>
-        ) : undefined
-      }
-      niceHeader
+      header={headerMessage ? formatMessage(headerMessage) : undefined}
       ariaLabelledBy="auth-modal-title"
     >
       <Box id="e2e-authentication-modal" px={marginX} py="32px" w="100%">


### PR DESCRIPTION
Adds `SettingsModal`  a tabbed modal with a side navigation 
and brings `components/UI/Modal` onto the design system's modal spec, since the new component is built on it.

## Why `niceHeader` is gone 

`Modal` had two header layouts. `niceHeader` rendered `header` raw, so its 8 call
sites each styled their own title — nothing inside `Modal` could make them match.
It also had a bug: `Modal` set `aria-labelledby="modal-header"` whenever a header
was passed, but only the default branch put that id on an element. All 8  sign-in
included pointed at nothing and had **no accessible name** for screen readers.


 Screenshots and before/after comparison are on the ticket.

# Changelog
## Added
- add settingModal and unify Modal component




# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
