### PR TITLE
[TAN-8635] New MCP tool to get tenant branding

### DIFF
--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -106,6 +106,7 @@ module McpServer
       McpServer::Tools::UpdateProject,
       McpServer::Tools::UpdatePhase,
       McpServer::Tools::GetResource,
+      McpServer::Tools::GetPlatformBranding,
       McpServer::Tools::GetFormFields,
       McpServer::Tools::GetProjectLayout,
       McpServer::Tools::UpdateProjectLayout,

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
@@ -7,8 +7,7 @@ class McpServer::Tools::GetPlatformBranding < McpServer::BaseTool
   def description
     <<~DESC.squish
       Reads the platform's branding: organization name, locales, brand colours,
-      logo URLs and style customizations (fonts, header colours, etc.). Use it to
-      make generated content match the platform's look and feel.
+      logo URLs and style customizations (fonts, header colours, etc.).
     DESC
   end
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
@@ -17,16 +17,17 @@ class McpServer::Tools::GetPlatformBranding < McpServer::BaseTool
   class Runner < McpServer::BaseTool::Runner
     def run
       config = AppConfiguration.instance
+      core = config.settings('core')
 
       response(
         "Branding of platform #{config.host}",
         structured: {
-          organization_name_multiloc: config.settings('core', 'organization_name'),
-          locales: config.settings('core', 'locales'),
+          organization_name_multiloc: core['organization_name'],
+          locales: core['locales'],
           colors: {
-            main: config.settings('core', 'color_main'),
-            secondary: config.settings('core', 'color_secondary'),
-            text: config.settings('core', 'color_text')
+            main: core['color_main'],
+            secondary: core['color_secondary'],
+            text: core['color_text']
           },
           logo_urls: (config.logo.versions.transform_values(&:url) if config.logo.file),
           style: config.style

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_platform_branding.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::GetPlatformBranding < McpServer::BaseTool
+  def name = 'get_platform_branding'
+  def annotations = READ_ANNOTATIONS
+
+  def description
+    <<~DESC.squish
+      Reads the platform's branding: organization name, locales, brand colours,
+      logo URLs and style customizations (fonts, header colours, etc.). Use it to
+      make generated content match the platform's look and feel.
+    DESC
+  end
+
+  def input_schema = { properties: {}, additionalProperties: false }
+
+  class Runner < McpServer::BaseTool::Runner
+    def run
+      config = AppConfiguration.instance
+
+      response(
+        "Branding of platform #{config.host}",
+        structured: {
+          organization_name_multiloc: config.settings('core', 'organization_name'),
+          locales: config.settings('core', 'locales'),
+          colors: {
+            main: config.settings('core', 'color_main'),
+            secondary: config.settings('core', 'color_secondary'),
+            text: config.settings('core', 'color_text')
+          },
+          logo_urls: (config.logo.versions.transform_values(&:url) if config.logo.file),
+          style: config.style
+        }
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_platform_branding_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_platform_branding_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::GetPlatformBranding do
+  let(:current_user) { create(:super_admin) }
+
+  def fetch_branding
+    run_mcp_tool(described_class, params: {}, current_user:)
+  end
+
+  it 'returns the platform branding' do
+    config = AppConfiguration.instance
+    config.settings['core']['color_main'] = '#163B6D'
+    config.style = { 'customFontName' => 'Fira Sans' }
+    config.logo = Rails.root.join('spec/fixtures/logo.png').open
+    config.save!
+
+    response = fetch_branding
+
+    expect(response).not_to be_error
+    expect(response.structured_content).to match(
+      organization_name_multiloc: config.settings('core', 'organization_name'),
+      locales: config.settings('core', 'locales'),
+      colors: {
+        main: '#163B6D',
+        secondary: config.settings('core', 'color_secondary'),
+        text: config.settings('core', 'color_text')
+      },
+      logo_urls: {
+        small: end_with('.png'),
+        medium: end_with('.png'),
+        large: end_with('.png')
+      },
+      style: { 'customFontName' => 'Fira Sans' }
+    )
+  end
+
+  it 'returns nil logo_urls when the platform has no logo' do
+    AppConfiguration.instance.remove_logo!
+
+    response = fetch_branding
+
+    expect(response).not_to be_error
+    expect(response.structured_content[:logo_urls]).to be_nil
+  end
+end


### PR DESCRIPTION
For context, original ask from Wietse:
> Reading tenant branding (app_configuration: colours, font, logo), today prototypes have to proxy or hardcode it per city

# Changelog
## Added
- [TAN-8635] New MCP tool to GET tenant branding