### PR TITLE
[TAN-8575] Restrict OAuth redirect_uri to http(s) at registration, validation and navigation

### DIFF
--- a/back/app/controllers/oauth/registrations_controller.rb
+++ b/back/app/controllers/oauth/registrations_controller.rb
@@ -37,8 +37,9 @@ module Oauth
           redirect_uris: application.redirect_uri.split
         }, status: :created
       else
+        error = application.errors.include?(:redirect_uri) ? 'invalid_redirect_uri' : 'invalid_client_metadata'
         render json: {
-          error: 'invalid_client_metadata',
+          error: error,
           error_description: application.errors.full_messages.join(', ')
         }, status: :bad_request
       end

--- a/back/app/controllers/oauth/registrations_controller.rb
+++ b/back/app/controllers/oauth/registrations_controller.rb
@@ -57,6 +57,7 @@ module Oauth
       uri = URI.parse(value)
       ALLOWED_REDIRECT_URI_SCHEMES.include?(uri.scheme.to_s.downcase) &&
         uri.host.present? &&
+        # RFC 6749 §3.1.2 (redirection endpoint should not hold fragment)
         uri.fragment.nil?
     rescue URI::InvalidURIError
       false

--- a/back/app/controllers/oauth/registrations_controller.rb
+++ b/back/app/controllers/oauth/registrations_controller.rb
@@ -9,12 +9,23 @@ module Oauth
 
     wrap_parameters :oauth_application
 
+    ALLOWED_REDIRECT_URI_SCHEMES = %w[http https].freeze
+
     # Rate limiting is handled by Rack::Attack (see config/initializers/rack_attack.rb).
 
     def create
+      redirect_uris = Array(oauth_application_params[:redirect_uris])
+
+      if redirect_uris.empty? || redirect_uris.any? { |uri| !allowed_redirect_uri?(uri) }
+        return render json: {
+          error: 'invalid_redirect_uri',
+          error_description: 'redirect_uris must be absolute http(s) URIs'
+        }, status: :bad_request
+      end
+
       application = Doorkeeper::Application.new(
         name: oauth_application_params[:client_name],
-        redirect_uri: Array(oauth_application_params[:redirect_uris]).join("\n"),
+        redirect_uri: redirect_uris.join("\n"),
         confidential: false
       )
 
@@ -37,6 +48,17 @@ module Oauth
 
     def oauth_application_params
       params.require(:oauth_application).permit(:client_name, redirect_uris: [])
+    end
+
+    def allowed_redirect_uri?(value)
+      return false unless value.is_a?(String)
+
+      uri = URI.parse(value)
+      ALLOWED_REDIRECT_URI_SCHEMES.include?(uri.scheme.to_s.downcase) &&
+        uri.host.present? &&
+        uri.fragment.nil?
+    rescue URI::InvalidURIError
+      false
     end
   end
 end

--- a/back/config/initializers/doorkeeper.rb
+++ b/back/config/initializers/doorkeeper.rb
@@ -289,7 +289,7 @@ Doorkeeper.configure do
   # callback during Dynamic Client Registration. Without this the
   # default (force SSL outside development) rejects http://localhost:<port>/...
   force_ssl_in_redirect_uri do |uri|
-    !Rails.env.development? && %w[localhost 127.0.0.1 ::1].exclude?(uri.host)
+    !Rails.env.development? && %w[localhost 127.0.0.1 ::1].exclude?(uri.hostname)
   end
 
   # Specify what redirect URI's you want to block during Application creation.
@@ -297,8 +297,8 @@ Doorkeeper.configure do
   #
   # You can use this option in order to forbid URI's with 'javascript' scheme
   # for example.
-  #
-  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  forbid_redirect_uri { |uri| %w[http https].exclude?(uri.scheme.to_s.downcase) }
 
   # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
   # to use URI-less OAuth grant flows like Client Credentials or Resource Owner

--- a/back/config/initializers/doorkeeper.rb
+++ b/back/config/initializers/doorkeeper.rb
@@ -289,7 +289,7 @@ Doorkeeper.configure do
   # callback during Dynamic Client Registration. Without this the
   # default (force SSL outside development) rejects http://localhost:<port>/...
   force_ssl_in_redirect_uri do |uri|
-    !Rails.env.development? && %w[localhost 127.0.0.1 ::1].exclude?(uri.hostname)
+    !Rails.env.development? && %w[localhost 127.0.0.1 ::1].exclude?(uri.hostname&.downcase)
   end
 
   # Specify what redirect URI's you want to block during Application creation.
@@ -297,7 +297,9 @@ Doorkeeper.configure do
   #
   # You can use this option in order to forbid URI's with 'javascript' scheme
   # for example.
-
+  #
+  # Scheme allowlist only — a browser must never be able to execute a stored
+  # redirect_uri. Whether http is acceptable is force_ssl_in_redirect_uri's job.
   forbid_redirect_uri { |uri| %w[http https].exclude?(uri.scheme.to_s.downcase) }
 
   # Allows to set blank redirect URIs for Applications in case Doorkeeper configured

--- a/back/config/initializers/doorkeeper.rb
+++ b/back/config/initializers/doorkeeper.rb
@@ -293,10 +293,6 @@ Doorkeeper.configure do
   end
 
   # Specify what redirect URI's you want to block during Application creation.
-  # Any redirect URI is allowed by default.
-  #
-  # You can use this option in order to forbid URI's with 'javascript' scheme
-  # for example.
   #
   # Scheme allowlist only — a browser must never be able to execute a stored
   # redirect_uri. Whether http is acceptable is force_ssl_in_redirect_uri's job.

--- a/back/spec/config/doorkeeper_redirect_uri_spec.rb
+++ b/back/spec/config/doorkeeper_redirect_uri_spec.rb
@@ -23,6 +23,7 @@ describe Doorkeeper::Application do
       'data scheme'               | 'data:text/html,<script>alert(1)</script>'  | false
       'vbscript scheme'           | 'vbscript:msgbox(1)'                        | false
       'https plus hostile URI'    | "https://ok.example.com/cb\njavascript://x%0Aalert(1)" | false
+      'loopback host with upcase' | 'http://LOCALHOST:33418/cb'                 | true
     end
 
     with_them do

--- a/back/spec/config/doorkeeper_redirect_uri_spec.rb
+++ b/back/spec/config/doorkeeper_redirect_uri_spec.rb
@@ -23,7 +23,7 @@ describe Doorkeeper::Application do
       'data scheme'               | 'data:text/html,<script>alert(1)</script>'  | false
       'vbscript scheme'           | 'vbscript:msgbox(1)'                        | false
       'https plus hostile URI'    | "https://ok.example.com/cb\njavascript://x%0Aalert(1)" | false
-      'loopback host with upcase' | 'http://LOCALHOST:33418/cb'                 | true
+      'loopback host with upcase' | 'http://LOCALHOST:33418/cb' | true
     end
 
     with_them do

--- a/back/spec/config/doorkeeper_redirect_uri_spec.rb
+++ b/back/spec/config/doorkeeper_redirect_uri_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# Defence in depth behind the allowlist in Oauth::RegistrationsController: whatever
+# creates a Doorkeeper::Application, the redirect_uri rules configured in
+# config/initializers/doorkeeper.rb (forbid_redirect_uri + force_ssl_in_redirect_uri)
+# must refuse any scheme a browser would execute.
+describe Doorkeeper::Application do
+  describe 'redirect_uri validation' do
+    using RSpec::Parameterized::TableSyntax
+
+    where(:case_name, :redirect_uri, :valid) do
+      'https URI'                 | 'https://client.example.com/cb'             | true
+      # RFC 8252 loopback callbacks, which is what MCP clients register.
+      # force_ssl_in_redirect_uri exempts them, so http must stay valid here.
+      'loopback host'             | 'http://localhost:33418/cb'                 | true
+      'loopback IPv4'             | 'http://127.0.0.1:33418/cb'                 | true
+      'loopback IPv6'             | 'http://[::1]:33418/cb'                     | true
+      'non-loopback http URI'     | 'http://client.example.com/cb'              | false
+      'javascript scheme'         | 'javascript:alert(document.cookie)'         | false
+      'javascript with authority' | 'javascript://x%0Aalert(document.cookie)'   | false
+      'data scheme'               | 'data:text/html,<script>alert(1)</script>'  | false
+      'vbscript scheme'           | 'vbscript:msgbox(1)'                        | false
+      'https plus hostile URI'    | "https://ok.example.com/cb\njavascript://x%0Aalert(1)" | false
+    end
+
+    with_them do
+      it 'accepts only http(s), and http only on loopback' do
+        application = described_class.new(name: 'Test MCP Client', redirect_uri: redirect_uri, confidential: false)
+
+        expect(application.valid?).to eq valid
+      end
+    end
+  end
+end

--- a/back/spec/requests/oauth_registrations_spec.rb
+++ b/back/spec/requests/oauth_registrations_spec.rb
@@ -42,6 +42,16 @@ describe Oauth::RegistrationsController do
       expect(response.parsed_body['redirect_uris']).to eq ['https://a.example.com/cb', 'http://127.0.0.1:5000/cb']
     end
 
+    # The other side of the error-code split: a failure that has nothing to do
+    # with redirect_uri keeps the generic RFC 7591 code.
+    it 'reports a non-redirect_uri problem with the generic error code' do
+      expect { register(['https://ok.example.com/cb'], client_name: nil) }
+        .not_to change(Doorkeeper::Application, :count)
+
+      expect(response).to have_http_status(:bad_request)
+      expect(response.parsed_body['error']).to eq 'invalid_client_metadata'
+    end
+
     describe 'redirect_uri scheme allowlist' do
       using RSpec::Parameterized::TableSyntax
 
@@ -62,6 +72,9 @@ describe Oauth::RegistrationsController do
         'URI with a fragment'         | ['https://ok.example.com/cb#fragment']
         'no redirect_uris'            | []
         'non-string entry'            | [{ 'uri' => 'https://ok.example.com/cb' }]
+        # Passes the controller allowlist (http is a valid scheme) and is refused one layer down
+        # by force_ssl_in_redirect_uri. Same code either way.
+        'plaintext non-loopback URI' | ['http://client.example.com/cb']
       end
 
       with_them do

--- a/back/spec/requests/oauth_registrations_spec.rb
+++ b/back/spec/requests/oauth_registrations_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+# RFC 7591 Dynamic Client Registration. The endpoint is public and
+# unauthenticated, so its redirect_uri scheme allowlist is what stops anyone from
+# registering a client whose redirect_uri runs script in the platform origin once
+# the SPA consent screen navigates to it (on approve as well as on deny).
+describe Oauth::RegistrationsController do
+  let(:headers) { { 'CONTENT_TYPE' => 'application/json' } }
+
+  def register(redirect_uris, client_name: 'Test MCP Client')
+    post '/oauth/registrations',
+      params: { client_name: client_name, redirect_uris: redirect_uris }.to_json,
+      headers: headers
+  end
+
+  describe 'POST /oauth/registrations' do
+    it 'registers a client with an https redirect_uri' do
+      expect { register(['https://client.example.com/oauth/callback']) }
+        .to change(Doorkeeper::Application, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['client_id']).to be_present
+      expect(response.parsed_body['redirect_uris']).to eq ['https://client.example.com/oauth/callback']
+    end
+
+    # RFC 8252: native apps get their authorization code on a loopback http
+    # callback, and those apps are what this endpoint exists for. The guard is on
+    # the scheme, not on https, precisely so loopback registration keeps working.
+    it 'registers a client with a loopback http redirect_uri' do
+      expect { register(['http://localhost:33418/callback']) }
+        .to change(Doorkeeper::Application, :count).by(1)
+
+      expect(response).to have_http_status(:created)
+    end
+
+    it 'registers a client with several valid redirect_uris' do
+      register(['https://a.example.com/cb', 'http://127.0.0.1:5000/cb'])
+
+      expect(response).to have_http_status(:created)
+      expect(response.parsed_body['redirect_uris']).to eq ['https://a.example.com/cb', 'http://127.0.0.1:5000/cb']
+    end
+
+    describe 'redirect_uri scheme allowlist' do
+      using RSpec::Parameterized::TableSyntax
+
+      where(:case_name, :redirect_uris) do
+        'javascript scheme'           | ['javascript:alert(document.cookie)']
+        # Parses as a URI with a host, so it survives Doorkeeper's default validators.
+        'javascript with authority'   | ['javascript://x%0Aalert(document.cookie)']
+        'javascript in mixed case'    | ['JavaScript:alert(1)']
+        'data scheme'                 | ['data:text/html,<script>alert(1)</script>']
+        'vbscript scheme'             | ['vbscript:msgbox(1)']
+        # Doorkeeper stores redirect URIs newline-separated and splits them on
+        # whitespace, so a URI smuggled into one entry would become a second
+        # registered redirect_uri. A prefix check on the entry would miss it.
+        'newline-smuggled URI'        | ["https://ok.example.com/cb\njavascript://x%0Aalert(1)"]
+        'valid URI plus hostile one'  | ['https://ok.example.com/cb', 'javascript:alert(1)']
+        'relative URI'                | ['/oauth/callback']
+        'scheme-relative URI'         | ['//evil.example.com/cb']
+        'URI with a fragment'         | ['https://ok.example.com/cb#fragment']
+        'no redirect_uris'            | []
+        'non-string entry'            | [{ 'uri' => 'https://ok.example.com/cb' }]
+      end
+
+      with_them do
+        it 'is rejected with invalid_redirect_uri and registers nothing' do
+          expect { register(redirect_uris) }.not_to change(Doorkeeper::Application, :count)
+
+          expect(response).to have_http_status(:bad_request)
+          expect(response.parsed_body['error']).to eq 'invalid_redirect_uri'
+        end
+      end
+    end
+  end
+end

--- a/front/app/containers/OAuthAuthorize/index.test.tsx
+++ b/front/app/containers/OAuthAuthorize/index.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+
+import type {
+  IOAuthAuthorizationRedirect,
+  OAuthAuthorizationParams,
+} from 'api/oauth_authorization/types';
+
+import { screen, render, userEvent } from 'utils/testUtils/rtl';
+
+const SAFE_REDIRECT_URI = 'https://client.example.com/oauth/callback';
+// Parses as a URI with a host, so it survives naive validation; a browser runs
+// `alert(...)` because `//x` comments out the rest of the line.
+const HOSTILE_REDIRECT_URI = 'javascript://x%0Aalert(document.cookie)';
+
+// Mutable per example. jest.mock factories may only close over names prefixed
+// with `mock`, so these carry the scenario into the mocked hooks below.
+let mockConsentRedirectUri = SAFE_REDIRECT_URI;
+let mockApproveRedirectUri = SAFE_REDIRECT_URI;
+
+jest.mock('api/me/useAuthUser', () =>
+  jest.fn(() => ({ data: { id: 'user-1' }, isLoading: false }))
+);
+
+jest.mock('api/oauth_authorization/useOAuthAuthorization', () =>
+  jest.fn(() => ({
+    data: {
+      data: {
+        type: 'oauth_authorization',
+        attributes: {
+          client_id: 'client-1',
+          client_name: 'Test MCP Client',
+          scopes: ['mcp:access'],
+          redirect_uri: mockConsentRedirectUri,
+          params: { client_id: 'client-1', state: 'state-123' },
+        },
+      },
+    },
+    isLoading: false,
+    isError: false,
+  }))
+);
+
+// Approving hits the API and navigates to whatever redirect_uri comes back —
+// which Doorkeeper builds from the same client-registered URI, so it is no more
+// trustworthy than the one on the consent screen.
+jest.mock('api/oauth_authorization/useCreateOAuthAuthorization', () =>
+  jest.fn(() => ({
+    mutate: (
+      _params: OAuthAuthorizationParams,
+      options?: { onSuccess?: (res: IOAuthAuthorizationRedirect) => void }
+    ) => {
+      options?.onSuccess?.({
+        data: {
+          type: 'oauth_authorization',
+          attributes: { redirect_uri: mockApproveRedirectUri },
+        },
+      });
+    },
+    isPending: false,
+  }))
+);
+
+jest.mock('utils/router', () => ({
+  ...jest.requireActual('utils/router'),
+  useSearch: () => ({ client_id: 'client-1', state: 'state-123' }),
+}));
+
+// Only the browser call is stubbed — the scheme guard under test stays real.
+const mockNavigateToUrl = jest.fn();
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  navigateToUrl: (url: string) => mockNavigateToUrl(url),
+}));
+
+import OAuthAuthorize from './index';
+
+describe('OAuthAuthorize', () => {
+  beforeEach(() => {
+    mockConsentRedirectUri = SAFE_REDIRECT_URI;
+    mockApproveRedirectUri = SAFE_REDIRECT_URI;
+  });
+
+  it('renders the consent screen for an http(s) redirect_uri', () => {
+    render(<OAuthAuthorize />);
+
+    expect(
+      screen.getByRole('button', { name: 'Authorize' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+  });
+
+  it('redirects the client back on deny', async () => {
+    const user = userEvent.setup();
+    render(<OAuthAuthorize />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockNavigateToUrl).toHaveBeenCalledWith(
+      `${SAFE_REDIRECT_URI}?error=access_denied&state=state-123`
+    );
+  });
+
+  it('redirects the client back on approve', async () => {
+    const user = userEvent.setup();
+    render(<OAuthAuthorize />);
+
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(mockNavigateToUrl).toHaveBeenCalledWith(SAFE_REDIRECT_URI);
+  });
+
+  // The reported attack: a client registered with a javascript: redirect_uri,
+  // executing in the platform origin as soon as the victim clicks deny.
+  it('refuses the consent screen entirely for a non-http(s) redirect_uri', () => {
+    mockConsentRedirectUri = HOSTILE_REDIRECT_URI;
+
+    render(<OAuthAuthorize />);
+
+    expect(
+      screen.getByText('This authorization request is invalid')
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Authorize' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Cancel' })
+    ).not.toBeInTheDocument();
+    expect(mockNavigateToUrl).not.toHaveBeenCalled();
+  });
+
+  it('navigates nowhere when approving returns a non-http(s) redirect_uri', async () => {
+    mockApproveRedirectUri = HOSTILE_REDIRECT_URI;
+    const user = userEvent.setup();
+    render(<OAuthAuthorize />);
+
+    await user.click(screen.getByRole('button', { name: 'Authorize' }));
+
+    expect(mockNavigateToUrl).not.toHaveBeenCalled();
+    expect(
+      await screen.findByText('This authorization request is invalid')
+    ).toBeInTheDocument();
+  });
+});

--- a/front/app/containers/OAuthAuthorize/index.tsx
+++ b/front/app/containers/OAuthAuthorize/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import {
   Box,
@@ -24,6 +24,7 @@ import Card from './components/Card';
 import IconBadge from './components/IconBadge';
 import InfoCard from './components/InfoCard';
 import messages from './messages';
+import { isSafeRedirectUrl, navigateToUrl } from './utils';
 
 const scopeContent = (scope: string) => {
   switch (scope) {
@@ -68,6 +69,25 @@ const OAuthAuthorize = () => {
   const { mutate: authorize, isPending: authorizing } =
     useCreateOAuthAuthorization();
 
+  const [redirectBlocked, setRedirectBlocked] = useState(false);
+
+  // A client is registered with a redirect_uri of its choosing, so the URI we
+  // are asked to send the user back to is attacker-controlled. Refuse the whole
+  // consent screen when the scheme is not http(s), rather than only guarding the navigation.
+  const unsafeRedirect =
+    !authorization ||
+    !isSafeRedirectUrl(authorization.data.attributes.redirect_uri);
+
+  // Single choke point for leaving the platform: window.location never receives
+  // a URL whose scheme we have not validated ourselves.
+  const navigateToClient = (url: string) => {
+    if (!isSafeRedirectUrl(url)) {
+      setRedirectBlocked(true);
+      return;
+    }
+    navigateToUrl(url);
+  };
+
   // Not logged in: open the normal sign-in flow in place. Once authenticated,
   // authUser updates and the consent details load. The OAuth params live in the
   // URL, which the in-page auth modal does not change, so they survive sign-in.
@@ -101,7 +121,7 @@ const OAuthAuthorize = () => {
         </Box>
       </Card>
     );
-  } else if (isError || !authorization) {
+  } else if (isError || !authorization || unsafeRedirect || redirectBlocked) {
     content = (
       <Card>
         <Box p="40px">
@@ -126,20 +146,22 @@ const OAuthAuthorize = () => {
     const handleAuthorize = () => {
       authorize(echoedParams, {
         onSuccess: (res) => {
-          window.location.assign(res.data.attributes.redirect_uri);
+          navigateToClient(res.data.attributes.redirect_uri);
         },
       });
     };
 
     // Denial persists nothing server-side: redirect the client back with
-    // error=access_denied, using the redirect_uri the server already validated.
+    // error=access_denied. The server validated this redirect_uri as one
+    // registered for the client; the scheme check above is what makes it safe
+    // to navigate to.
     const handleDeny = () => {
       const url = new URL(redirect_uri);
       url.searchParams.set('error', 'access_denied');
       if (params.state) {
         url.searchParams.set('state', params.state);
       }
-      window.location.assign(url.toString());
+      navigateToClient(url.toString());
     };
 
     content = (

--- a/front/app/containers/OAuthAuthorize/index.tsx
+++ b/front/app/containers/OAuthAuthorize/index.tsx
@@ -121,7 +121,7 @@ const OAuthAuthorize = () => {
         </Box>
       </Card>
     );
-  } else if (isError || !authorization || unsafeRedirect || redirectBlocked) {
+  } else if (isError || unsafeRedirect || redirectBlocked) {
     content = (
       <Card>
         <Box p="40px">

--- a/front/app/containers/OAuthAuthorize/utils.test.ts
+++ b/front/app/containers/OAuthAuthorize/utils.test.ts
@@ -1,0 +1,23 @@
+import { isSafeRedirectUrl } from './utils';
+
+describe('isSafeRedirectUrl', () => {
+  it('accepts https and loopback http callbacks', () => {
+    expect(isSafeRedirectUrl('https://client.example.com/cb')).toBe(true);
+    expect(isSafeRedirectUrl('http://localhost:33418/cb')).toBe(true);
+    expect(isSafeRedirectUrl('http://127.0.0.1:33418/cb')).toBe(true);
+  });
+
+  it('rejects script-bearing schemes', () => {
+    expect(isSafeRedirectUrl('javascript:alert(document.cookie)')).toBe(false);
+    // Parses as a URL with a host, so it survives naive validation.
+    expect(isSafeRedirectUrl('javascript://x%0Aalert(1)')).toBe(false);
+    expect(isSafeRedirectUrl('data:text/html,<script>1</script>')).toBe(false);
+    expect(isSafeRedirectUrl('vbscript:msgbox(1)')).toBe(false);
+    expect(isSafeRedirectUrl('JavaScript:alert(1)')).toBe(false);
+  });
+
+  it('rejects anything that is not an absolute URL', () => {
+    expect(isSafeRedirectUrl('/relative')).toBe(false);
+    expect(isSafeRedirectUrl('')).toBe(false);
+  });
+});

--- a/front/app/containers/OAuthAuthorize/utils.ts
+++ b/front/app/containers/OAuthAuthorize/utils.ts
@@ -1,0 +1,19 @@
+// A redirect_uri can only ever be an http(s) URL. Any other scheme —
+// javascript:, data:, vbscript: — executes in the platform origin as soon as it
+// is handed to window.location, so it is refused before any navigation happens.
+const SAFE_PROTOCOLS = ['http:', 'https:'];
+
+export const isSafeRedirectUrl = (value: string) => {
+  try {
+    return SAFE_PROTOCOLS.includes(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+};
+
+// The navigation itself, wrapped so the consent screen's behaviour can be
+// asserted: jsdom exposes window.location as a read-only property, so the call
+// cannot be spied on where it happens.
+export const navigateToUrl = (url: string) => {
+  window.location.assign(url);
+};


### PR DESCRIPTION
This PR has been written with Claude code.

🎩 What? Why?
Our Dynamic Client Registration endpoint (POST /oauth/registrations) lets any client register itself with a redirect_uri of its own choosing, and the consent screen later navigates the browser to that URI. Nothing constrained the scheme, so a client could register javascript:..., data:... or vbscript:... and have it executed in the platform origin the moment a user approved (or denied) the consent screen — the stored URI was handed straight to window.location.assign.

This PR closes that with three independent layers, so no single code path is the only thing standing between an attacker-supplied string and the browser:

**1. Registration endpoint (Oauth::RegistrationsController)**
redirect_uris are now validated before the application is built: the list must be non-empty and every entry must be an absolute http(s) URI with a host and no fragment (RFC 6749 §3.1.2). Rejections return invalid_redirect_uri / 400 and persist nothing. The failure path of application.save now also distinguishes invalid_redirect_uri from the generic invalid_client_metadata, so clients get the error code the spec expects.

**2. Doorkeeper configuration (config/initializers/doorkeeper.rb)**
forbid_redirect_uri is enabled with a scheme allowlist (http, https), so the rule holds for any code path that creates a Doorkeeper::Application, not just our controller. force_ssl_in_redirect_uri keeps its existing job — deciding whether plain http is acceptable — and now reads uri.hostname instead of uri.host, which fixes two things: IPv6 loopback (http://[::1]:33418/cb, where host includes the brackets) and uppercase hostnames. Loopback http callbacks stay valid because that is what MCP clients register (RFC 8252).

**3. Consent screen (front/app/containers/OAuthAuthorize)**
The scheme is re-checked in the browser before any navigation. If the redirect_uri returned by the API is not http(s), the consent screen refuses to render at all and shows the error card, rather than only blocking the final navigation. Both exits — approve and deny — go through a single navigateToClient choke point, so window.location never receives a URL whose scheme we have not validated ourselves. The navigation itself is extracted to utils.ts (navigateToUrl) purely so the behaviour is assertable: jsdom exposes window.location as read-only and it cannot be spied on in place.

✅ Tasks

 Add tests:
- back/spec/config/doorkeeper_redirect_uri_spec.rb — table-driven validation of the Doorkeeper rules: https accepted, http accepted only on loopback (hostname, IPv4, IPv6, uppercase), and javascript: / data: / vbscript: refused, including the javascript://x%0A… authority-shaped variant and a multi-line redirect_uri where a valid https entry is followed by a hostile one.
- back/spec/requests/oauth_registrations_spec.rb — registration succeeds for https, loopback http and multiple URIs; hostile schemes are rejected with invalid_redirect_uri and create no application; non-redirect_uri failures still report invalid_client_metadata.
- front/app/containers/OAuthAuthorize/utils.test.ts and index.test.tsx — the helper accepts https/loopback http and rejects script-bearing schemes and non-absolute URLs; the consent screen renders and redirects normally for http(s), refuses to render for a hostile redirect_uri, and navigates nowhere if a hostile URI comes back from the approve call.


# Changelog
## Technical
- OAuth client registration and the consent screen now only accept `http(s)` redirect URIs, blocking script-bearing schemes (`javascript:`, `data:`, `vbscript:`) from being stored or navigated to.
- OAuth redirect URI validation now handles IPv6 loopback and uppercase hostnames correctly.