### PR TITLE
TAN-7824 Security improvements

### DIFF
--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -35,10 +35,6 @@ class WebApi::V1::ResetPasswordController < ApplicationController
       @user.find_or_create_confirmation(:email_confirmation).confirm! if @user.confirmation_required?
 
       if @user.save
-        # A reset ends every session that was open before it: whoever was signed
-        # in with the old password (an attacker, on a compromised account) is
-        # signed out and has to produce the new one. Unlike update_password
-        # there is no session to keep alive here - the caller isn't signed in.
         @user.expire_token!
 
         render json: WebApi::V1::UserSerializer.new(

--- a/back/app/controllers/web_api/v1/reset_password_controller.rb
+++ b/back/app/controllers/web_api/v1/reset_password_controller.rb
@@ -35,6 +35,12 @@ class WebApi::V1::ResetPasswordController < ApplicationController
       @user.find_or_create_confirmation(:email_confirmation).confirm! if @user.confirmation_required?
 
       if @user.save
+        # A reset ends every session that was open before it: whoever was signed
+        # in with the old password (an attacker, on a compromised account) is
+        # signed out and has to produce the new one. Unlike update_password
+        # there is no session to keep alive here - the caller isn't signed in.
+        @user.expire_token!
+
         render json: WebApi::V1::UserSerializer.new(
           @user,
           params: jsonapi_serializer_params

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -162,7 +162,7 @@ class WebApi::V1::UsersController < ApplicationController
     end
 
     RequestEmailConfirmationCodeJob.perform_now(@user) if auto_send_code?(@user, :email_confirmation)
-    render_check_action(@user, :email_confirmation)
+    render_check_action(@user)
   end
 
   # The phone counterpart of check_email: validates a phone number without
@@ -188,7 +188,6 @@ class WebApi::V1::UsersController < ApplicationController
     RequestPhoneConfirmationCodeJob.issue_code_and_deliver_later(@user) if auto_send_code?(@user, :phone_confirmation)
     render_check_action(
       @user,
-      :phone_confirmation,
       code_retry_after: @user&.phone_confirmation&.seconds_until_resend_allowed.to_i
     )
   end
@@ -429,27 +428,33 @@ class WebApi::V1::UsersController < ApplicationController
   end
 
   # Shared by check_email and check_phone: given the account that owns the
-  # submitted identifier (nil when there is none) and the name of the confirmation
-  # that covers that identifier, tell the frontend which step to go to next.
-  # code_retry_after is passed for phone only: only SMS codes have a minimum
-  # interval between requests, and the confirmation step counts it down instead
-  # of offering a resend the backend would reject.
-  def render_check_action(user, confirmation_name, code_retry_after: nil)
-    render json: raw_json({ action: check_action(user, confirmation_name), code_retry_after: code_retry_after }.compact)
+  # submitted identifier (nil when there is none), tell the frontend which step
+  # to go to next. code_retry_after is passed for phone only: only SMS codes
+  # have a minimum interval between requests, and the confirmation step counts
+  # it down instead of offering a resend the backend would reject.
+  def render_check_action(user, code_retry_after: nil)
+    render json: raw_json({ action: check_action(user), code_retry_after: code_retry_after }.compact)
   end
 
-  def check_action(user, confirmation_name)
+  # An account that has a password authenticates with it, never with a code:
+  # the code steps are the password-less path, and both RequestCodePolicy and
+  # UserConfirmationService reject an account with a password. So a user who has
+  # one always goes to the password step, including the legacy shape where a
+  # password was set before the identifier was ever confirmed - sending those to
+  # 'confirm' would only offer a code that can no longer be redeemed. They can
+  # still get in: the password reset flow confirms the email on the way through.
+  def check_action(user)
     return 'terms' if user.nil?
-    return 'password' if !user.confirmation_pending?(confirmation_name) && !user.no_password?
+    return 'password' unless user.no_password?
 
     'confirm'
   end
 
-  # Users who still have to confirm, and users without a password, get a code sent
-  # automatically. The callers send it themselves, because email codes are sent
-  # inline while SMS codes are only issued inline and delivered from a job.
+  # Users without a password - the ones the confirmation step is for - get a code
+  # sent automatically. The callers send it themselves, because email codes are
+  # sent inline while SMS codes are only issued inline and delivered from a job.
   def auto_send_code?(user, confirmation_name)
-    return false if check_action(user, confirmation_name) != 'confirm'
+    return false if check_action(user) != 'confirm'
 
     # If users already have a code_reset_count > 0,
     # they tried to log in previously and failed. In this case, we don't

--- a/back/app/controllers/web_api/v1/users_controller.rb
+++ b/back/app/controllers/web_api/v1/users_controller.rb
@@ -162,7 +162,7 @@ class WebApi::V1::UsersController < ApplicationController
     end
 
     RequestEmailConfirmationCodeJob.perform_now(@user) if auto_send_code?(@user, :email_confirmation)
-    render_check_action(@user)
+    render json: raw_json({ action: check_action(@user) })
   end
 
   # The phone counterpart of check_email: validates a phone number without
@@ -186,10 +186,10 @@ class WebApi::V1::UsersController < ApplicationController
     @user = User.find_by_phone_number(parsed.e164)
 
     RequestPhoneConfirmationCodeJob.issue_code_and_deliver_later(@user) if auto_send_code?(@user, :phone_confirmation)
-    render_check_action(
-      @user,
-      code_retry_after: @user&.phone_confirmation&.seconds_until_resend_allowed.to_i
-    )
+    render json: raw_json({ 
+      action: check_action(@user), 
+      code_retry_after: @user&.phone_confirmation&.seconds_until_resend_allowed.to_i 
+    }.compact)
   end
 
   def create
@@ -427,22 +427,7 @@ class WebApi::V1::UsersController < ApplicationController
     params.permit(:seat_type, :user_id, :user_email)
   end
 
-  # Shared by check_email and check_phone: given the account that owns the
-  # submitted identifier (nil when there is none), tell the frontend which step
-  # to go to next. code_retry_after is passed for phone only: only SMS codes
-  # have a minimum interval between requests, and the confirmation step counts
-  # it down instead of offering a resend the backend would reject.
-  def render_check_action(user, code_retry_after: nil)
-    render json: raw_json({ action: check_action(user), code_retry_after: code_retry_after }.compact)
-  end
-
-  # An account that has a password authenticates with it, never with a code:
-  # the code steps are the password-less path, and both RequestCodePolicy and
-  # UserConfirmationService reject an account with a password. So a user who has
-  # one always goes to the password step, including the legacy shape where a
-  # password was set before the identifier was ever confirmed - sending those to
-  # 'confirm' would only offer a code that can no longer be redeemed. They can
-  # still get in: the password reset flow confirms the email on the way through.
+  # An account that has a password authenticates with it, never with a code.
   def check_action(user)
     return 'terms' if user.nil?
     return 'password' unless user.no_password?
@@ -450,9 +435,6 @@ class WebApi::V1::UsersController < ApplicationController
     'confirm'
   end
 
-  # Users without a password - the ones the confirmation step is for - get a code
-  # sent automatically. The callers send it themselves, because email codes are
-  # sent inline while SMS codes are only issued inline and delivered from a job.
   def auto_send_code?(user, confirmation_name)
     return false if check_action(user) != 'confirm'
 

--- a/back/app/policies/request_code_policy.rb
+++ b/back/app/policies/request_code_policy.rb
@@ -1,13 +1,6 @@
 # frozen_string_literal: true
 
 class RequestCodePolicy < ApplicationPolicy
-  # Guards a request for an in-place email confirmation code (the
-  # request_code_email action). That action serves the public flow only - email
-  # signup and passwordless login - so `record` is the account that owns the
-  # submitted `email` param and `user` (current_user) must be nil. A signed-in
-  # user re-confirming their own email goes through request_reconfirm_code_email?
-  # instead, which is why an authenticated caller is rejected outright rather
-  # than checked for ownership.
   def request_code_email?
     return false unless user.nil?
     return false unless app_configuration.feature_activated?('password_login')
@@ -19,9 +12,6 @@ class RequestCodePolicy < ApplicationPolicy
     true
   end
 
-  # Guards a re-confirmation code for the signed-in user's own email. Not gated
-  # by password_login: an account created through SSO must still be able to
-  # re-confirm. `record` is current_user (see the controller).
   def request_reconfirm_code_email?
     return false if user.nil?
     return false if user.email.blank?
@@ -75,12 +65,6 @@ class RequestCodePolicy < ApplicationPolicy
 
   private
 
-  # request_code_email? and request_code_phone? serve the password-less
-  # login/signup flow, where the code alone signs the account in (see
-  # UserConfirmationService#validate_no_password!). An account that has a
-  # password authenticates with it, so no code is issued for it here. The
-  # request_reconfirm_code_* actions are unaffected: the caller is already
-  # signed in there.
   def password_set?(record)
     record.password_digest.present?
   end

--- a/back/app/policies/request_code_policy.rb
+++ b/back/app/policies/request_code_policy.rb
@@ -13,6 +13,7 @@ class RequestCodePolicy < ApplicationPolicy
     return false unless app_configuration.feature_activated?('password_login')
     return false if record.nil?
     return false if record.email.blank?
+    return false if password_set?(record)
     return false if code_reset_count(record.email_confirmation) >= max_retries - 1
 
     true
@@ -46,6 +47,7 @@ class RequestCodePolicy < ApplicationPolicy
     return false unless app_configuration.feature_activated?('sms_login')
     return false if record.nil?
     return false if record.phone.blank?
+    return false if password_set?(record)
     return false if code_reset_count(record.phone_confirmation) >= max_retries - 1
 
     true
@@ -72,6 +74,16 @@ class RequestCodePolicy < ApplicationPolicy
   end
 
   private
+
+  # request_code_email? and request_code_phone? serve the password-less
+  # login/signup flow, where the code alone signs the account in (see
+  # UserConfirmationService#validate_no_password!). An account that has a
+  # password authenticates with it, so no code is issued for it here. The
+  # request_reconfirm_code_* actions are unaffected: the caller is already
+  # signed in there.
+  def password_set?(record)
+    record.password_digest.present?
+  end
 
   def code_reset_count(confirmation)
     confirmation&.code_reset_count || 0

--- a/back/app/services/user_confirmation_service.rb
+++ b/back/app/services/user_confirmation_service.rb
@@ -143,11 +143,6 @@ class UserConfirmationService
     raise ValidationError.new(:user, :blank) if user.blank?
   end
 
-  # validate_and_confirm_email! and validate_and_confirm_phone! back the
-  # password-less login/signup flow: a valid code on its own signs the account
-  # in. An account that has a password must go through that password, so a code
-  # can never be traded for a session on it. The authenticated reconfirm_* and
-  # *_new_* paths are unaffected - there the caller already holds a token.
   def validate_no_password!(user)
     raise ValidationError.new(:user, :has_password) if user.password_digest.present?
   end

--- a/back/app/services/user_confirmation_service.rb
+++ b/back/app/services/user_confirmation_service.rb
@@ -39,6 +39,7 @@ class UserConfirmationService
     # feature is enabled for email confirmation
     validate_password_login_enabled!
     validate_user!(user)
+    validate_no_password!(user)
     validate_email!(user.email)
     validate_and_confirm!(user.email_confirmation, code)
     ClaimTokenService.complete(user)
@@ -79,6 +80,7 @@ class UserConfirmationService
     validate_password_login_enabled!
     validate_sms_enabled!
     validate_user!(user)
+    validate_no_password!(user)
     validate_phone!(user.phone)
     validate_and_confirm!(user.phone_confirmation, code)
     ClaimTokenService.complete(user)
@@ -139,6 +141,15 @@ class UserConfirmationService
 
   def validate_user!(user)
     raise ValidationError.new(:user, :blank) if user.blank?
+  end
+
+  # validate_and_confirm_email! and validate_and_confirm_phone! back the
+  # password-less login/signup flow: a valid code on its own signs the account
+  # in. An account that has a password must go through that password, so a code
+  # can never be traded for a session on it. The authenticated reconfirm_* and
+  # *_new_* paths are unaffected - there the caller already holds a token.
+  def validate_no_password!(user)
+    raise ValidationError.new(:user, :has_password) if user.password_digest.present?
   end
 
   def validate_email!(email)

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/etat_lu/etat_lu_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/etat_lu/etat_lu_omniauth.rb
@@ -53,10 +53,6 @@ module CustomIdMethods::EtatLu
       true
     end
 
-    def email_confirmed?(auth)
-      auth&.info&.email.present?
-    end
-
     def filter_auth_to_persist(auth)
       auth_to_persist = auth.deep_dup
       auth_to_persist.tap { |h| h.delete(:credentials) }

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/fake_sso/fake_sso_omniauth.rb
@@ -83,10 +83,6 @@ module CustomIdMethods::FakeSso
       false
     end
 
-    def email_confirmed?(auth)
-      auth.info['email_verified']
-    end
-
     # The fake SSO JWT secret is only needed to verify ID tokens against a real
     # Fake SSO service. It is not set in every environment (e.g. CI), so a
     # missing value must not raise and break the omniauth flow.

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/google/google_omniauth.rb
@@ -68,10 +68,6 @@ module CustomIdMethods::Google
       super + %i[remote_avatar_url]
     end
 
-    def email_confirmed?(auth)
-      auth.extra.raw_info.email_verified
-    end
-
     private
 
     def remote_avatar_url(auth)

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/hoplr/hoplr_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/hoplr/hoplr_omniauth.rb
@@ -118,9 +118,5 @@ module CustomIdMethods::Hoplr
     def locked_custom_fields
       %i[neighbourhood]
     end
-
-    def email_confirmed?(auth)
-      auth.info.email_verified
-    end
   end
 end

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/id_austria/id_austria_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/id_austria/id_austria_omniauth.rb
@@ -57,12 +57,6 @@ module CustomIdMethods::IdAustria
       false
     end
 
-    def email_confirmed?(auth)
-      # Even if the response says the email is NOT verified, we assume that it is if email is present
-      # TODO (Luuc): confirm what this response looks like in production, and see if we can tighten this
-      auth&.info&.email.present?
-    end
-
     def filter_auth_to_persist(auth)
       auth_to_persist = auth.deep_dup
       auth_to_persist.tap { |h| h.delete(:credentials) }

--- a/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/keycloak/keycloak_omniauth.rb
+++ b/back/engines/commercial/custom_id_methods/app/lib/custom_id_methods/keycloak/keycloak_omniauth.rb
@@ -58,12 +58,6 @@ module CustomIdMethods::Keycloak
       config[:provider] == 'rheinbahn'
     end
 
-    def email_confirmed?(auth)
-      # Even if the response says the email is NOT verified, we assume that it is if email is present
-      # TODO (Luuc): confirm what this response looks like in production, and see if we can tighten this
-      auth&.info&.email.present?
-    end
-
     def filter_auth_to_persist(auth)
       auth_to_persist = auth.deep_dup
       auth_to_persist.tap { |h| h.delete(:credentials) }

--- a/back/lib/id_methods/base.rb
+++ b/back/lib/id_methods/base.rb
@@ -92,8 +92,9 @@ module IdMethods
     end
 
     def email_confirmed?(_auth)
-      # TODO: (Luuc): should we set this to be auth.extra.raw_info.email_verified? by default?
-      true
+      email_included = auth&.info&.email.present?
+      email_verified = auth.info['email_verified'] || auth.extra.raw_info.email_verified
+      email_included && email_verified
     end
 
     def enforced_email_domains

--- a/back/lib/id_methods/base.rb
+++ b/back/lib/id_methods/base.rb
@@ -91,8 +91,8 @@ module IdMethods
       true
     end
 
-    def email_confirmed?(_auth)
-      email_included = auth&.info&.email.present?
+    def email_confirmed?(auth)
+      email_included = auth.info.email.present?
       email_verified = auth.info['email_verified'] || auth.extra.raw_info.email_verified
       email_included && email_verified
     end

--- a/back/spec/acceptance/confirmations_spec.rb
+++ b/back/spec/acceptance/confirmations_spec.rb
@@ -136,28 +136,32 @@ resource 'Confirmations' do
         expect(anonymous_exposure.visitor_hash).to be_nil
       end
 
-      example 'allows confirming a user with password that is already confirmed' do
-        user_with_password = create(:unconfirmed_user, password: 'password123')
+      # This endpoint is the password-less login path: a valid code alone returns
+      # an auth token. An account that has a password must sign in with it, so a
+      # code can never be traded for a session on such an account.
+      example 'does not allow confirming a user with a password that is already confirmed' do
+        user_with_password = create(:user, password: 'password123')
+        expect(user_with_password.reload).not_to be_confirmation_required
         RequestEmailConfirmationCodeJob.perform_now user_with_password
         code = user_with_password.reload.email_confirmation.code
-        do_request(confirmation: { email: user_with_password.email, code: })
-        expect(user_with_password.reload).not_to be_confirmation_required
 
-        RequestEmailConfirmationCodeJob.perform_now user_with_password
-        expect(user_with_password.reload).not_to be_confirmation_required
-        code = user_with_password.reload.email_confirmation.code
         do_request(confirmation: { email: user_with_password.email, code: })
-        assert_status 200
+
+        assert_status 422
+        expect(json_parse(response_body)).to include_response_error(:user, 'has_password')
       end
 
-      example 'allows confirming a user with password that requires confirmation' do
+      example 'does not allow confirming a user with a password that requires confirmation' do
         user_with_password = create(:unconfirmed_user, password: 'password123')
         RequestEmailConfirmationCodeJob.perform_now user_with_password
         expect(user_with_password).to be_confirmation_required
 
         code = user_with_password.email_confirmation.code
         do_request(confirmation: { email: user_with_password.email, code: })
-        assert_status 200
+
+        assert_status 422
+        expect(json_parse(response_body)).to include_response_error(:user, 'has_password')
+        expect(user_with_password.reload).to be_confirmation_required
       end
 
       example 'returns an unauthorized status when the caller is authenticated' do
@@ -379,6 +383,18 @@ resource 'Confirmations' do
       example 'does not work when no user has that phone number' do
         do_request(confirmation: { phone: '+14155559999', code: user.phone_confirmation.code })
         assert_status 422
+      end
+
+      # The mirror of confirm_code_email: a valid code alone returns an auth
+      # token, so an account that has a password is not reachable through it.
+      example 'does not work when the user has a password' do
+        user.update_columns(password_digest: 'super_secret')
+
+        do_request(confirmation: { phone: user.phone, code: user.phone_confirmation.code })
+
+        assert_status 422
+        expect(json_parse(response_body)).to include_response_error(:user, 'has_password')
+        expect(user.reload.phone_confirmed_at).to be_nil
       end
 
       example 'does not work when the sms feature is disabled' do

--- a/back/spec/acceptance/request_codes_spec.rb
+++ b/back/spec/acceptance/request_codes_spec.rb
@@ -45,15 +45,17 @@ resource 'Request codes' do
         .with(an_instance_of(EmailCampaigns::Campaigns::EmailConfirmation), user, hash_including(:code)).once
     end
 
-    example 'works if user has password and has email confirmed' do
+    # This endpoint serves the password-less login/signup flow, where the code
+    # alone signs the account in. An account that has a password authenticates
+    # with it instead, so it never gets a code here.
+    example 'does not work if user has password and has email confirmed' do
       user = create(:user, email: 'test@test.com')
       expect(user.password_digest).not_to be_nil
       expect(user.confirmation_required?).to be false
 
       do_request(request_code: { email: user.email })
-      expect(response_status).to eq 200
-      expect(delivery_service).to have_received(:send_now_to_user)
-        .with(an_instance_of(EmailCampaigns::Campaigns::EmailConfirmation), user, hash_including(:code)).once
+      expect(response_status).to eq 401
+      expect(delivery_service).not_to have_received(:send_now_to_user)
     end
 
     # This endpoint serves callers that aren't signed in yet. A signed-in user
@@ -69,15 +71,15 @@ resource 'Request codes' do
 
     # This is an edge case related to legacy users, where a user has a password set
     # but has not confirmed their email yet. This should not be possible anymore.
-    example 'works if user has password and does not have email confirmed' do
+    # Having a password is what closes this endpoint, regardless of that state.
+    example 'does not work if user has password and does not have email confirmed' do
       user = create(:unconfirmed_user, email: 'test@test.com', password_digest: 'super_secret')
       expect(user.password_digest).not_to be_nil
       expect(user.confirmation_required?).to be true
 
       do_request(request_code: { email: user.email })
-      expect(response_status).to eq 200
-      expect(delivery_service).to have_received(:send_now_to_user)
-        .with(an_instance_of(EmailCampaigns::Campaigns::EmailConfirmation), user, hash_including(:code)).once
+      expect(response_status).to eq 401
+      expect(delivery_service).not_to have_received(:send_now_to_user)
     end
 
     example 'It does not work if user reached code_reset_count' do
@@ -364,6 +366,18 @@ resource 'Request codes' do
       expect { do_request(request_code: { phone: '+14155552671' }) }
         .not_to enqueue_job(RequestPhoneConfirmationCodeJob)
       expect(response_status).to eq 401
+    end
+
+    # The mirror of request_code_email: the code alone signs the account in, so
+    # an account that has a password never gets one here.
+    example 'It does not work if the account has a password' do
+      user = create(:unconfirmed_phone_user, phone: '+14155552671')
+      user.update_columns(password_digest: 'super_secret')
+
+      expect { do_request(request_code: { phone: '+14155552671' }) }
+        .not_to enqueue_job(RequestPhoneConfirmationCodeJob)
+      expect(response_status).to eq 401
+      expect(user.reload.phone_confirmation).to be_nil
     end
 
     # This endpoint serves callers that aren't signed in yet. A signed-in user

--- a/back/spec/acceptance/reset_password_spec.rb
+++ b/back/spec/acceptance/reset_password_spec.rb
@@ -63,6 +63,30 @@ resource 'Users' do
         expect(@user.authenticate(password)).to be @user
       end
 
+      # A reset is what someone does when their account may be compromised, so
+      # the sessions opened with the old password must not survive it.
+      example 'Invalidates the tokens issued before the reset' do
+        old_token = AuthToken::AuthToken.new(payload: @user.to_token_payload).token
+        old_expiry_key = @user.token_expiry_key
+
+        do_request
+
+        expect(status).to eq 200
+        expect(@user.reload.token_expiry_key).to be_present
+        expect(@user.token_expiry_key).not_to eq old_expiry_key
+        expect { AuthToken::AuthToken.new(token: old_token).entity_for(User) }
+          .to raise_error ActiveRecord::RecordNotFound
+      end
+
+      example 'Does not invalidate the tokens when the reset fails', document: false do
+        old_expiry_key = @user.token_expiry_key
+
+        do_request(user: { password: 'short', token: token })
+
+        expect(status).to eq 422
+        expect(@user.reload.token_expiry_key).to eq old_expiry_key
+      end
+
       example '[error] Reset password using invalid token' do
         do_request(user: { password: password, token: 'abcabcabc' })
         expect(status).to be 401

--- a/back/spec/acceptance/users_spec.rb
+++ b/back/spec/acceptance/users_spec.rb
@@ -172,6 +172,10 @@ resource 'Users' do
           end
         end
 
+        # A legacy shape: a password was set before the email was ever confirmed.
+        # The confirmation step is the password-less path and no longer accepts an
+        # account with a password, so there is no code to send here. These users
+        # get back in through the password reset flow, which confirms them.
         context 'when a user exists with a password and does not have email confirmed', document: false do
           before do
             @user = create(:unconfirmed_user, email: 'test@test.com', password_digest: 'super_secret')
@@ -180,12 +184,12 @@ resource 'Users' do
 
           let(:email) { 'test@test.com' }
 
-          example_request 'Returns "confirm"' do
+          example_request 'Returns "password" without sending a code' do
             expect(@user.password_digest).not_to be_nil
             expect(@user.confirmation_required?).to be true
             assert_status 200
-            expect(json_response_body[:data][:attributes][:action]).to eq('confirm')
-            expect(RequestEmailConfirmationCodeJob).to have_received(:perform_now).with(@user)
+            expect(json_response_body[:data][:attributes][:action]).to eq('password')
+            expect(RequestEmailConfirmationCodeJob).not_to have_received(:perform_now).with(@user)
           end
         end
 
@@ -229,13 +233,16 @@ resource 'Users' do
           end
         end
 
+        # Same legacy shape as above, SSO-created: the password closes the
+        # confirmation step, so they are sent to the password one. Signing in
+        # through the identity provider still confirms them.
         context 'when user was created by SSO, has a password, email unconfirmed' do
           let(:user) { create(:unconfirmed_user, password_digest: 'super_secret', identities: [create(:facebook_identity)]) }
           let(:email) { user.email }
 
-          example_request 'Returns "confirm"' do
+          example_request 'Returns "password"' do
             assert_status 200
-            expect(json_response_body[:data][:attributes][:action]).to eq('confirm')
+            expect(json_response_body[:data][:attributes][:action]).to eq('password')
           end
         end
 
@@ -408,6 +415,9 @@ resource 'Users' do
           end
         end
 
+        # The phone mirror of the email case: an SMS code would let whoever holds
+        # the (still unconfirmed) number into an account that is protected by a
+        # password, so no code is sent and the caller is sent to the password step.
         context 'when a user exists with a password but has not confirmed their phone', document: false do
           before do
             @user = create(:user, phone: '+14155552671')
@@ -416,11 +426,12 @@ resource 'Users' do
 
           let(:phone) { '+14155552671' }
 
-          example_request 'Returns "confirm"' do
+          example_request 'Returns "password" without sending a code' do
             expect(@user.password_digest).not_to be_nil
+            expect(@user.phone_confirmed_at).to be_nil
             assert_status 200
-            expect(json_response_body[:data][:attributes][:action]).to eq('confirm')
-            expect(RequestPhoneConfirmationCodeJob).to have_received(:issue_code_and_deliver_later).with(@user)
+            expect(json_response_body[:data][:attributes][:action]).to eq('password')
+            expect(RequestPhoneConfirmationCodeJob).not_to have_received(:issue_code_and_deliver_later).with(@user)
           end
         end
 

--- a/back/spec/policies/request_code_policy_spec.rb
+++ b/back/spec/policies/request_code_policy_spec.rb
@@ -12,15 +12,32 @@ RSpec.describe RequestCodePolicy do
       let(:user) { nil }
 
       it 'permits requesting a code for an existing account' do
-        record = create(:user, email: 'test@test.com')
+        record = create(:unconfirmed_user, email: 'test@test.com')
         expect(described_class.new(nil, record)).to permit(:request_code_email)
       end
 
-      it 'permits requesting a code for a full account (password set + confirmed)' do
-        record = create(:user, email: 'test@test.com')
-        expect(record.password_digest).not_to be_nil
+      it 'permits requesting a code for a password-less account that is already confirmed' do
+        record = create(:unconfirmed_user, email: 'test@test.com')
+        record.find_or_create_confirmation(:email_confirmation).confirm!
+        expect(record.password_digest).to be_nil
         expect(record.confirmation_required?).to be false
         expect(described_class.new(nil, record)).to permit(:request_code_email)
+      end
+
+      # This action serves the password-less login/signup flow, where the code
+      # alone signs the account in. An account that has a password authenticates
+      # with it instead, so no code is issued for it here.
+      it 'does not permit requesting a code for an account that has a password' do
+        record = create(:user, email: 'test@test.com')
+        expect(record.password_digest).not_to be_nil
+        expect(described_class.new(nil, record)).not_to permit(:request_code_email)
+      end
+
+      # The legacy shape: a password was set before the email was ever confirmed.
+      it 'does not permit for an account with a password that still has to confirm' do
+        record = create(:unconfirmed_user, email: 'test@test.com', password_digest: 'super_secret')
+        expect(record.confirmation_required?).to be true
+        expect(described_class.new(nil, record)).not_to permit(:request_code_email)
       end
 
       it 'does not permit when no account matches the email' do
@@ -34,7 +51,7 @@ RSpec.describe RequestCodePolicy do
       end
 
       it 'does not permit when password_login is disabled' do
-        record = create(:user, email: 'test@test.com')
+        record = create(:unconfirmed_user, email: 'test@test.com')
         allow(AppConfiguration.instance).to receive(:feature_activated?).with('password_login').and_return(false)
         expect(described_class.new(nil, record)).not_to permit(:request_code_email)
       end
@@ -98,12 +115,21 @@ RSpec.describe RequestCodePolicy do
         expect(described_class.new(nil, record)).to permit(:request_code_phone)
       end
 
+      # The mirror of request_code_email?: the code alone signs the account in,
+      # so an account that has a password is not reachable through it.
+      it 'does not permit requesting a code for an account that has a password' do
+        record = create(:user, :with_confirmed_phone)
+        expect(record.password_digest).not_to be_nil
+        expect(described_class.new(nil, record)).not_to permit(:request_code_phone)
+      end
+
       it 'does not permit when no account matches the phone number' do
         expect(described_class.new(nil, nil)).not_to permit(:request_code_phone)
       end
 
       it 'does not permit when the account has no phone number' do
-        record = create(:user)
+        record = create(:unconfirmed_user)
+        expect(record.phone).to be_nil
         expect(described_class.new(nil, record)).not_to permit(:request_code_phone)
       end
 

--- a/back/spec/services/user_confirmation_service_spec.rb
+++ b/back/spec/services/user_confirmation_service_spec.rb
@@ -139,15 +139,25 @@ RSpec.describe UserConfirmationService do
       end
     end
 
+    # A code alone signs the account in here, so an account that has a password
+    # must go through that password instead.
     context 'when the user has a password' do
       let(:user) { create(:unconfirmed_user, password_digest: 'super_secret') }
 
       it 'returns a user has password error' do
         expect(user.confirmation_required?).to be true
         expect(user.password_digest).not_to be_nil
+
         result = service.validate_and_confirm_email!(user, user.email_confirmation.code)
-        expect(result.success?).to be true
-        expect(user.reload.confirmation_required?).to be false
+
+        expect(result.success?).to be false
+        expect(result.errors.details).to eq(user: [{ error: :has_password }])
+        expect(user.reload.confirmation_required?).to be true
+      end
+
+      it 'does not count the attempt as a code retry' do
+        expect { service.validate_and_confirm_email!(user, 'failcode') }
+          .not_to change { user.email_confirmation.reload.code_retry_count }
       end
     end
 
@@ -236,7 +246,9 @@ RSpec.describe UserConfirmationService do
   end
 
   describe '#validate_and_confirm_phone!' do
-    let(:user) { create(:user, phone: '+14155552671') }
+    # Password-less: this is the login path, and an account with a password is
+    # not allowed through it (see the 'when the user has a password' context).
+    let(:user) { create(:user, phone: '+14155552671', password: nil) }
 
     # The code request sends the OTP synchronously, so the provider is invoked.
     include_context 'with stubbed SMS provider'
@@ -293,6 +305,25 @@ RSpec.describe UserConfirmationService do
 
         expect(result.success?).to be false
         expect(result.errors.details).to eq(user: [{ error: :no_phone }])
+      end
+    end
+
+    # The mirror of the email case: a code alone signs the account in here, so
+    # an account that has a password must go through that password instead.
+    context 'when the user has a password' do
+      before { user.update_columns(password_digest: 'super_secret') }
+
+      it 'returns a user has password error' do
+        result = service.validate_and_confirm_phone!(user, confirmation.code)
+
+        expect(result.success?).to be false
+        expect(result.errors.details).to eq(user: [{ error: :has_password }])
+        expect(user.reload.phone_confirmed_at).to be_nil
+      end
+
+      it 'does not count the attempt as a code retry' do
+        expect { service.validate_and_confirm_phone!(user, 'failcode') }
+          .not_to change { user.phone_confirmation.reload.code_retry_count }
       end
     end
   end


### PR DESCRIPTION
# Changelog
## Technical
- Omniauth flow: by default, always check omniauth response email_verified attribute
- Block OTP with email/phone if account has password set (same behavior as before)
- Invalidate JWT on reset password
