### PR TITLE
TAN-8619: [DO NOT MERGE] Spike — live mobile preview of draft phase settings

### DIFF
--- a/front/app/components/DraftPreviewBridge/index.tsx
+++ b/front/app/components/DraftPreviewBridge/index.tsx
@@ -1,0 +1,108 @@
+// SPIKE (TAN-8619) — throwaway. Do not merge.
+//
+// Receives draft phase attributes posted by the admin shell and writes them
+// into this frame's TanStack cache, so the citizen page re-renders from unsaved
+// form state without a save or a reload. Mirrors the mechanism the content
+// builder already uses (ProjectPageBuilderPage -> FullscreenPreview/Wrapper),
+// except the payload is phase attributes rather than craft.js nodes.
+import { useEffect } from 'react';
+
+import { useQueryClient } from '@tanstack/react-query';
+
+import phasesKeys from 'api/phases/keys';
+import { IPhase, IPhases, IPhaseData } from 'api/phases/types';
+
+export const DRAFT_PREVIEW_MESSAGE = 'DRAFT_PREVIEW_PHASE';
+export const DRAFT_PREVIEW_RESET = 'DRAFT_PREVIEW_RESET';
+export const DRAFT_PREVIEW_APPLIED = 'DRAFT_PREVIEW_APPLIED';
+
+export type DraftPreviewMessage = {
+  type: typeof DRAFT_PREVIEW_MESSAGE;
+  projectId: string;
+  phaseId: string;
+  attributes: Partial<IPhaseData['attributes']>;
+  sentAt: number;
+};
+
+// Sent after a save or discard: drop every draft and refetch, so the preview
+// picks up whatever the server recomputed (action_descriptors above all).
+export type DraftPreviewResetMessage = {
+  type: typeof DRAFT_PREVIEW_RESET;
+};
+
+export type DraftPreviewAppliedMessage = {
+  type: typeof DRAFT_PREVIEW_APPLIED;
+  sentAt: number;
+};
+
+type Incoming = DraftPreviewMessage | DraftPreviewResetMessage;
+
+const isIncoming = (data: unknown): data is Incoming =>
+  typeof data === 'object' &&
+  data !== null &&
+  ((data as Incoming).type === DRAFT_PREVIEW_MESSAGE ||
+    (data as Incoming).type === DRAFT_PREVIEW_RESET);
+
+const DraftPreviewBridge = () => {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    // Only meaningful when hosted by the admin shell.
+    if (window.parent === window) return;
+
+    const handleMessage = (e: MessageEvent) => {
+      if (e.origin !== window.location.origin) return;
+      if (!isIncoming(e.data)) return;
+
+      if (e.data.type === DRAFT_PREVIEW_RESET) {
+        queryClient.invalidateQueries({ queryKey: phasesKeys.all() });
+        return;
+      }
+
+      const { projectId, phaseId, attributes, sentAt } = e.data;
+
+      // PhaseTitle and friends read the item key...
+      queryClient.setQueryData<IPhase>(
+        phasesKeys.item({ phaseId }),
+        (current) =>
+          current && {
+            ...current,
+            data: {
+              ...current.data,
+              attributes: { ...current.data.attributes, ...attributes },
+            },
+          }
+      );
+
+      // ...while ProjectsShowPage and the CTA bar read the list key.
+      queryClient.setQueryData<IPhases>(
+        phasesKeys.list({ projectId }),
+        (current) =>
+          current && {
+            ...current,
+            data: current.data.map((phase) =>
+              phase.id === phaseId
+                ? {
+                    ...phase,
+                    attributes: { ...phase.attributes, ...attributes },
+                  }
+                : phase
+            ),
+          }
+      );
+
+      const applied: DraftPreviewAppliedMessage = {
+        type: DRAFT_PREVIEW_APPLIED,
+        sentAt,
+      };
+      window.parent.postMessage(applied, window.location.origin);
+    };
+
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, [queryClient]);
+
+  return null;
+};
+
+export default DraftPreviewBridge;

--- a/front/app/containers/Admin/projects/project/newBackoffice/PhaseBuild/index.tsx
+++ b/front/app/containers/Admin/projects/project/newBackoffice/PhaseBuild/index.tsx
@@ -1,0 +1,297 @@
+// SPIKE (TAN-8619) — throwaway. Do not merge.
+//
+// Rough three-pane phase Build view: the real phase form in the rail, a phone
+// preview of the citizen phase page in the centre, and a readout on the right
+// that says which unsaved fields the preview can and cannot reflect. Exists to
+// measure how far draft live preview can go and what saving costs, not to be
+// the layout.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Box, Button, Text, colors } from '@citizenlab/cl2-component-library';
+
+import { IUpdatedPhaseProperties } from 'api/phases/types';
+import usePhase from 'api/phases/usePhase';
+import usePhases from 'api/phases/usePhases';
+import useProjectById from 'api/projects/useProjectById';
+
+import useLocale from 'hooks/useLocale';
+
+import AdminPhaseEdit from 'containers/Admin/projects/project/phaseSetup';
+
+import {
+  DRAFT_PREVIEW_APPLIED,
+  DRAFT_PREVIEW_MESSAGE,
+  DRAFT_PREVIEW_RESET,
+  DraftPreviewAppliedMessage,
+  DraftPreviewMessage,
+  DraftPreviewResetMessage,
+} from 'components/DraftPreviewBridge';
+
+import { useParams } from 'utils/router';
+
+const PHONE_WIDTH = 400;
+const PHONE_HEIGHT = 800;
+const SCALE = 0.72;
+
+type Verdict = 'live' | 'permission-gated' | 'not-read-by-citizen-page';
+
+// Which phase attributes the citizen page reads client-side (live), which it
+// reads but whose *effect* comes from server-computed action_descriptors
+// (permission-gated: the gate only refreshes on save), and which nothing on the
+// citizen page reads at all. Derived from grepping `attributes.<x>` reads
+// outside admin code.
+const LIVE = new Set<keyof IUpdatedPhaseProperties>([
+  'title_multiloc',
+  'description_multiloc',
+  'start_at',
+  'end_at',
+  'participation_method',
+  'presentation_mode',
+  'available_views',
+  'ideas_order',
+  'input_term',
+  'vote_term',
+  'voting_method',
+  'voting_min_total',
+  'voting_max_total',
+  'voting_min_selected_options',
+  'voting_max_votes_per_idea',
+  'voting_filtering_enabled',
+  'autoshare_results_enabled',
+  'native_survey_title_multiloc',
+  'native_survey_button_multiloc',
+  'survey_embed_url',
+  'survey_service',
+  'survey_popup_frequency',
+  'document_annotation_embed_url',
+  'report_public',
+]);
+
+const PERMISSION_GATED = new Set<keyof IUpdatedPhaseProperties>([
+  'submission_enabled',
+  'commenting_enabled',
+  'reacting_enabled',
+  'reacting_like_method',
+  'reacting_like_limited_max',
+  'reacting_dislike_enabled',
+  'reacting_dislike_method',
+  'reacting_dislike_limited_max',
+  'allow_anonymous_participation',
+  'prescreening_mode',
+  'user_data_collection',
+  'user_fields_in_form_enabled',
+]);
+
+const verdictOf = (field: keyof IUpdatedPhaseProperties): Verdict =>
+  PERMISSION_GATED.has(field)
+    ? 'permission-gated'
+    : LIVE.has(field)
+    ? 'live'
+    : 'not-read-by-citizen-page';
+
+const isApplied = (data: unknown): data is DraftPreviewAppliedMessage =>
+  typeof data === 'object' &&
+  data !== null &&
+  'type' in data &&
+  data.type === DRAFT_PREVIEW_APPLIED;
+
+const verdictColor: Record<Verdict, string> = {
+  live: colors.success,
+  'permission-gated': colors.orange500,
+  'not-read-by-citizen-page': colors.grey600,
+};
+
+const PhaseBuild = () => {
+  const { projectId, phaseId } = useParams({
+    from: '/$locale/admin/projects/$projectId/build/$phaseId',
+  });
+  const locale = useLocale();
+  const { data: project } = useProjectById(projectId);
+  const { data: phases } = usePhases(projectId);
+  const { data: phase } = usePhase(phaseId);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [draft, setDraft] = useState<IUpdatedPhaseProperties>();
+  const [latencyMs, setLatencyMs] = useState<number | null>(null);
+  const [postCount, setPostCount] = useState(0);
+  // Bumping this remounts the form, which is how it resets to the saved phase.
+  const [formInstance, setFormInstance] = useState(0);
+
+  useEffect(() => {
+    const handleMessage = (e: MessageEvent) => {
+      if (e.origin !== window.location.origin) return;
+      const data: unknown = e.data;
+      if (isApplied(data)) {
+        setLatencyMs(Math.round(performance.now() - data.sentAt));
+      }
+    };
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
+  }, []);
+
+  // Must be referentially stable: the form mirrors formData in an effect that
+  // depends on this callback, so a fresh identity per render (every ACK
+  // re-renders us) would post -> ack -> re-render -> post forever. First
+  // version of this spike did exactly that: 349 posts for one keystroke.
+  const handleFormDataChange = useCallback(
+    (formData: IUpdatedPhaseProperties) => {
+      setDraft(formData);
+      setPostCount((n) => n + 1);
+      iframeRef.current?.contentWindow?.postMessage(
+        {
+          type: DRAFT_PREVIEW_MESSAGE,
+          projectId,
+          phaseId,
+          attributes: formData,
+          sentAt: performance.now(),
+        } satisfies DraftPreviewMessage,
+        window.location.origin
+      );
+    },
+    [projectId, phaseId]
+  );
+
+  const postReset = () => {
+    const message: DraftPreviewResetMessage = { type: DRAFT_PREVIEW_RESET };
+    iframeRef.current?.contentWindow?.postMessage(
+      message,
+      window.location.origin
+    );
+  };
+
+  const handleSaved = useCallback(() => {
+    const message: DraftPreviewResetMessage = { type: DRAFT_PREVIEW_RESET };
+    iframeRef.current?.contentWindow?.postMessage(
+      message,
+      window.location.origin
+    );
+  }, []);
+
+  const handleDiscard = () => {
+    setDraft(undefined);
+    setFormInstance((n) => n + 1);
+    postReset();
+  };
+
+  if (!project || !phases || !phase) return null;
+
+  const phaseNumber = phases.data.findIndex((p) => p.id === phaseId) + 1;
+  const previewSrc = `/${locale}/projects/${project.data.attributes.slug}/${phaseNumber}`;
+
+  const saved = phase.data.attributes;
+  const dirtyFields = draft
+    ? (Object.keys(draft) as (keyof IUpdatedPhaseProperties)[]).filter(
+        (field) => JSON.stringify(draft[field]) !== JSON.stringify(saved[field])
+      )
+    : [];
+
+  return (
+    <Box display="flex" height="100%" minHeight="0">
+      <Box
+        w="420px"
+        flexShrink={0}
+        overflowY="auto"
+        p="16px"
+        borderRight={`1px solid ${colors.grey300}`}
+        background={colors.white}
+      >
+        <AdminPhaseEdit
+          key={formInstance}
+          onFormDataChange={handleFormDataChange}
+          onSaved={handleSaved}
+        />
+      </Box>
+
+      <Box
+        flexGrow={1}
+        display="flex"
+        alignItems="flex-start"
+        justifyContent="center"
+        p="24px"
+        background={colors.background}
+        overflowY="auto"
+      >
+        <Box
+          w={`${PHONE_WIDTH * SCALE}px`}
+          h={`${PHONE_HEIGHT * SCALE}px`}
+          border={`1.5px solid ${colors.grey300}`}
+          borderRadius="22px"
+          overflow="hidden"
+          background={colors.white}
+          flexShrink={0}
+        >
+          <Box
+            as="iframe"
+            ref={iframeRef}
+            src={previewSrc}
+            title="Phase preview"
+            display="block"
+            w={`${PHONE_WIDTH}px`}
+            h={`${PHONE_HEIGHT}px`}
+            border="none"
+            transform={`scale(${SCALE})`}
+            style={{ transformOrigin: 'top left' }}
+          />
+        </Box>
+      </Box>
+
+      <Box
+        w="320px"
+        flexShrink={0}
+        overflowY="auto"
+        p="16px"
+        borderLeft={`1px solid ${colors.grey300}`}
+        background={colors.white}
+        display="flex"
+        flexDirection="column"
+        gap="12px"
+      >
+        <Text fontWeight="bold" m="0">
+          SPIKE readout
+        </Text>
+        <Text m="0" fontSize="s">
+          preview: <code>{previewSrc}</code>
+        </Text>
+        <Text m="0" fontSize="s">
+          drafts posted: {postCount} · last round trip:{' '}
+          {latencyMs === null ? '—' : `${latencyMs} ms`}
+        </Text>
+        <Button
+          buttonStyle="secondary"
+          size="s"
+          onClick={handleDiscard}
+          disabled={dirtyFields.length === 0}
+        >
+          Discard draft ({dirtyFields.length})
+        </Button>
+
+        <Text fontWeight="bold" m="0" mt="8px">
+          Unsaved fields
+        </Text>
+        {dirtyFields.length === 0 && (
+          <Text m="0" fontSize="s" color="textSecondary">
+            none — preview shows saved state
+          </Text>
+        )}
+        {dirtyFields.map((field) => {
+          const verdict = verdictOf(field);
+          return (
+            <Box key={field} display="flex" flexDirection="column">
+              <Text m="0" fontSize="s" fontWeight="semi-bold">
+                {field}
+              </Text>
+              <Text
+                m="0"
+                fontSize="xs"
+                style={{ color: verdictColor[verdict] }}
+              >
+                {verdict}
+              </Text>
+            </Box>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+};
+
+export default PhaseBuild;

--- a/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/index.tsx
@@ -67,9 +67,18 @@ interface Props {
   projectId: string;
   phase: IPhase | undefined;
   standaloneSurvey?: boolean;
+  // SPIKE (TAN-8619) — throwaway. Do not merge.
+  onFormDataChange?: (formData: IUpdatedPhaseProperties) => void;
+  onSaved?: () => void;
 }
 
-const AdminPhaseEdit = ({ projectId, phase, standaloneSurvey }: Props) => {
+const AdminPhaseEdit = ({
+  projectId,
+  phase,
+  standaloneSurvey,
+  onFormDataChange,
+  onSaved,
+}: Props) => {
   const phaseId = phase?.data.id;
   const { data: phaseFileAttachments } = useFileAttachments({
     attachable_id: phaseId,
@@ -147,6 +156,11 @@ const AdminPhaseEdit = ({ projectId, phase, standaloneSurvey }: Props) => {
       setInStatePhaseFileAttachments(phaseFileAttachments.data);
     }
   }, [phaseFileAttachments]);
+
+  // SPIKE (TAN-8619): mirror every form change to the live preview.
+  useEffect(() => {
+    if (formData) onFormDataChange?.(formData);
+  }, [formData, onFormDataChange]);
 
   if (!formatMessageWithLocale) return null;
 
@@ -367,6 +381,7 @@ const AdminPhaseEdit = ({ projectId, phase, standaloneSurvey }: Props) => {
         } else {
           setFormData(response.data.attributes);
         }
+        onSaved?.();
       })
       .catch(({ errors }) => {
         // For some reason, the BE adds a 'blank' error
@@ -536,7 +551,11 @@ const AdminPhaseEdit = ({ projectId, phase, standaloneSurvey }: Props) => {
   );
 };
 
-const AdminPhaseEditWrapper = () => {
+// SPIKE (TAN-8619): the two optional callbacks are throwaway. Do not merge.
+const AdminPhaseEditWrapper = ({
+  onFormDataChange,
+  onSaved,
+}: Pick<Props, 'onFormDataChange' | 'onSaved'>) => {
   const { projectId, phaseId } = useParams({ strict: false });
   const { placement } = useSearch({ strict: false });
   const { data: phase } = usePhase(phaseId);
@@ -554,6 +573,8 @@ const AdminPhaseEditWrapper = () => {
       projectId={projectId}
       phase={phaseId ? phase : undefined}
       standaloneSurvey={spotlightSurveysEnabled && placement === 'standalone'}
+      onFormDataChange={onFormDataChange}
+      onSaved={onSaved}
     />
   );
 };

--- a/front/app/containers/Admin/projects/routes.tsx
+++ b/front/app/containers/Admin/projects/routes.tsx
@@ -35,6 +35,10 @@ const AdminProjectPageNewBackoffice = lazy(
   () => import('./project/newBackoffice/ProjectPage')
 );
 const AdminProjectPhaseIndex = lazy(() => import('./project/phase'));
+// SPIKE (TAN-8619) — throwaway. Do not merge.
+const AdminPhaseBuildSpike = lazy(
+  () => import('./project/newBackoffice/PhaseBuild')
+);
 const AdminProjectsProjectGeneral = lazy(() => import('./project/general'));
 const AdminProjectsProjectGeneralSetUp = lazy(
   () => import('./project/general/setUp')
@@ -247,6 +251,17 @@ const projectPageRoute = createRoute({
   component: () => (
     <PageLoading>
       <AdminProjectPageNewBackoffice />
+    </PageLoading>
+  ),
+});
+
+// SPIKE (TAN-8619) — throwaway. Do not merge.
+const phaseBuildSpikeRoute = createRoute({
+  getParentRoute: () => projectRoute,
+  path: 'build/$phaseId',
+  component: () => (
+    <PageLoading>
+      <AdminPhaseBuildSpike />
     </PageLoading>
   ),
 });
@@ -802,6 +817,7 @@ const createAdminProjectsRoutes = (moduleRoutes: RouteConfiguration[] = []) => {
     projectRoute.addChildren([
       projectIndexRoute,
       projectPageRoute,
+      phaseBuildSpikeRoute,
       projectGeneralRoute.addChildren([
         projectGeneralIndexRoute,
         projectGeneralInputTagsRoute,

--- a/front/app/containers/ProjectsShowPage/index.tsx
+++ b/front/app/containers/ProjectsShowPage/index.tsx
@@ -20,6 +20,7 @@ import useProjectBySlug from 'api/projects/useProjectBySlug';
 
 import useLocale from 'hooks/useLocale';
 
+import DraftPreviewBridge from 'components/DraftPreviewBridge';
 import ErrorBoundary from 'components/ErrorBoundary';
 import PageNotFound from 'components/PageNotFound';
 import FullPageSpinner from 'components/UI/FullPageSpinner';
@@ -202,6 +203,8 @@ const ProjectsShowPageWrapper = () => {
 
 export default () => (
   <ErrorBoundary>
+    {/* SPIKE (TAN-8619) — throwaway. Do not merge. */}
+    <DraftPreviewBridge />
     <ProjectsShowPageWrapper />
   </ErrorBoundary>
 );


### PR DESCRIPTION
> ⚠️ **DO NOT MERGE.** Throwaway spike for the redesign's slice 4 ("live preview spike"). It exists so others can run it locally and read the findings; nothing here is production code. No changelog on purpose.

**Ticket:** [TAN-8619 Spike live mobile preview](https://app.notion.com/p/govocal/Spike-live-mobile-preview-3cf9663b7b268097a47dec4e61c65d85) — full write-up and measurements live there.

## Question
Can the centre-pane phone preview reflect **unsaved** phase settings, at phase level, and what does that cost?

## Answer (short)
Yes, cheaply. The admin shell posts draft phase attributes into the preview iframe; a small bridge inside the frame writes them into that frame's TanStack cache. Zero changes to any citizen-facing component. Round trip ~130 ms in dev. Presentation-level settings (title, dates, method, views, voting config…) go live; participation *permissions* don't — and for an admin viewer they never will, because `actionTakingRules` short-circuits to `enabled` for moderators. A visitor-eyed preview is a correctness requirement, independent of live-vs-saved.

## What's in here
- `components/DraftPreviewBridge` — origin-checked `message` listener → `setQueryData` on phase item + list keys; a `RESET` message invalidates after save/discard. Only active when framed.
- `phaseSetup` — two optional callbacks (`onFormDataChange`, `onSaved`), otherwise untouched.
- `newBackoffice/PhaseBuild` + route `/admin/projects/:projectId/build/:phaseId` — rough three-pane view: real phase form · phone preview of `/projects/:slug/:n` · a readout naming each unsaved field as live / permission-gated / not read by the citizen page.

## Try it
Open any project's phase at `/en/admin/projects/<projectId>/build/<phaseId>`, then type in *Phase name*, click a method card, toggle *Submitting posts*, save, discard — and watch the phone and the readout.