### PR TITLE
[TAN-8612] Publish the front bundle of every commit for epic previews

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,8 +588,34 @@ jobs:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run:
-          command: TEST_BUILD="true" npm run build
+          # This job runs without the citizenlab-ee-environment context: the
+          # build environment is explicit, so no staging or production
+          # identifier (Sentry DSN, Intercom app id, PostHog key) ends up in
+          # the bundle. The bundle is served by the epic preview platform
+          # (cl2-deployment/epic), one commit at a time.
+          name: Build (epic previews)
+          command: |
+            SENTRY_ENV=epic SENTRY_DSN="${EPIC_SENTRY_DSN:-}" POSTHOG_API_KEY="${EPIC_POSTHOG_API_KEY:-}" \
+              TEST_BUILD="true" npm run build
           no_output_timeout: "30m"
+      - run:
+          # Bucket, endpoint and write-only key come from the epic-front-bundles
+          # context. Fork builds have no context: no upload, no preview.
+          name: Publish the bundle for epic previews
+          command: |
+            if [ -z "${EPIC_BUNDLE_ACCESS_KEY_ID:-}" ]; then
+              echo "No bundle credentials in this build (fork?), skipping the upload."
+              exit 0
+            fi
+            rm -f build/*.map build/assets/*.map
+            tar -czf /tmp/build.tar.gz -C build .
+            AWS_ACCESS_KEY_ID="$EPIC_BUNDLE_ACCESS_KEY_ID" \
+            AWS_SECRET_ACCESS_KEY="$EPIC_BUNDLE_SECRET_ACCESS_KEY" \
+            AWS_DEFAULT_REGION="${EPIC_BUNDLE_REGION:-fr-par}" \
+              aws s3 cp /tmp/build.tar.gz "s3://$EPIC_BUNDLE_BUCKET/$CIRCLE_SHA1/build.tar.gz" \
+                --endpoint-url "${EPIC_BUNDLE_ENDPOINT:-https://s3.fr-par.scw.cloud}" \
+                --acl public-read
+            echo "Published $EPIC_BUNDLE_BUCKET/$CIRCLE_SHA1/build.tar.gz"
 
   front-extract-intl:
     docker:
@@ -1365,7 +1391,9 @@ workflows:
                 - crowdin_master
                 - /l10n_.*/
       - front-build:
-          context: citizenlab-ee-environment
+          # Only the bundle bucket key (cl2-deployment/epic); the rest of
+          # the pipeline keeps citizenlab-ee-environment.
+          context: epic-front-bundles
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,19 +588,14 @@ jobs:
             - /root/.npm
           key: v2-npm-cache-{{ checksum "package-lock.json" }}
       - run:
-          # This job runs without the citizenlab-ee-environment context: the
-          # build environment is explicit, so no staging or production
-          # identifier (Sentry DSN, Intercom app id, PostHog key) ends up in
-          # the bundle. The bundle is served by the epic preview platform
-          # (cl2-deployment/epic), one commit at a time.
+          # This doubles as a test that the build succeeds, and also produces a
+          # build artifact for preview deployments (epic platform).
           name: Build (epic previews)
           command: |
             SENTRY_ENV=epic SENTRY_DSN="${EPIC_SENTRY_DSN:-}" POSTHOG_API_KEY="${EPIC_POSTHOG_API_KEY:-}" \
               TEST_BUILD="true" npm run build
           no_output_timeout: "30m"
       - run:
-          # Bucket, endpoint and write-only key come from the epic-front-bundles
-          # context. Fork builds have no context: no upload, no preview.
           name: Publish the bundle for epic previews
           command: |
             if [ -z "${EPIC_BUNDLE_ACCESS_KEY_ID:-}" ]; then
@@ -1391,8 +1386,7 @@ workflows:
                 - crowdin_master
                 - /l10n_.*/
       - front-build:
-          # Only the bundle bucket key (cl2-deployment/epic); the rest of
-          # the pipeline keeps citizenlab-ee-environment.
+          # Test build is used on epics, uses a different context
           context: epic-front-bundles
           filters:
             branches:


### PR DESCRIPTION
The `front-build` job (runs on every branch) now uploads `build.tar.gz` to the epic bundle bucket (`<sha>/build.tar.gz`, Scaleway Object Storage), where the new epic preview platform (`cl2-deployment/epic`, TAN-8612) fetches it. Nothing else in the pipeline changes: no epic job, no trigger, no cluster credential in CircleCI.

The job runs with the new context `epic-front-bundles` instead of `citizenlab-ee-environment`:

- the build environment is explicit (`SENTRY_ENV=epic`, optional `EPIC_SENTRY_DSN` and `EPIC_POSTHOG_API_KEY`), so no staging or production identifier (Sentry DSN, Intercom app id, PostHog key) ends up in the bundle;
- the production secrets of `citizenlab-ee-environment` are no longer exposed to `npm install` on every branch in this job.

Fork builds have no context and skip the upload (and get no preview).

**Do not merge before** the CircleCI context `epic-front-bundles` exists with `EPIC_BUNDLE_ACCESS_KEY_ID`, `EPIC_BUNDLE_SECRET_ACCESS_KEY` and `EPIC_BUNDLE_BUCKET` (values from `tofu output` in `cl2-deployment/epic/scaleway`, see the runbook `cl2-deployment/epic/README.md`). Without the context the job still builds and only logs that the upload is skipped. First thing to watch on the first run: `npm ci` and `npm run build` succeed without the old context (no context variable is used by this job today).

# Changelog
## Technical
- CI now saves all front-end builds to a bucket on Scaleway, to speed up deployments on the new epic platform
