### PR TITLE
Log MCP payload fields on the internal gateway channel

### DIFF
--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/internal_mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/internal_mcp_controller.rb
@@ -21,7 +21,14 @@ module McpServer
     before_action :set_sentry_context
 
     def create
-      Sentry.set_tags(mcp_tool: params.dig(:params, :name)) if params[:method] == 'tools/call'
+      # Best-effort log-line capture; parse errors must not block the transport.
+      begin
+        @mcp_method = params[:method]
+        @mcp_tool = @mcp_method == 'tools/call' ? params.dig(:params, :name) : nil
+      rescue StandardError
+        @mcp_method = @mcp_tool = nil
+      end
+      Sentry.set_tags(mcp_tool: @mcp_tool) if @mcp_tool
 
       server = MCP::Server.new(
         name: 'go_vocal_internal',
@@ -73,7 +80,21 @@ module McpServer
       tenant = host.presence && Tenant.find_by(host: host)
       return render(json: { error: "Unknown tenant host: #{host}" }, status: :not_found) unless tenant
 
+      # Stashed for append_info_to_payload, which runs after the schema switches back.
+      @tenant = tenant
       tenant.switch(&)
+    end
+
+    # Mirrors McpController's field names so CloudWatch queries cover both channels.
+    # Runs after switch_tenant unwinds, so ivars only — no tenant-schema lookups.
+    def append_info_to_payload(payload)
+      super
+      payload[:tenant_id]    = @tenant&.id
+      payload[:tenant_host]  = @tenant&.host
+      payload[:user_id]      = @acting_user&.id
+      payload[:acting_staff] = request.headers['X-Acting-Staff'].presence
+      payload[:mcp_method]   = @mcp_method
+      payload[:mcp_tool]     = @mcp_tool
     end
 
     # Mirrors McpPolicy#create? (feature flag + active super admin), with explicit
@@ -116,7 +137,7 @@ module McpServer
     # acting user, with the real staff identity in the payload (the acting user
     # may be the shared internal account).
     def log_tool_call_activity
-      return unless params[:method] == 'tools/call'
+      return unless @mcp_method == 'tools/call'
 
       LogActivityJob.perform_later(
         acting_user,
@@ -124,7 +145,7 @@ module McpServer
         acting_user,
         Time.zone.now.to_i,
         payload: {
-          tool: params.dig(:params, :name),
+          tool: @mcp_tool,
           acting_staff: request.headers['X-Acting-Staff']
         }
       )

--- a/back/engines/commercial/mcp_server/spec/requests/internal_mcp_endpoint_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/requests/internal_mcp_endpoint_spec.rb
@@ -138,6 +138,48 @@ describe McpServer::InternalMcpController do
     end
   end
 
+  describe 'semantic-logger payload' do
+    def payload_for(body, extra_headers = {})
+      payloads = []
+      subscriber = ->(_name, _started, _finished, _id, payload) { payloads << payload }
+      ActiveSupport::Notifications.subscribed(subscriber, 'process_action.action_controller') do
+        post '/admin_api/mcp', params: body, headers: headers.merge(extra_headers)
+      end
+      payloads.last
+    end
+
+    it 'includes tenant, acting user and the JSON-RPC method' do
+      payload = payload_for(rpc_body('tools/list'))
+
+      expect(response).to have_http_status(:ok)
+      expect(payload[:tenant_host]).to eq(tenant_host)
+      expect(payload[:tenant_id]).to eq(Tenant.find_by(host: tenant_host).id)
+      expect(payload[:user_id]).to eq(internal_account.id)
+      expect(payload[:acting_staff]).to be_nil
+      expect(payload[:mcp_method]).to eq('tools/list')
+      expect(payload[:mcp_tool]).to be_nil
+    end
+
+    it 'includes the tool name and staff identity for a tools/call request' do
+      payload = payload_for(
+        rpc_body('tools/call', { name: 'list_areas', arguments: {} }),
+        'X-Acting-Staff' => 'someone@govocal.com'
+      )
+
+      expect(payload[:mcp_method]).to eq('tools/call')
+      expect(payload[:mcp_tool]).to eq('list_areas')
+      expect(payload[:acting_staff]).to eq('someone@govocal.com')
+    end
+
+    it 'omits tenant fields when the tenant host is unknown' do
+      payload = payload_for(rpc_body('tools/list'), 'X-Tenant-Host' => 'unknown.example.net')
+
+      expect(response).to have_http_status(:not_found)
+      expect(payload[:tenant_id]).to be_nil
+      expect(payload[:tenant_host]).to be_nil
+    end
+  end
+
   describe 'protocol handshake' do
     it 'handles initialize' do
       initialize_params = {


### PR DESCRIPTION
Log MCP payload fields on the internal gateway channel

Adds `append_info_to_payload` to `InternalMcpController`, mirroring `McpController`'s field names (`tenant_id`, `tenant_host`, `user_id`, `mcp_method`, `mcp_tool`) plus `acting_staff`, so `cl2-admin` MCP traffic shows up in the same CloudWatch queries as the public channel (distinguishable via `payload.controller`).

Note: the payload hook runs after the `switch_tenant` around-action unwinds, so it reads ivars captured during the action instead of `Tenant.safe_current` / `acting_user`.

- No behavior change to request handling or activity logging.
- Specs: semantic-logger payload coverage mirroring the public endpoint spec.

Note: Written with Claude Code.