### PR TITLE
[TAN-8648] New MCP tool for adding demo inputs

### DIFF
--- a/back/app/services/random_custom_field_values_service.rb
+++ b/back/app/services/random_custom_field_values_service.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+# Generates plausible random answers for custom fields, for seeding demo data:
+# survey responses and user demographics. Extracted from the
+# demos:seed_native_survey_responses rake task.
+class RandomCustomFieldValuesService
+  def generate(fields)
+    {}.tap do |values|
+      fields.each do |field|
+        next if field.input_type == 'page'
+        # Skip optional fields ~20% of the time
+        next if !field.required? && rand < 0.2
+
+        value = generate_field_value(field)
+        values[field.key] = value unless value.nil?
+      end
+    end
+  end
+
+  private
+
+  def generate_field_value(field)
+    case field.code
+    when 'birthyear'
+      generate_birthyear_value
+    when 'domicile'
+      generate_domicile_value
+    else
+      generate_value_for_type(field)
+    end
+  end
+
+  def generate_birthyear_value
+    # Age 18-80
+    current_year = Time.zone.now.year
+    rand((current_year - 80)..(current_year - 18))
+  end
+
+  def generate_domicile_value
+    area_ids = Area.pluck(:id)
+    return nil if area_ids.empty?
+
+    # 90% chance of selecting an area, 10% chance of 'outside'
+    rand < 0.1 ? 'outside' : area_ids.sample
+  end
+
+  def generate_value_for_type(field)
+    case field.input_type
+    when 'text', 'html', 'text_multiloc', 'html_multiloc'
+      generate_text_value(field)
+    when 'multiline_text', 'multiline_text_multiloc'
+      generate_multiline_text_value
+    when 'number'
+      rand(1..(field.maximum || 100))
+    when 'linear_scale', 'sentiment_linear_scale', 'rating'
+      weighted_random_scale(field.maximum || 5)
+    when 'select', 'select_image'
+      generate_select_value(field)
+    when 'multiselect', 'multiselect_image'
+      generate_multiselect_value(field)
+    when 'checkbox'
+      [true, false].sample
+    when 'date'
+      rand(365).days.ago.to_date.iso8601
+    when 'ranking'
+      field.options.reject(&:other).shuffle.map(&:key)
+    when 'matrix_linear_scale'
+      generate_matrix_value(field)
+    when 'point'
+      generate_point_value
+    when 'line'
+      generate_line_value
+    when 'polygon'
+      generate_polygon_value
+    end
+    # Returns nil for unsupported types like file_upload, shapefile_upload, files, image_files
+  end
+
+  def generate_text_value(field)
+    responses = [
+      'I think this is a great initiative.',
+      'More community involvement would help.',
+      'We need better infrastructure.',
+      'This could improve quality of life.',
+      'I support this proposal.',
+      'Environmental concerns should be prioritized.',
+      'Safety is my main concern.',
+      'This would benefit local businesses.',
+      'Education should be the focus.',
+      'We need more green spaces.'
+    ]
+
+    title = field.title_multiloc[locale] || field.key
+    "#{responses.sample} (Re: #{title.truncate(30)})"
+  end
+
+  def generate_multiline_text_value
+    paragraphs = [
+      "This is an important topic that affects our community.\n\nI believe we should focus on sustainable solutions that benefit everyone.",
+      "After careful consideration, I think the proposed changes would be beneficial.\n\nHowever, we should also consider the long-term impacts.",
+      "My main concerns are:\n- Environmental impact\n- Community engagement\n- Budget allocation\n\nThese should be addressed before moving forward.",
+      "I appreciate the opportunity to provide feedback.\n\nOverall, I support the initiative but would like to see more details on implementation."
+    ]
+    paragraphs.sample
+  end
+
+  def generate_select_value(field)
+    options = field.options.reject(&:other)
+    return nil if options.empty?
+
+    # Occasionally select 'other' option if available
+    other_option = field.options.find(&:other)
+    if other_option && rand < 0.1
+      other_option.key
+    else
+      # Weight earlier options more heavily for non-uniform distribution
+      weighted_random_option(options).key
+    end
+  end
+
+  def generate_multiselect_value(field)
+    options = field.options.reject(&:other)
+    return [] if options.empty?
+
+    num_selections = rand(1..[3, options.count].min)
+    options.sample(num_selections).map(&:key)
+  end
+
+  def generate_matrix_value(field)
+    max = field.maximum || 5
+    field.matrix_statements.to_h { |statement| [statement.key, weighted_random_scale(max)] }
+  end
+
+  # Skewed toward higher values (more positive responses).
+  # For max=5: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]
+  def weighted_random_scale(max)
+    weights = (1..max).flat_map { |n| Array.new(n, n) }
+    weights.sample
+  end
+
+  # Earlier options weighted more heavily, e.g. for 4 options: [4, 3, 2, 1]
+  def weighted_random_option(options)
+    return options.first if options.size == 1
+
+    total_weight = options.size * (options.size + 1) / 2
+    random_point = rand(total_weight)
+
+    cumulative = 0
+    options.each_with_index do |option, index|
+      weight = options.size - index
+      cumulative += weight
+      return option if random_point < cumulative
+    end
+
+    options.last
+  end
+
+  def generate_point_value
+    # Random point, roughly in the Belgium area as default
+    lat = 50.5 + (rand * 1.0)
+    lng = 3.5 + (rand * 2.0)
+    { 'type' => 'Point', 'coordinates' => [lng.round(6), lat.round(6)] }
+  end
+
+  def generate_line_value
+    num_points = rand(3..5)
+    base_lat = 50.5 + (rand * 1.0)
+    base_lng = 3.5 + (rand * 2.0)
+
+    coordinates = Array.new(num_points) do |i|
+      [(base_lng + (i * 0.01)).round(6), (base_lat + (rand * 0.01)).round(6)]
+    end
+
+    { 'type' => 'LineString', 'coordinates' => coordinates }
+  end
+
+  def generate_polygon_value
+    base_lat = 50.5 + (rand * 1.0)
+    base_lng = 3.5 + (rand * 2.0)
+    size = 0.01
+
+    coordinates = [
+      [base_lng.round(6), base_lat.round(6)],
+      [(base_lng + size).round(6), base_lat.round(6)],
+      [(base_lng + size).round(6), (base_lat + size).round(6)],
+      [base_lng.round(6), (base_lat + size).round(6)],
+      [base_lng.round(6), base_lat.round(6)] # Close the polygon
+    ]
+
+    { 'type' => 'Polygon', 'coordinates' => [coordinates] }
+  end
+
+  def locale
+    @locale ||= AppConfiguration.instance.settings('core', 'locales').first
+  end
+end

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -102,6 +102,7 @@ module McpServer
       McpServer::Tools::CreatePollQuestion,
       McpServer::Tools::CreatePollOption,
       McpServer::Tools::CreateDemoInputs,
+      McpServer::Tools::CreateDemoComments,
       McpServer::Tools::DestroyResource,
       McpServer::Tools::UpdateResource,
       McpServer::Tools::UpdateProject,

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -115,6 +115,7 @@ module McpServer
       McpServer::Tools::ReplaceFormFields,
       McpServer::Tools::ListProjects,
       McpServer::Tools::ListPhases,
+      McpServer::Tools::ListInputs,
       McpServer::Tools::ListEvents,
       McpServer::Tools::ListCauses,
       McpServer::Tools::ListPollQuestions,

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -101,6 +101,7 @@ module McpServer
       McpServer::Tools::CreateCause,
       McpServer::Tools::CreatePollQuestion,
       McpServer::Tools::CreatePollOption,
+      McpServer::Tools::CreateDemoInputs,
       McpServer::Tools::DestroyResource,
       McpServer::Tools::UpdateResource,
       McpServer::Tools::UpdateProject,

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/base_tool/response_helpers.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/base_tool/response_helpers.rb
@@ -18,11 +18,13 @@ module McpServer::BaseTool::ResponseHelpers
   end
 
   def invalid_record_error(record)
-    errors = record.errors.map do |e|
+    error('Validation failed:', structured: { errors: record_errors(record) })
+  end
+
+  def record_errors(record)
+    record.errors.map do |e|
       e.details.merge(attribute: e.attribute.to_s, message: e.message)
     end
-
-    error('Validation failed:', structured: { errors: errors })
   end
 
   def not_found_error(label, id) = error("#{label} not found: #{id}")

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class McpServer::Serializers::Input < McpServer::Serializers::Base
+  wraps ::WebApi::V1::IdeaSerializer
+
+  def attributes(record)
+    super.merge(**urls(record).compact)
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Lean row shape for input listings. Full content via get_resource type 'input'.
+class McpServer::Serializers::InputSummary < McpServer::Serializers::Base
+  def attributes(record)
+    {
+      id: record.id,
+      title_multiloc: record.title_multiloc,
+      author_name: record.author_name,
+      idea_status_code: record.idea_status&.code,
+      likes_count: record.likes_count,
+      dislikes_count: record.dislikes_count,
+      comments_count: record.comments_count,
+      budget: record.budget,
+      published_at: record.published_at,
+      **urls(record).compact
+    }
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_comments.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_comments.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::CreateDemoComments < McpServer::BaseTool
+  MAX_COMMENTS_PER_CALL = 50
+
+  def name = 'create_demo_comments'
+
+  def annotations
+    {
+      read_only_hint: false,
+      destructive_hint: false,
+      idempotent_hint: false,
+      open_world_hint: false
+    }
+  end
+
+  def description
+    <<~DESC.squish
+      Creates demo comments on inputs (ideas, proposals). Each comment gets a generated
+      fake demo author and a backdated timestamp after the input it comments on. Only
+      available on demo and trial platforms. Write comments that fit the input's content.
+      For threaded replies, create the top-level comments first, then pass their returned
+      IDs as parent_id in a second call. Max #{MAX_COMMENTS_PER_CALL} comments per call.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        comments: {
+          type: 'array',
+          minItems: 1,
+          maxItems: MAX_COMMENTS_PER_CALL,
+          items: {
+            type: 'object',
+            properties: {
+              idea_id: { type: 'string', description: 'The ID of the input to comment on.' },
+              body_multiloc: { **multiloc_schema, description: 'Comment body (HTML).' },
+              parent_id: {
+                type: 'string',
+                description: 'ID of an existing comment on the same input, to create a threaded reply.'
+              }
+            },
+            required: %w[idea_id body_multiloc],
+            additionalProperties: false
+          }
+        }
+      },
+      required: %w[comments],
+      additionalProperties: false
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    DEMO_ONLY_MESSAGE = 'Demo comments can only be created on demo and trial platforms.'
+
+    def run
+      return error(DEMO_ONLY_MESSAGE) unless published_writable_platform?
+
+      ideas = Idea.where(id: params[:comments].pluck(:idea_id)).index_by(&:id)
+      missing_idea_id = params[:comments].pluck(:idea_id).find { |id| !ideas[id] }
+      return not_found_error('Idea', missing_idea_id) if missing_idea_id
+
+      parents = Comment.where(id: params[:comments].pluck(:parent_id).compact).index_by(&:id)
+      bad_parent = params[:comments].find do |attributes|
+        attributes[:parent_id] && parents[attributes[:parent_id]]&.idea_id != attributes[:idea_id]
+      end
+      return not_found_error('Parent comment on the same input', bad_parent[:parent_id]) if bad_parent
+
+      ceiling_message = McpServer::DemoData.user_ceiling_error_message(params[:comments].size)
+      return error(ceiling_message) if ceiling_message
+
+      comments = params[:comments].map do |attributes|
+        build_comment(attributes, ideas[attributes[:idea_id]], parents[attributes[:parent_id]])
+      end
+      comments.each { |comment| authorize(comment, :create?) }
+
+      errors = comments.each_with_index.filter_map do |comment, index|
+        { index:, errors: record_errors(comment) } if comment.invalid?
+      end
+      return error('Validation failed:', structured: { errors: }) if errors.any?
+
+      ActiveRecord::Base.transaction do
+        comments.each do |comment|
+          comment.author.save!
+          comment.save!
+        end
+      end
+
+      response(
+        "Created #{comments.size} demo comments",
+        structured: { comment_ids: comments.map(&:id) }
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      invalid_record_error(e.record)
+    end
+
+    private
+
+    def build_comment(attributes, idea, parent)
+      time = Faker::Time.between(from: [idea.created_at, parent&.created_at].compact.max, to: Time.zone.now)
+      Comment.new(
+        idea: idea,
+        parent: parent,
+        body_multiloc: attributes[:body_multiloc],
+        author: McpServer::DemoData.build_author(time - rand(72).hours),
+        created_at: time
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
@@ -120,11 +120,8 @@ class McpServer::Tools::CreateDemoInputs < McpServer::BaseTool
                      "of max #{McpServer::DemoData::MAX_INPUTS_PER_PROJECT}. Do not create more.")
       end
 
-      user_count = McpServer::DemoData.demo_users.count
-      return unless user_count + requested > McpServer::DemoData::MAX_USERS_PER_TENANT
-
-      error("Demo user ceiling reached: this platform has #{user_count} demo users " \
-            "of max #{McpServer::DemoData::MAX_USERS_PER_TENANT}. Do not create more.")
+      user_ceiling_message = McpServer::DemoData.user_ceiling_error_message(requested)
+      error(user_ceiling_message) if user_ceiling_message
     end
 
     def build_ideas(phase)

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
@@ -1,0 +1,168 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::CreateDemoInputs < McpServer::BaseTool
+  MAX_INPUTS_PER_CALL = 50
+
+  def name = 'create_demo_inputs'
+
+  def annotations
+    {
+      read_only_hint: false,
+      destructive_hint: false,
+      idempotent_hint: false,
+      open_world_hint: false
+    }
+  end
+
+  def description
+    <<~DESC.squish
+      Creates demo inputs (ideas, proposals or native survey responses) in a phase.
+      Each input gets a generated fake demo author and a backdated timestamp spread
+      over the phase's date range, so participation charts look realistic. Only
+      available on demo and trial platforms. Write content that fits the project's
+      context. For form fields (native surveys, extra ideation fields), read the
+      form via get_form_fields first and answer via custom_field_values.
+      Max #{MAX_INPUTS_PER_CALL} inputs per call; call repeatedly for more.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        phase_id: { type: 'string', description: 'The ID of the phase to create the inputs in.' },
+        inputs: {
+          type: 'array',
+          minItems: 1,
+          maxItems: MAX_INPUTS_PER_CALL,
+          items: {
+            type: 'object',
+            properties: {
+              title_multiloc: {
+                **multiloc_schema,
+                description: 'Input title. Required for ideation and proposals phases.'
+              },
+              body_multiloc: {
+                **multiloc_schema,
+                description: 'Input body (HTML). Required for ideation and proposals phases.'
+              },
+              custom_field_values: {
+                type: 'object',
+                description: 'Answers keyed by form field key (see get_form_fields). ' \
+                             'Required for native_survey phases; optional extra form fields on ideation phases.'
+              },
+              location: {
+                type: 'object',
+                properties: {
+                  lat: { type: 'number' },
+                  lng: { type: 'number' },
+                  description: { type: 'string', description: 'Human-readable address or place name.' }
+                },
+                required: %w[lat lng],
+                additionalProperties: false,
+                description: 'Where the input is located, for map views.'
+              },
+              budget: {
+                type: 'number',
+                description: 'Cost of the input. Only for budgeting (participatory budget) phases.'
+              }
+            },
+            additionalProperties: false
+          }
+        }
+      },
+      required: %w[phase_id inputs],
+      additionalProperties: false
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    DEMO_ONLY_MESSAGE = 'Demo inputs can only be created on demo and trial platforms.'
+
+    def run
+      phase = Phase.find_by(id: params[:phase_id])
+      return not_found_error('Phase', params[:phase_id]) unless phase
+      return error(DEMO_ONLY_MESSAGE) unless published_writable_platform?
+
+      ceiling = ceiling_error(phase.project)
+      return ceiling if ceiling
+
+      ideas = build_ideas(phase)
+      ideas.each { |idea| authorize(idea, :create?) }
+
+      errors = ideas.each_with_index.filter_map do |idea, index|
+        { index:, errors: record_errors(idea) } if idea.invalid?
+      end
+      return error('Validation failed:', structured: { errors: }) if errors.any?
+
+      ActiveRecord::Base.transaction do
+        ideas.each do |idea|
+          idea.author.save!
+          idea.save!
+        end
+      end
+
+      response(
+        "Created #{ideas.size} demo inputs in phase #{phase.id}",
+        structured: { idea_ids: ideas.map(&:id) }
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      invalid_record_error(e.record)
+    end
+
+    private
+
+    def ceiling_error(project)
+      requested = params[:inputs].size
+
+      input_count = McpServer::DemoData.demo_input_count(project)
+      if input_count + requested > McpServer::DemoData::MAX_INPUTS_PER_PROJECT
+        return error("Demo input ceiling reached: this project has #{input_count} demo inputs " \
+                     "of max #{McpServer::DemoData::MAX_INPUTS_PER_PROJECT}. Do not create more.")
+      end
+
+      user_count = McpServer::DemoData.demo_users.count
+      return unless user_count + requested > McpServer::DemoData::MAX_USERS_PER_TENANT
+
+      error("Demo user ceiling reached: this platform has #{user_count} demo users " \
+            "of max #{McpServer::DemoData::MAX_USERS_PER_TENANT}. Do not create more.")
+    end
+
+    def build_ideas(phase)
+      times = McpServer::DemoData.sample_times(
+        params[:inputs].size,
+        from: input_window_start(phase),
+        to: phase.end_at&.in_time_zone&.end_of_day || Time.zone.now,
+        event_times: phase.project.events.pluck(:start_at)
+      )
+      params[:inputs].zip(times).map { |attributes, time| build_idea(phase, attributes, time) }
+    end
+
+    def build_idea(phase, attributes, time)
+      location = attributes[:location]
+      Idea.new(
+        project: phase.project,
+        phases: [phase],
+        creation_phase: phase.pmethod.transitive? ? nil : phase,
+        publication_status: 'published',
+        author: McpServer::DemoData.build_author(time - rand(72).hours),
+        created_at: time,
+        published_at: time,
+        title_multiloc: attributes[:title_multiloc],
+        body_multiloc: attributes[:body_multiloc],
+        custom_field_values: attributes[:custom_field_values] || {},
+        budget: attributes[:budget],
+        location_description: location&.dig(:description),
+        location_point_geojson: location && { 'type' => 'Point', 'coordinates' => [location[:lng], location[:lat]] }
+      )
+    end
+
+    def input_window_start(phase)
+      start = phase.start_at.in_time_zone
+      expire_days = phase.expire_days_limit
+      return start unless phase.participation_method == 'proposals' && expire_days
+
+      # Proposals backdated past the expiry window would render as expired.
+      [start, (expire_days - 1).days.ago.beginning_of_day].max
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
@@ -9,6 +9,7 @@ class McpServer::Tools::GetResource < McpServer::BaseTool
     'area' => { model: Area, serializer: McpServer::Serializers::Area },
     'global_topic' => { model: GlobalTopic, serializer: McpServer::Serializers::GlobalTopic },
     'cause' => { model: Volunteering::Cause, serializer: McpServer::Serializers::Cause },
+    'input' => { model: Idea, serializer: McpServer::Serializers::Input },
     'poll_question' => { model: Polls::Question, serializer: McpServer::Serializers::PollQuestion },
     'poll_option' => { model: Polls::Option, serializer: McpServer::Serializers::PollOption }
   }.freeze

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -8,7 +8,9 @@ class McpServer::Tools::ListInputs < McpServer::BaseTool
     <<~DESC.squish
       Lists the published inputs (ideas, proposals or native survey responses) of a phase,
       newest first, in a lean row shape. Search by title or body. Read a single input's
-      full content (body, form answers) with get_resource type 'input'.
+      full content (body, form answers) with get_resource type 'input'. For bulk analysis
+      across many inputs (e.g. summarizing all survey answers), use run_reporting_sql_query
+      instead of paging through this tool.
     DESC
   end
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::ListInputs < McpServer::BaseTool
+  def name = 'list_inputs'
+  def annotations = READ_ANNOTATIONS
+
+  def description
+    <<~DESC.squish
+      Lists the published inputs (ideas, proposals or native survey responses) of a phase,
+      newest first, in a lean row shape. Search by title or body. Read a single input's
+      full content (body, form answers) with get_resource type 'input'.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        phase_id: { type: 'string', description: 'The ID of the phase to list the inputs of.' },
+        search: { type: 'string', description: 'Search by title or body' },
+        **PAGINATION_SCHEMA
+      },
+      required: %w[phase_id]
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    def run
+      phase = Phase.find_by(id: params[:phase_id])
+      return not_found_error('Phase', params[:phase_id]) unless phase
+
+      scope = phase.ideas.published.order(created_at: :desc)
+      scope = scope.search_by_all(params[:search]) if params[:search].present?
+
+      paginated_response(
+        'inputs',
+        scope,
+        **params.slice(:page, :per_page),
+        serializer: McpServer::Serializers::InputSummary
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
@@ -27,6 +27,7 @@ module McpServer::DemoData
       first_name: first_name,
       last_name: last_name,
       locale: AppConfiguration.instance.settings('core', 'locales').sample,
+      custom_field_values: RandomCustomFieldValuesService.new.generate(CustomField.registration.enabled),
       confirmation_required: false,
       email_confirmed_at: registered_at,
       registration_completed_at: registered_at,

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
@@ -21,8 +21,9 @@ module McpServer::DemoData
   def build_author(registered_at)
     first_name = Faker::Name.first_name
     last_name = Faker::Name.last_name
+    # parameterize: Faker names can contain apostrophes/accents, invalid in emails.
     User.new(
-      email: "#{first_name}.#{last_name}.#{SecureRandom.hex(4)}@#{EMAIL_DOMAIN}".downcase,
+      email: "#{"#{first_name}.#{last_name}".parameterize(separator: '.')}.#{SecureRandom.hex(4)}@#{EMAIL_DOMAIN}",
       first_name: first_name,
       last_name: last_name,
       locale: AppConfiguration.instance.settings('core', 'locales').sample,
@@ -52,7 +53,7 @@ module McpServer::DemoData
     Array.new(count) do
       target = rand * total
       day = weights.find_index { |weight| (target -= weight) <= 0 } || (days - 1)
-      [from + day.days + rand(86_400).seconds, now].min
+      [from + day.days + rand(86_400).seconds, to].min
     end
   end
 end

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
@@ -17,6 +17,14 @@ module McpServer::DemoData
     project.ideas.where(author: demo_users).count
   end
 
+  def user_ceiling_error_message(requested)
+    count = demo_users.count
+    return if count + requested <= MAX_USERS_PER_TENANT
+
+    "Demo user ceiling reached: this platform has #{count} demo users " \
+      "of max #{MAX_USERS_PER_TENANT}. Do not create more."
+  end
+
   # Built without a password, so demo users cannot sign in.
   def build_author(registered_at)
     first_name = Faker::Name.first_name

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# Shared machinery for the demo-data tools. The fixed email domain marks demo
+# users, so it doubles as the query key for ceilings and future cleanup.
+module McpServer::DemoData
+  EMAIL_DOMAIN = 'demo-users.govocal.com'
+  MAX_INPUTS_PER_PROJECT = 1_000
+  MAX_USERS_PER_TENANT = 5_000
+
+  module_function
+
+  def demo_users
+    User.where('email LIKE ?', "%@#{EMAIL_DOMAIN}")
+  end
+
+  def demo_input_count(project)
+    project.ideas.where(author: demo_users).count
+  end
+
+  # Built without a password, so demo users cannot sign in.
+  def build_author(registered_at)
+    first_name = Faker::Name.first_name
+    last_name = Faker::Name.last_name
+    User.new(
+      email: "#{first_name}.#{last_name}.#{SecureRandom.hex(4)}@#{EMAIL_DOMAIN}".downcase,
+      first_name: first_name,
+      last_name: last_name,
+      locale: AppConfiguration.instance.settings('core', 'locales').sample,
+      confirmation_required: false,
+      email_confirmed_at: registered_at,
+      registration_completed_at: registered_at,
+      created_at: registered_at
+    )
+  end
+
+  # Timestamps shaped like a real participation curve over [from, to] (clamped
+  # to the past): a launch spike decaying over time, with bumps around events.
+  def sample_times(count, from:, to:, event_times: [])
+    now = Time.zone.now
+    to = [to, now].min
+    return Array.new(count, now) if from >= to
+
+    days = ((to - from) / 1.day).ceil
+    event_days = event_times.filter_map { |time| ((time - from) / 1.day).floor if time.between?(from, to) }
+    weights = Array.new(days) do |day|
+      weight = 1.0 + (9.0 * Math.exp(-3.0 * day / days))
+      weight += 5.0 if event_days.any? { |event_day| (day - event_day).abs <= 1 }
+      weight
+    end
+
+    total = weights.sum
+    Array.new(count) do
+      target = rand * total
+      day = weights.find_index { |weight| (target -= weight) <= 0 } || (days - 1)
+      [from + day.days + rand(86_400).seconds, now].min
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_comments_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_comments_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::CreateDemoComments do
+  let(:current_user) { create(:super_admin) }
+  let(:idea) { create(:idea, created_at: 10.days.ago) }
+
+  def create_comments(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  def comment_input(body, idea_id: idea.id, **attributes)
+    { idea_id:, body_multiloc: { 'en' => body }, **attributes }
+  end
+
+  before { change_lifecycle_stage('demo') }
+
+  it 'creates comments with fake demo authors, backdated after the input' do
+    response = create_comments(comments: [comment_input('Great idea!'), comment_input('I disagree.')])
+
+    expect(response).not_to be_error
+    comments = idea.reload.comments
+    expect(response.structured_content[:comment_ids]).to match_array(comments.map(&:id))
+    expect(idea.comments_count).to eq(2)
+
+    comments.each do |comment|
+      expect(comment.author.email).to end_with("@#{McpServer::DemoData::EMAIL_DOMAIN}")
+      expect(comment.created_at).to be_between(idea.created_at, Time.zone.now)
+    end
+  end
+
+  it 'creates threaded replies after the parent comment' do
+    parent = create(:comment, idea: idea, created_at: 5.days.ago)
+
+    response = create_comments(comments: [comment_input('Well said.', parent_id: parent.id)])
+
+    expect(response).not_to be_error
+    reply = Comment.find(response.structured_content[:comment_ids].sole)
+    expect(reply.parent).to eq(parent)
+    expect(reply.created_at).to be_between(parent.created_at, Time.zone.now)
+  end
+
+  it 'refuses a parent comment from another input' do
+    parent = create(:comment, created_at: 5.days.ago)
+
+    response = create_comments(comments: [comment_input('Well said.', parent_id: parent.id)])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Parent comment on the same input not found')
+    expect(Comment.count).to eq(1)
+  end
+
+  it 'returns not found for an unknown idea' do
+    response = create_comments(comments: [comment_input('Great!', idea_id: 'unknown')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Idea not found')
+  end
+
+  it 'refuses on platforms that are not demo or trial' do
+    change_lifecycle_stage('active')
+
+    response = create_comments(comments: [comment_input('Great!')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('demo and trial platforms')
+    expect(Comment.count).to eq(0)
+  end
+
+  it 'refuses when the demo user ceiling is reached' do
+    stub_const('McpServer::DemoData::MAX_USERS_PER_TENANT', 1)
+
+    response = create_comments(comments: [comment_input('One'), comment_input('Two')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Demo user ceiling reached')
+    expect(Comment.count).to eq(0)
+  end
+
+  it 'returns validation errors per comment index and creates nothing' do
+    response = create_comments(comments: [comment_input('Fine.'), comment_input('')])
+
+    expect(response).to be_error
+    errors = response.structured_content[:errors]
+    expect(errors.sole[:index]).to eq(1)
+    expect(Comment.count).to eq(0)
+    expect(McpServer::DemoData.demo_users.count).to eq(0)
+  end
+
+  it 'refuses non-admin users' do
+    response = run_mcp_tool(
+      described_class,
+      params: { comments: [comment_input('Great!')] },
+      current_user: create(:user)
+    )
+
+    expect(response).to be_error
+    expect(Comment.count).to eq(0)
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_inputs_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_inputs_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::CreateDemoInputs do
+  let(:current_user) { create(:super_admin) }
+
+  def create_inputs(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  def idea_input(title)
+    {
+      title_multiloc: { 'en' => title },
+      body_multiloc: { 'en' => "<p>#{title}</p>" }
+    }
+  end
+
+  before { change_lifecycle_stage('demo') }
+
+  it 'creates ideation ideas with fake demo authors and backdated timestamps' do
+    create(:idea_status_proposed)
+    phase = create(:phase, start_at: 20.days.ago, end_at: 10.days.from_now)
+
+    response = create_inputs(
+      phase_id: phase.id,
+      inputs: [
+        idea_input('Bike lanes').merge(location: { lat: 50.85, lng: 4.35, description: 'Grand Place' }),
+        idea_input('More trees').merge(budget: 2500)
+      ]
+    )
+
+    expect(response).not_to be_error
+    ideas = phase.reload.ideas
+    expect(response.structured_content[:idea_ids]).to match_array(ideas.map(&:id))
+
+    ideas.each do |idea|
+      expect(idea).to be_published
+      expect(idea.author.email).to end_with("@#{McpServer::DemoData::EMAIL_DOMAIN}")
+      expect(idea.author.password_digest).to be_nil
+      expect(idea.created_at).to be_between(phase.start_at.in_time_zone, Time.zone.now)
+      expect(idea.published_at).to eq(idea.created_at)
+      expect(idea.creation_phase).to be_nil
+      expect(idea.idea_status.code).to eq('proposed')
+    end
+
+    bike_lanes = ideas.find { |idea| idea.title_multiloc['en'] == 'Bike lanes' }
+    expect(bike_lanes.location_description).to eq('Grand Place')
+    expect(bike_lanes.location_point.coordinates).to eq([4.35, 50.85])
+    more_trees = ideas.find { |idea| idea.title_multiloc['en'] == 'More trees' }
+    expect(more_trees.budget).to eq(2500)
+  end
+
+  it 'creates native survey responses' do
+    create(:idea_status_proposed)
+    phase = create(:native_survey_phase, start_at: 10.days.ago, end_at: 5.days.from_now)
+    form = create(:custom_form, participation_context: phase)
+    field = create(:custom_field, resource: form)
+
+    response = create_inputs(
+      phase_id: phase.id,
+      inputs: [{ custom_field_values: { field.key => 'An answer' } }]
+    )
+
+    expect(response).not_to be_error
+    survey_response = phase.reload.ideas.sole
+    expect(survey_response.creation_phase).to eq(phase)
+    expect(survey_response.custom_field_values).to eq(field.key => 'An answer')
+    expect(survey_response.author.email).to end_with("@#{McpServer::DemoData::EMAIL_DOMAIN}")
+  end
+
+  it 'keeps backdated proposals within the expiry window' do
+    create(:idea_status, :proposals, code: 'proposed')
+    phase = create(:proposals_phase, start_at: 200.days.ago, end_at: 5.days.from_now, expire_days_limit: 30)
+
+    response = create_inputs(phase_id: phase.id, inputs: [idea_input('Car-free Sundays')])
+
+    expect(response).not_to be_error
+    proposal = phase.reload.ideas.sole
+    expect(proposal.creation_phase).to eq(phase)
+    expect(proposal.created_at).to be > 30.days.ago
+  end
+
+  it 'refuses on platforms that are not demo or trial' do
+    change_lifecycle_stage('active')
+    phase = create(:phase)
+
+    response = create_inputs(phase_id: phase.id, inputs: [idea_input('Bike lanes')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('demo and trial platforms')
+    expect(Idea.count).to eq(0)
+  end
+
+  it 'returns validation errors per input index and creates nothing' do
+    create(:idea_status_proposed)
+    phase = create(:phase)
+
+    response = create_inputs(
+      phase_id: phase.id,
+      inputs: [idea_input('Bike lanes'), { body_multiloc: { 'en' => '<p>No title</p>' } }]
+    )
+
+    expect(response).to be_error
+    errors = response.structured_content[:errors]
+    expect(errors.sole[:index]).to eq(1)
+    expect(errors.sole[:errors].pluck(:attribute)).to include('title_multiloc')
+    expect(Idea.count).to eq(0)
+    expect(McpServer::DemoData.demo_users.count).to eq(0)
+  end
+
+  it 'refuses when the project demo input ceiling is reached' do
+    create(:idea_status_proposed)
+    phase = create(:phase)
+    stub_const('McpServer::DemoData::MAX_INPUTS_PER_PROJECT', 1)
+
+    response = create_inputs(phase_id: phase.id, inputs: [idea_input('One'), idea_input('Two')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Demo input ceiling reached')
+    expect(Idea.count).to eq(0)
+  end
+
+  it 'refuses when the platform demo user ceiling is reached' do
+    phase = create(:phase)
+    stub_const('McpServer::DemoData::MAX_USERS_PER_TENANT', 1)
+
+    response = create_inputs(phase_id: phase.id, inputs: [idea_input('One'), idea_input('Two')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Demo user ceiling reached')
+  end
+
+  it 'refuses non-admin users' do
+    create(:idea_status_proposed)
+    phase = create(:phase)
+
+    response = run_mcp_tool(
+      described_class,
+      params: { phase_id: phase.id, inputs: [idea_input('Bike lanes')] },
+      current_user: create(:user)
+    )
+
+    expect(response).to be_error
+    expect(Idea.count).to eq(0)
+  end
+
+  it 'returns not found for an unknown phase' do
+    response = create_inputs(phase_id: 'unknown', inputs: [idea_input('Bike lanes')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Phase not found')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
@@ -31,6 +31,19 @@ describe McpServer::Tools::GetResource do
     )
   end
 
+  it 'gets an input with its full content' do
+    idea = create(:idea)
+    response = get('input', idea.id)
+    expect(response).not_to be_error
+    expect(response.structured_content).to include(
+      id: idea.id,
+      title_multiloc: idea.title_multiloc,
+      body_multiloc: idea.body_multiloc,
+      author_name: idea.author.full_name,
+      public_url: be_present
+    )
+  end
+
   it 'gets an event' do
     event = create(:event)
     response = get('event', event.id)

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListInputs do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  def list(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  it 'lists the published inputs of a phase, newest first, in a lean row shape' do
+    phase = create(:phase)
+    old_idea = create(:idea, project: phase.project, phases: [phase], published_at: 2.days.ago, created_at: 2.days.ago)
+    new_idea = create(:idea, project: phase.project, phases: [phase])
+    create(:idea, project: phase.project, phases: [phase], publication_status: 'draft')
+    create(:idea) # other project
+
+    response = list(phase_id: phase.id)
+
+    expect(response).not_to be_error
+    rows = response.structured_content[:data]
+    expect(rows.pluck(:id)).to eq [new_idea.id, old_idea.id]
+    expect(rows.first).to match(
+      id: new_idea.id,
+      title_multiloc: new_idea.title_multiloc,
+      author_name: new_idea.author.full_name,
+      idea_status_code: new_idea.idea_status.code,
+      likes_count: 0,
+      dislikes_count: 0,
+      comments_count: 0,
+      budget: new_idea.budget,
+      published_at: be_present,
+      public_url: be_present
+    )
+    expect(rows.first).not_to have_key(:body_multiloc)
+  end
+
+  it 'searches by title' do
+    phase = create(:phase)
+    match = create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'Bike lanes now' })
+    create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'More trees' })
+
+    response = list(phase_id: phase.id, search: 'bike lanes')
+
+    expect(response.structured_content[:data].pluck(:id)).to eq [match.id]
+  end
+
+  it 'paginates' do
+    phase = create(:phase)
+    create_list(:idea, 3, project: phase.project, phases: [phase])
+
+    response = list(phase_id: phase.id, per_page: 2, page: 2)
+
+    expect(response.structured_content[:data].size).to eq(1)
+    expect(response.structured_content.dig(:pagination, :total_count)).to eq(3)
+  end
+
+  it 'returns not found for an unknown phase' do
+    response = list(phase_id: 'unknown')
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Phase not found')
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::DemoData do
+  describe '.demo_users' do
+    it 'returns only users on the demo email domain' do
+      demo_user = create(:user, email: "jane.doe.abcd@#{described_class::EMAIL_DOMAIN}")
+      create(:user)
+
+      expect(described_class.demo_users).to eq [demo_user]
+    end
+  end
+
+  describe '.build_author' do
+    it 'builds a valid, confirmed user on the demo domain without a password' do
+      registered_at = 3.days.ago
+      author = described_class.build_author(registered_at)
+
+      expect(author.save).to be true
+      expect(author.email).to end_with("@#{described_class::EMAIL_DOMAIN}")
+      expect(author.password_digest).to be_nil
+      expect(author.confirmation_required?).to be false
+      expect(author.registration_completed_at).to be_within(1.second).of(registered_at)
+      expect(author.created_at).to be_within(1.second).of(registered_at)
+      expect(AppConfiguration.instance.settings('core', 'locales')).to include(author.locale)
+    end
+  end
+
+  describe '.sample_times' do
+    it 'returns times within the range, never in the future' do
+      from = 30.days.ago
+      times = described_class.sample_times(20, from: from, to: 10.days.from_now)
+
+      expect(times.size).to eq(20)
+      expect(times).to all(be_between(from, Time.zone.now))
+    end
+
+    it 'returns the current time when the range lies in the future' do
+      times = described_class.sample_times(3, from: 2.days.from_now, to: 10.days.from_now)
+
+      expect(times).to all(be_within(1.second).of(Time.zone.now))
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
@@ -26,6 +26,16 @@ describe McpServer::DemoData do
       expect(AppConfiguration.instance.settings('core', 'locales')).to include(author.locale)
     end
 
+    it 'fills in random answers for enabled registration fields' do
+      gender = create(:custom_field_gender, :with_options, required: true)
+      create(:custom_field_checkbox, resource_type: 'User', key: 'disabled_one', enabled: false)
+
+      author = described_class.build_author(Time.zone.now)
+
+      expect(gender.options.map(&:key)).to include(author.custom_field_values[gender.key])
+      expect(author.custom_field_values).not_to have_key('disabled_one')
+    end
+
     it 'builds a valid email from names with apostrophes and accents' do
       allow(Faker::Name).to receive_messages(first_name: 'Zoë', last_name: "O'Conner")
 

--- a/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/services/mcp_server/demo_data_spec.rb
@@ -25,6 +25,15 @@ describe McpServer::DemoData do
       expect(author.created_at).to be_within(1.second).of(registered_at)
       expect(AppConfiguration.instance.settings('core', 'locales')).to include(author.locale)
     end
+
+    it 'builds a valid email from names with apostrophes and accents' do
+      allow(Faker::Name).to receive_messages(first_name: 'Zoë', last_name: "O'Conner")
+
+      author = described_class.build_author(Time.zone.now)
+
+      expect(author.save).to be true
+      expect(author.email).to match(/\Azoe\.o\.conner\.\h{8}@/)
+    end
   end
 
   describe '.sample_times' do
@@ -34,6 +43,13 @@ describe McpServer::DemoData do
 
       expect(times.size).to eq(20)
       expect(times).to all(be_between(from, Time.zone.now))
+    end
+
+    it 'keeps times within a range that ended in the past' do
+      from = 30.days.ago
+      to = 10.days.ago
+
+      expect(described_class.sample_times(20, from: from, to: to)).to all(be_between(from, to))
     end
 
     it 'returns the current time when the range lies in the future' do

--- a/back/engines/commercial/multi_tenancy/lib/tasks/demos/seed_native_survey_responses.rake
+++ b/back/engines/commercial/multi_tenancy/lib/tasks/demos/seed_native_survey_responses.rake
@@ -10,7 +10,6 @@
 #   - Only works on demo platforms or localhost
 #   - By default creates anonymous responses (no author)
 #   - Set anonymous=false to create a user for each response
-
 namespace :demos do
   desc 'Seed a native survey phase with dummy responses'
   task :seed_native_survey_responses, %i[host phase_id num_responses anonymous] => [:environment] do |_t, args|
@@ -58,16 +57,14 @@ namespace :demos do
   end
 end
 
-# rubocop:disable Metrics/ModuleLength
 module SeedNativeSurveyResponses
-  BUILTIN_USER_FIELDS = %w[first_name last_name email].freeze
-
   class << self
     def run(phase, num_responses, anonymous: true)
       @phase = phase
       @project = phase.project
       @locale = AppConfiguration.instance.settings('core', 'locales').first
       @anonymous = anonymous
+      @field_values = RandomCustomFieldValuesService.new
 
       puts "\n#{'=' * 80}"
       puts "Seeding #{num_responses} responses for phase: #{phase.title_multiloc[@locale] || phase.id}"
@@ -95,7 +92,7 @@ module SeedNativeSurveyResponses
       responses_created = 0
       users_created = 0
       num_responses.times do |i|
-        custom_field_values = generate_response(answerable_fields)
+        custom_field_values = @field_values.generate(answerable_fields)
 
         idea_attrs = {
           project: @project,
@@ -140,15 +137,13 @@ module SeedNativeSurveyResponses
       last_name = Faker::Name.last_name
       email = "#{first_name.downcase}.#{last_name.downcase}.#{SecureRandom.hex(4)}@example.com"
 
-      user_custom_field_values = generate_user_custom_field_values
-
       user = User.new(
         first_name: first_name,
         last_name: last_name,
         email: email,
         password: SecureRandom.hex(16),
         locale: @locale,
-        custom_field_values: user_custom_field_values,
+        custom_field_values: @field_values.generate(@user_fields),
         registration_completed_at: Time.current
       )
 
@@ -159,252 +154,5 @@ module SeedNativeSurveyResponses
         nil
       end
     end
-
-    def generate_user_custom_field_values
-      return {} if @user_fields.blank?
-
-      {}.tap do |values|
-        @user_fields.each do |field|
-          # Skip built-in fields that are handled separately
-          next if BUILTIN_USER_FIELDS.include?(field.code)
-          # Skip optional fields ~20% of the time
-          next if !field.required? && rand < 0.2
-
-          value = generate_user_field_value(field)
-          values[field.key] = value unless value.nil?
-        end
-      end
-    end
-
-    def generate_user_field_value(field)
-      case field.code
-      when 'birthyear'
-        generate_birthyear_value
-      when 'domicile'
-        generate_domicile_value
-      else
-        generate_value_for_field(field)
-      end
-    end
-
-    def generate_birthyear_value
-      # Generate a valid birthyear (age 18-80)
-      current_year = Time.zone.now.year
-      rand((current_year - 80)..(current_year - 18))
-    end
-
-    def generate_domicile_value
-      area_ids = Area.pluck(:id)
-      return nil if area_ids.empty?
-
-      # 90% chance of selecting an area, 10% chance of 'outside'
-      if rand < 0.1
-        'outside'
-      else
-        area_ids.sample
-      end
-    end
-
-    def generate_response(fields)
-      {}.tap do |values|
-        fields.each do |field|
-          # Skip optional fields ~20% of the time
-          next if !field.required? && rand < 0.2
-
-          value = generate_value_for_field(field)
-          values[field.key] = value unless value.nil?
-        end
-      end
-    end
-
-    def generate_value_for_field(field)
-      case field.input_type
-      when 'text', 'html', 'text_multiloc', 'html_multiloc'
-        generate_text_value(field)
-      when 'multiline_text', 'multiline_text_multiloc'
-        generate_multiline_text_value
-      when 'number'
-        generate_number_value(field)
-      when 'linear_scale', 'sentiment_linear_scale', 'rating'
-        generate_linear_scale_value(field)
-      when 'select', 'select_image'
-        generate_select_value(field)
-      when 'multiselect', 'multiselect_image'
-        generate_multiselect_value(field)
-      when 'checkbox'
-        generate_checkbox_value
-      when 'date'
-        generate_date_value
-      when 'ranking'
-        generate_ranking_value(field)
-      when 'matrix_linear_scale'
-        generate_matrix_value(field)
-      when 'point'
-        generate_point_value
-      when 'line'
-        generate_line_value
-      when 'polygon'
-        generate_polygon_value
-      end
-      # Returns nil for unsupported types like file_upload, shapefile_upload, files, image_files
-    end
-
-    def generate_text_value(field)
-      responses = [
-        'I think this is a great initiative.',
-        'More community involvement would help.',
-        'We need better infrastructure.',
-        'This could improve quality of life.',
-        'I support this proposal.',
-        'Environmental concerns should be prioritized.',
-        'Safety is my main concern.',
-        'This would benefit local businesses.',
-        'Education should be the focus.',
-        'We need more green spaces.'
-      ]
-
-      title = field.title_multiloc[@locale] || field.key
-      "#{responses.sample} (Re: #{title.truncate(30)})"
-    end
-
-    def generate_multiline_text_value
-      paragraphs = [
-        "This is an important topic that affects our community.\n\nI believe we should focus on sustainable solutions that benefit everyone.",
-        "After careful consideration, I think the proposed changes would be beneficial.\n\nHowever, we should also consider the long-term impacts.",
-        "My main concerns are:\n- Environmental impact\n- Community engagement\n- Budget allocation\n\nThese should be addressed before moving forward.",
-        "I appreciate the opportunity to provide feedback.\n\nOverall, I support the initiative but would like to see more details on implementation."
-      ]
-      paragraphs.sample
-    end
-
-    def generate_number_value(field)
-      max = field.maximum || 100
-      rand(1..max)
-    end
-
-    def generate_linear_scale_value(field)
-      max = field.maximum || 5
-      # Skew toward higher values (more positive responses)
-      weighted_random_scale(max)
-    end
-
-    def generate_select_value(field)
-      options = field.options.reject(&:other)
-      return nil if options.empty?
-
-      # Occasionally select 'other' option if available
-      other_option = field.options.find(&:other)
-      if other_option && rand < 0.1
-        other_option.key
-      else
-        # Weight earlier options more heavily for non-uniform distribution
-        weighted_random_option(options).key
-      end
-    end
-
-    def generate_multiselect_value(field)
-      options = field.options.reject(&:other)
-      return [] if options.empty?
-
-      # Select 1-3 random options
-      num_selections = rand(1..[3, options.count].min)
-      options.sample(num_selections).map(&:key)
-    end
-
-    def generate_checkbox_value
-      [true, false].sample
-    end
-
-    def generate_date_value
-      # Random date within the last year
-      rand(365).days.ago.to_date.iso8601
-    end
-
-    def generate_ranking_value(field)
-      options = field.options.reject(&:other)
-      return [] if options.empty?
-
-      # Return all options in random order
-      options.shuffle.map(&:key)
-    end
-
-    def generate_matrix_value(field)
-      statements = field.matrix_statements
-      return {} if statements.empty?
-
-      max = field.maximum || 5
-      {}.tap do |matrix|
-        statements.each do |statement|
-          # Skew toward higher values (more positive responses)
-          matrix[statement.key] = weighted_random_scale(max)
-        end
-      end
-    end
-
-    # Generate a weighted random scale value skewed toward higher values
-    # Creates a distribution where 4s and 5s are more common than 1s and 2s
-    def weighted_random_scale(max)
-      # Use a simple approach: pick from a weighted array
-      # For max=5: [1, 2, 2, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5]
-      weights = (1..max).flat_map { |n| Array.new(n, n) }
-      weights.sample
-    end
-
-    # Select an option with non-uniform weights (earlier options weighted more heavily)
-    def weighted_random_option(options)
-      return options.first if options.size == 1
-
-      # Assign decreasing weights: first option gets highest weight
-      # E.g., for 4 options: weights are [4, 3, 2, 1]
-      total_weight = options.size * (options.size + 1) / 2
-      random_point = rand(total_weight)
-
-      cumulative = 0
-      options.each_with_index do |option, index|
-        weight = options.size - index
-        cumulative += weight
-        return option if random_point < cumulative
-      end
-
-      options.last
-    end
-
-    def generate_point_value
-      # Generate a random point (roughly in Belgium area as default)
-      lat = 50.5 + (rand * 1.0)
-      lng = 3.5 + (rand * 2.0)
-      { 'type' => 'Point', 'coordinates' => [lng.round(6), lat.round(6)] }
-    end
-
-    def generate_line_value
-      # Generate a random line with 3-5 points
-      num_points = rand(3..5)
-      base_lat = 50.5 + (rand * 1.0)
-      base_lng = 3.5 + (rand * 2.0)
-
-      coordinates = Array.new(num_points) do |i|
-        [(base_lng + (i * 0.01)).round(6), (base_lat + (rand * 0.01)).round(6)]
-      end
-
-      { 'type' => 'LineString', 'coordinates' => coordinates }
-    end
-
-    def generate_polygon_value
-      # Generate a simple rectangular polygon
-      base_lat = 50.5 + (rand * 1.0)
-      base_lng = 3.5 + (rand * 2.0)
-      size = 0.01
-
-      coordinates = [
-        [base_lng.round(6), base_lat.round(6)],
-        [(base_lng + size).round(6), base_lat.round(6)],
-        [(base_lng + size).round(6), (base_lat + size).round(6)],
-        [base_lng.round(6), (base_lat + size).round(6)],
-        [base_lng.round(6), base_lat.round(6)] # Close the polygon
-      ]
-
-      { 'type' => 'Polygon', 'coordinates' => [coordinates] }
-    end
   end
 end
-# rubocop:enable Metrics/ModuleLength

--- a/back/spec/services/random_custom_field_values_service_spec.rb
+++ b/back/spec/services/random_custom_field_values_service_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe RandomCustomFieldValuesService do
+  subject(:service) { described_class.new }
+
+  it 'answers every required field with a type-appropriate value' do
+    select = create(:custom_field_select, :with_options, required: true)
+    checkbox = create(:custom_field_checkbox, required: true)
+    number = create(:custom_field_number, required: true, maximum: 10)
+
+    values = service.generate([select, checkbox, number])
+
+    expect(select.options.map(&:key)).to include(values[select.key])
+    expect(values[checkbox.key]).to be_in([true, false])
+    expect(values[number.key]).to be_between(1, 10)
+  end
+
+  it 'generates a birthyear for ages 18-80' do
+    birthyear = create(:custom_field_birthyear, required: true)
+
+    value = service.generate([birthyear])[birthyear.key]
+
+    expect(value).to be_between(Time.zone.now.year - 80, Time.zone.now.year - 18)
+  end
+
+  it 'generates a domicile from the platform areas' do
+    domicile = create(:custom_field_domicile, required: true)
+    area = create(:area)
+
+    value = service.generate([domicile])[domicile.key]
+
+    expect(value).to be_in([area.id, 'outside'])
+  end
+
+  it 'skips pages and unsupported types' do
+    page = create(:custom_field_page)
+    file_upload = create(:custom_field_file_upload, required: true)
+
+    expect(service.generate([page, file_upload])).to eq({})
+  end
+end


### PR DESCRIPTION
New `create_demo_inputs` MCP tool (TAN-8648): batch-creates demo ideas, proposals or survey responses in a phase.

The MCP client LLM writes the content; the backend adds fake authors (`@demo-users.govocal.com`, the domain marks demo data, no migrations) and backdates timestamps over the phase range shaped like a real participation curve.

Guards: demo/trial platforms only, 50 inputs/call, ceilings of 1,000 demo inputs/project and 5,000 demo users/tenant. No SideFx, all-or-nothing transaction. First commit: small `record_errors` helper extraction.

Testing: 13 new specs, engine suite green, verified over the wire on localhost.

🤖 Generated with Claude Code.

**_Note: Used this branch as a base branch to merge a number of additional MCP PRs into before release (so contains more code, but it has all been reviewed & approved)._**

# Changelog
# Added
- [TAN-8648] New MCP demo data tool for adding inputs (ideas, native surveys responses, proposals).