### PR TITLE
TAN-8598 Insights tab demographics hidden

### DIFF
--- a/back/app/services/insights/base_phase_insights_service.rb
+++ b/back/app/services/insights/base_phase_insights_service.rb
@@ -177,10 +177,15 @@ module Insights
       end
     end
 
+    # The permissions that actually govern participation in the phase: the rows
+    # the phase owns, plus, for every action it has not overridden, the copy of
+    # the global 'visiting' permission it inherits.
+    # See Permissions::PermissionInheritanceService.
+    # 'attending_event' is left out: event attendance is not phase participation.
     def phase_permissions
-      @phase.permissions
-        .where.not(action: 'attending_event')
-        .includes(:permissions_custom_fields, :groups)
+      Permissions::PermissionInheritanceService.new
+        .effective_permissions(@phase)
+        .reject { |permission| permission.action == 'attending_event' }
     end
 
     def birthyear_demographics_data(participant_custom_field_values)

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/permission.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/permission.rb
@@ -4,6 +4,10 @@ class McpServer::Serializers::Permission < McpServer::Serializers::Base
   def attributes(record)
     {
       action: record.action,
+      # Whether the action still follows the global 'visiting' permission, i.e.
+      # the platform-wide sign-in flow, rather than settings of its own.
+      # See Permissions::PermissionInheritanceService.
+      inherited: record.inherited?,
       permitted_by: record.permitted_by,
       group_ids: record.groups.pluck(:id),
       demographic_questions: record.permissions_custom_fields.map do |pcf|

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_phase_permissions.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_phase_permissions.rb
@@ -7,7 +7,9 @@ class McpServer::Tools::ListPhasePermissions < McpServer::BaseTool
   def description
     <<~DESC.squish
       Lists the permissions of a phase (one per applicable action, e.g. posting_idea, voting).
-      Permissions are auto-created with the phase — there is no create tool.
+      There is no create tool. An action the phase has not customised is reported with
+      inherited: true, along with the platform-wide sign-in settings it follows; updating it
+      with update_phase_permission gives the phase settings of its own.
       Call before update_phase_permission to see which actions exist.
     DESC
   end
@@ -26,9 +28,11 @@ class McpServer::Tools::ListPhasePermissions < McpServer::BaseTool
       phase = Phase.find_by(id: params[:phase_id])
       return not_found_error('Phase', params[:phase_id]) unless phase
 
-      permissions = phase
-        .permissions.includes(:groups, :permissions_custom_fields)
-        .order_by_action(phase)
+      # Mixes the permissions the phase owns with the ones it inherits from the
+      # global 'visiting' permission, in the phase's action order.
+      # See Permissions::PermissionInheritanceService.
+      permissions = Permissions::PermissionInheritanceService.new
+        .effective_permissions(phase)
         .map { |permission| McpServer::Serializers::Permission.serialize(permission) }
 
       response(

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_phase_permission.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/update_phase_permission.rb
@@ -15,9 +15,11 @@ class McpServer::Tools::UpdatePhasePermission < McpServer::BaseTool
 
   def description
     <<~DESC.squish
-      Updates a phase permission (auto-created with the phase). Sets who can perform an action,
-      with optional group restrictions, demographic-question requirements, verification recency,
-      and a custom rejection message.
+      Updates a phase permission. Sets who can perform an action, with optional group
+      restrictions, demographic-question requirements, verification recency, and a custom
+      rejection message. An action the phase has not customised yet follows the platform-wide
+      sign-in settings (inherited: true in list_phase_permissions); updating it gives the phase
+      settings of its own, starting from the ones it was inheriting.
     DESC
   end
 
@@ -130,7 +132,10 @@ class McpServer::Tools::UpdatePhasePermission < McpServer::BaseTool
 
       authorize_project!(phase.project)
 
-      permission = phase.permissions.find_by(action: params[:action])
+      # Resolves to the row the phase owns or, for an action it has not
+      # customised, to the copy of the global 'visiting' permission it follows.
+      # See Permissions::PermissionInheritanceService.
+      permission = inheritance_service.find(phase, params[:action])
       return invalid_action_response(phase, params[:action]) unless permission
 
       authorize(permission, :update?)
@@ -152,6 +157,10 @@ class McpServer::Tools::UpdatePhasePermission < McpServer::BaseTool
       )
 
       ActiveRecord::Base.transaction do
+        # Customising an action means detaching it from the global 'visiting'
+        # permission first: a no-op once the phase owns the action. Inside the
+        # transaction so that a rejected update leaves no override behind.
+        permission = inheritance_service.override!(phase, params[:action])
         permission.update!(merge_multilocs(permission, attributes))
         replace_demographic_questions(permission, params[:demographic_questions]) if params.key?(:demographic_questions)
       end
@@ -165,6 +174,10 @@ class McpServer::Tools::UpdatePhasePermission < McpServer::BaseTool
     end
 
     private
+
+    def inheritance_service
+      @inheritance_service ||= Permissions::PermissionInheritanceService.new
+    end
 
     def invalid_action_response(phase, action)
       valid_actions = Permission.available_actions(phase) || []

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phase_permissions_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_phase_permissions_spec.rb
@@ -20,12 +20,55 @@ describe McpServer::Tools::ListPhasePermissions do
     expect(response.structured_content).to match(
       phase_id: phase.id,
       permissions: [
-        a_hash_including(action: 'posting_idea'),
-        a_hash_including(action: 'commenting_idea'),
-        a_hash_including(action: 'reacting_idea'),
-        a_hash_including(action: 'attending_event')
+        a_hash_including(action: 'posting_idea', inherited: false),
+        a_hash_including(action: 'commenting_idea', inherited: false),
+        a_hash_including(action: 'reacting_idea', inherited: false),
+        a_hash_including(action: 'attending_event', inherited: false)
       ]
     )
+  end
+
+  # A phase action has no permission row of its own until it is overridden;
+  # until then it follows the global 'visiting' permission.
+  # See Permissions::PermissionInheritanceService.
+  context 'when the phase has not customised its permissions' do
+    let!(:visiting_permission) do
+      create(:global_permission, action: 'visiting', permitted_by: 'admins_moderators')
+    end
+
+    before { Permissions::PermissionInheritanceService.clear_source_permission_cache }
+
+    it 'lists every action with the settings it inherits' do
+      phase = create(:phase)
+
+      response = list(phase_id: phase.id)
+
+      expect(response).not_to be_error
+
+      expect(response.structured_content).to match(
+        phase_id: phase.id,
+        permissions: [
+          a_hash_including(action: 'posting_idea', inherited: true, permitted_by: 'admins_moderators'),
+          a_hash_including(action: 'commenting_idea', inherited: true, permitted_by: 'admins_moderators'),
+          a_hash_including(action: 'reacting_idea', inherited: true, permitted_by: 'admins_moderators'),
+          a_hash_including(action: 'attending_event', inherited: true, permitted_by: 'admins_moderators')
+        ]
+      )
+    end
+
+    it 'reports the actions the phase has customised as its own' do
+      phase = create(:phase)
+      Permissions::PermissionInheritanceService.new.override!(phase, 'posting_idea')
+
+      response = list(phase_id: phase.id)
+
+      expect(response.structured_content[:permissions]).to match([
+        a_hash_including(action: 'posting_idea', inherited: false),
+        a_hash_including(action: 'commenting_idea', inherited: true),
+        a_hash_including(action: 'reacting_idea', inherited: true),
+        a_hash_including(action: 'attending_event', inherited: true)
+      ])
+    end
   end
 
   it 'serializes permission fields' do

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
@@ -36,6 +36,7 @@ describe McpServer::Tools::UpdatePhasePermission do
 
       expect(response.structured_content).to match(
         action: permission.action,
+        inherited: false,
         permitted_by: 'admins_moderators',
         group_ids: [],
         demographic_questions: [],
@@ -171,6 +172,63 @@ describe McpServer::Tools::UpdatePhasePermission do
 
         expect(response).to be_error
         expect(permission.permissions_custom_fields.pluck(:custom_field_id)).to eq([existing_field.id])
+      end
+    end
+
+    # A phase action has no permission row of its own until it is overridden;
+    # until then it follows the global 'visiting' permission.
+    # See Permissions::PermissionInheritanceService.
+    context 'when the phase has not customised the action' do
+      let(:phase) { create(:phase, project: project) }
+      let(:params) do
+        {
+          phase_id: phase.id,
+          action: 'commenting_idea',
+          permitted_by: 'admins_moderators'
+        }
+      end
+
+      let!(:visiting_permission) do
+        create(
+          :global_permission,
+          action: 'visiting',
+          permitted_by: 'users',
+          require_name: false,
+          require_password: false
+        )
+      end
+
+      before { Permissions::PermissionInheritanceService.clear_source_permission_cache }
+
+      it 'overrides the action and applies the update' do
+        response = nil
+        expect { response = run(params) }
+          .to change { phase.permissions.pluck(:action) }.from([]).to(%w[commenting_idea])
+
+        expect(response).not_to be_error
+        expect(phase.permissions.sole.permitted_by).to eq 'admins_moderators'
+      end
+
+      it 'starts from the settings the action was inheriting' do
+        response = run(params.merge(permitted_by: 'users'))
+
+        expect(response).not_to be_error
+        expect(response.structured_content).to include(
+          inherited: false, # It is customised for this phase from now on
+          permitted_by: 'users',
+          require_name: false,
+          require_password: false
+        )
+      end
+
+      it 'leaves no override behind when the update is rejected' do
+        demographic_questions = [{ custom_field_id: SecureRandom.uuid }]
+
+        response = nil
+        expect { response = run(params.merge(permitted_by: 'users', demographic_questions:)) }
+          .not_to change { phase.permissions.count }.from(0)
+
+        expect(response).to be_error
       end
     end
 

--- a/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
+++ b/back/spec/acceptance/phase_insights/ideation_phase_insights_spec.rb
@@ -123,5 +123,17 @@ resource 'Phase insights' do
     include_examples 'phase insights demographics',
       gender_blank: 1,
       birthyear_blank: 1
+
+    # Phase permissions only exist once an admin overrides them; until then the
+    # phase follows the global 'visiting' permission, and its demographic
+    # questions are the ones the insights report on.
+    # See Permissions::PermissionInheritanceService.
+    context 'when the phase has not overridden its permissions' do
+      before { ideation_phase.permissions.destroy_all }
+
+      include_examples 'phase insights demographics',
+        gender_blank: 1,
+        birthyear_blank: 1
+    end
   end
 end

--- a/back/spec/services/insights/base_phase_insights_service_spec.rb
+++ b/back/spec/services/insights/base_phase_insights_service_spec.rb
@@ -162,6 +162,47 @@ RSpec.describe Insights::BasePhaseInsightsService do
     end
   end
 
+  # A phase action only gets a permission row of its own once an admin overrides
+  # it; until then it follows the global 'visiting' permission.
+  # See Permissions::PermissionInheritanceService.
+  describe '#phase_permissions' do
+    let!(:visiting_permission) { create(:global_permission, action: 'visiting') }
+
+    before { Permissions::PermissionInheritanceService.clear_source_permission_cache }
+
+    it 'combines the overridden permissions of the phase with the inherited ones' do
+      permissions = service.send(:phase_permissions)
+
+      expect(permissions.map(&:action)).to match_array %w[voting commenting_idea]
+      expect(permissions.find { |permission| permission.action == 'voting' }).not_to be_inherited
+      expect(permissions.find { |permission| permission.action == 'commenting_idea' }).to be_inherited
+    end
+
+    it 'inherits every action when the phase has overridden none' do
+      permission1.destroy!
+
+      permissions = service.send(:phase_permissions)
+
+      expect(permissions.map(&:action)).to match_array %w[voting commenting_idea]
+      expect(permissions).to all(be_inherited)
+    end
+
+    it 'excludes attending_event, whether it is inherited or overridden' do
+      expect(service.send(:phase_permissions).map(&:action)).not_to include 'attending_event'
+
+      create(:permission, action: 'attending_event', permission_scope: phase)
+
+      expect(service.send(:phase_permissions).map(&:action)).not_to include 'attending_event'
+    end
+
+    it 'excludes actions that are disabled on the phase, including overridden ones' do
+      create(:permission, action: 'commenting_idea', permission_scope: phase)
+      phase.update!(commenting_enabled: false)
+
+      expect(service.send(:phase_permissions).map(&:action)).to eq %w[voting]
+    end
+  end
+
   describe '#demographics_data' do
     it 'only includes data related to fields used in phase-level action permissions' do
       permission1.update!(custom_fields_behavior: 'custom')
@@ -184,6 +225,53 @@ RSpec.describe Insights::BasePhaseInsightsService do
       result = service.send(:demographics_data, flattened_participations, participant_ids)
 
       expect(result.pluck(:key)).to match_array(%w[single_select1 single_select3])
+    end
+
+    # See Permissions::PermissionInheritanceService.
+    context 'when the phase has not overridden all of its permissions' do
+      let!(:visiting_permission) { create(:global_permission, action: 'visiting', custom_fields_behavior: 'custom') }
+
+      let(:participations) { [create(:basket_participation)] }
+      let(:participant_ids) { participations.pluck(:participant_id).uniq }
+
+      before { Permissions::PermissionInheritanceService.clear_source_permission_cache }
+
+      it "includes the fields of the global 'visiting' permission for the inherited actions" do
+        permission1.destroy! # The phase now inherits all of its permissions
+
+        inherited_field = create(:custom_field, resource_type: 'User', key: 'inherited_select', code: nil, input_type: 'select')
+        create(:custom_field, resource_type: 'User', key: 'unrelated_select', code: nil, input_type: 'select')
+        create(:permissions_custom_field, permission: visiting_permission, custom_field: inherited_field)
+
+        result = service.send(:demographics_data, participations, participant_ids)
+
+        expect(result.pluck(:key)).to eq %w[inherited_select]
+      end
+
+      it "includes no fields when the global 'visiting' permission has its demographic questions disabled" do
+        permission1.destroy!
+        visiting_permission.update!(custom_fields_behavior: 'disabled')
+        create(:custom_field, resource_type: 'User', key: 'unrelated_select', code: nil, input_type: 'select')
+
+        result = service.send(:demographics_data, participations, participant_ids)
+
+        expect(result).to be_empty
+      end
+
+      it 'prefers the fields of the overridden permission over the inherited ones' do
+        phase.update!(commenting_enabled: false) # Leaves 'voting' as the only action
+
+        permission1.update!(custom_fields_behavior: 'custom')
+        overridden_field = create(:custom_field, resource_type: 'User', key: 'overridden_select', code: nil, input_type: 'select')
+        create(:permissions_custom_field, permission: permission1, custom_field: overridden_field)
+
+        inherited_field = create(:custom_field, resource_type: 'User', key: 'inherited_select', code: nil, input_type: 'select')
+        create(:permissions_custom_field, permission: visiting_permission, custom_field: inherited_field)
+
+        result = service.send(:demographics_data, participations, participant_ids)
+
+        expect(result.pluck(:key)).to eq %w[overridden_select]
+      end
     end
 
     it 'only includes data related to specific types of user custom fields' do


### PR DESCRIPTION
# Changelog
## Fixed
- Insights tab: show demographics also if permission is inherited
## Technical
- MCP server: use inherited permissions