### PR TITLE
 Fix survey choice questions being read twice by screen readers

### DIFF
--- a/front/app/component-library/components/Checkbox/index.tsx
+++ b/front/app/component-library/components/Checkbox/index.tsx
@@ -102,6 +102,7 @@ type Props = {
   id?: string;
   dataTestId?: string;
   tabIndex?: number;
+  ariaLabel?: string;
 } & CheckboxProps &
   BoxPaddingProps &
   BoxMarginProps;
@@ -127,6 +128,7 @@ const Checkbox = ({
   setRef,
   ariaInvalid,
   ariaDescribedBy,
+  ariaLabel,
   ...boxProps
 }: Props) => {
   const handleOnCheckboxClick = (event: React.MouseEvent) => {
@@ -153,6 +155,7 @@ const Checkbox = ({
         ref={setRef}
         aria-invalid={ariaInvalid}
         aria-describedby={ariaDescribedBy}
+        aria-label={ariaLabel}
       />
       <StyledCheckbox
         data-testid={dataTestId || testEnv('check-mark-background')}

--- a/front/app/component-library/components/CheckboxWithLabel/index.tsx
+++ b/front/app/component-library/components/CheckboxWithLabel/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import useInstanceId from '../../hooks/useInstanceId';
 import testEnv from '../../utils/testUtils/testEnv';
 import Box, { BoxMarginProps, BoxPaddingProps } from '../Box';
 import Checkbox, { CheckboxProps } from '../Checkbox';
@@ -10,6 +11,7 @@ type Props = {
   labelTooltipText?: string | JSX.Element | null;
   // This should be used for testing. Only add id prop if there's no other option
   dataTestId?: string;
+  id?: string;
   ariaLabel?: string;
   tabIndex?: number;
   dataCy?: string;
@@ -29,6 +31,7 @@ const CheckboxWithLabel = ({
   checkedColor,
   labelTooltipText,
   dataTestId,
+  id,
   usePrimaryBorder,
   required,
   ariaLabel,
@@ -39,13 +42,15 @@ const CheckboxWithLabel = ({
   ariaDescribedBy,
   ...boxProps
 }: Props) => {
+  const uuid = useInstanceId();
+  const inputId = id ?? uuid;
+
   const handleLabelClick = (event: React.MouseEvent) => {
     stopLabelPropagation && event.stopPropagation();
   };
 
   return (
     <Box
-      as="label"
       position="relative"
       display="flex"
       flex="1"
@@ -57,6 +62,7 @@ const CheckboxWithLabel = ({
       {...boxProps}
     >
       <Checkbox
+        id={inputId}
         onChange={onChange}
         checked={checked}
         disabled={disabled}
@@ -66,14 +72,22 @@ const CheckboxWithLabel = ({
         usePrimaryBorder={usePrimaryBorder}
         name={name}
         required={required}
-        aria-label={ariaLabel}
+        ariaLabel={ariaLabel}
         tabIndex={tabIndex}
         setRef={setRef}
         ariaInvalid={ariaInvalid}
         ariaDescribedBy={ariaDescribedBy}
         mr="8px"
       />
-      {label}
+      <Box
+        as="label"
+        htmlFor={inputId}
+        flex="1"
+        aria-hidden={ariaLabel ? true : undefined}
+        style={{ cursor: 'pointer' }}
+      >
+        {label}
+      </Box>
       &nbsp;
       {labelTooltipText && (
         <IconTooltip

--- a/front/app/components/CustomFieldsForm/Fields/SingleSelectField.tsx
+++ b/front/app/components/CustomFieldsForm/Fields/SingleSelectField.tsx
@@ -14,7 +14,6 @@ import RadioGroup from 'components/HookForm/RadioGroup';
 import Radio from 'components/HookForm/RadioGroup/Radio';
 import Select from 'components/HookForm/Select';
 
-import { ScreenReaderOnly } from 'utils/a11y';
 import { useIntl } from 'utils/cl-intl';
 
 import messages from '../messages';
@@ -81,9 +80,6 @@ const SingleSelectField = ({
           padding="0px"
           aria-required={question.required}
         >
-          <ScreenReaderOnly>
-            <legend>{localize(question.title_multiloc)}</legend>
-          </ScreenReaderOnly>
           {options.map((option) => (
             <StyledBox
               style={{ cursor: 'pointer' }}

--- a/front/app/components/HookForm/CheckboxMultiSelect/index.tsx
+++ b/front/app/components/HookForm/CheckboxMultiSelect/index.tsx
@@ -14,7 +14,6 @@ import { CLError, IOption, RHFErrors } from 'typings';
 
 import Error, { TFieldName } from 'components/UI/Error';
 
-import { ScreenReaderOnly } from 'utils/a11y';
 interface Props extends Omit<SelectProps, 'onChange'> {
   name: string;
   options: IOption[];
@@ -35,7 +34,6 @@ const CheckboxMultiSelect = ({
   name,
   options,
   scrollErrorIntoView,
-  title,
   'aria-required': ariaRequired,
 }: Props) => {
   const {
@@ -72,9 +70,6 @@ const CheckboxMultiSelect = ({
               aria-invalid={fieldState.error ? true : undefined}
               aria-describedby={ariaDescribedBy}
             >
-              <ScreenReaderOnly>
-                <legend>{title}</legend>
-              </ScreenReaderOnly>
               {options.map((option, index) => (
                 <StyledBox
                   style={{ cursor: 'pointer' }}
@@ -97,6 +92,7 @@ const CheckboxMultiSelect = ({
                         {option.label}
                       </Text>
                     }
+                    ariaLabel={option.label}
                     checked={checkedOptions.includes(option.value)}
                     usePrimaryBorder={false}
                     setRef={index === 0 ? (el) => ref(el) : undefined}


### PR DESCRIPTION
Survey multiple-choice questions were read out twice by screen readers —
both the question and each option.
Two separate causes.

**The question** was rendered twice:
- once in a `<label for="…">` pointing at an id that does not exist
- once in a `<legend>` wrapped in a `<span>`, so it named nothing

Both ended up as loose text, read one after the other.

**Each option** was rendered twice:
- the `<label>` wrapped the input, so its text named the checkbox
- the same text also stayed in the reading order as its own node

A label only gets absorbed into the control's name when it sits *beside*
the input and is bound with `for=`.

## What changed

- Removed the two hidden `<legend>` elements — they duplicated the
  question and named nothing.
- `CheckboxWithLabel` now gives the input an id and renders the label as
  a sibling bound with `htmlFor`, instead of wrapping the input.
- `Checkbox` now forwards `ariaLabel` to the input. It previously landed
  on the wrapper `<div>`, so it never worked.
- Survey options pass `ariaLabel`, so the checkbox is named once even
  though the visible label is a `<Text>` element.



# Changelog
## A11y
- Fix survey CheckboxMultiSelect questions being read twice by screen readers

# For translators
<!-- In case your PR adds new copy, provide context to translators and proofreaders on the copy they are translating. Using screenshots is extra useful. -->
