### PR TITLE
[Tan-8354] survey response with demographics only

### DIFF
--- a/back/app/controllers/web_api/v1/ideas_controller.rb
+++ b/back/app/controllers/web_api/v1/ideas_controller.rb
@@ -309,7 +309,9 @@ class WebApi::V1::IdeasController < ApplicationController
       update_file_upload_fields input, input.custom_form, update_params
 
       if anonymize_user_at_the_end
-        input.author_id = nil
+        # the anonymous_participation concern will set author_id to nil
+        # setting anonymous to true ensures that author_hash is generated with salt_anon
+        input.anonymous = true
         input.save!
       end
 

--- a/back/spec/acceptance/ideas/ideas_update_spec.rb
+++ b/back/spec/acceptance/ideas/ideas_update_spec.rb
@@ -837,6 +837,26 @@ resource 'Ideas' do
               end
             end
           end
+
+          context 'with user_data_collection set to demographics only' do
+            before do
+              permission = project.phases.first.permissions.find_by(action: 'posting_idea')
+              permission.update!(user_data_collection: 'demographics_only')
+            end
+
+            let(:publication_status) { 'published' }
+
+            example_request 'Can change a survey response from draft to published' do
+              assert_status 200
+              expect(response_data[:attributes][:publication_status]).to eq 'published'
+
+              idea = Idea.find(response_data[:id])
+              expect(idea.custom_field_values['u_age']).to eq 30
+              expect(idea.anonymous).to be true
+              expect(idea.author).to be_nil
+              expect(idea.author_hash).to eq(Idea.create_author_hash(input.author.id, project.id, true))
+            end
+          end
         end
       end
 


### PR DESCRIPTION
🎩 What? Why?
On a native survey, when the posting_idea permission had user_data_collection set to 'demographics_only', it was possible for a user to response multiple times, despite that allow_multiple_responses was false.
This PR replaces, in ideas_controller update action, `input.author_id = nil` with `input.anonymous = true` (as in create action, line 178) to let the `AnonymousParticipation` logic nullify the author and recalculate the hash using the correct salt.


✅ Tasks
- [X] Add acceptance test for 'demographics_only' case in idea's update

# Changelog
## Fixed
- only one response allowed per user, for native survey with permission 'demographics_only' and allow_multiple_responses false

