### PR TITLE
[TAN-8652] Add MCP tool for adding demo comments to inputs

### DIFF
--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -102,6 +102,7 @@ module McpServer
       McpServer::Tools::CreatePollQuestion,
       McpServer::Tools::CreatePollOption,
       McpServer::Tools::CreateDemoInputs,
+      McpServer::Tools::CreateDemoComments,
       McpServer::Tools::DestroyResource,
       McpServer::Tools::UpdateResource,
       McpServer::Tools::UpdateProject,

--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -115,6 +115,7 @@ module McpServer
       McpServer::Tools::ReplaceFormFields,
       McpServer::Tools::ListProjects,
       McpServer::Tools::ListPhases,
+      McpServer::Tools::ListInputs,
       McpServer::Tools::ListEvents,
       McpServer::Tools::ListCauses,
       McpServer::Tools::ListPollQuestions,

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class McpServer::Serializers::Input < McpServer::Serializers::Base
+  wraps ::WebApi::V1::IdeaSerializer
+
+  def attributes(record)
+    super.merge(**urls(record).compact)
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Lean row shape for input listings. Full content via get_resource type 'input'.
+class McpServer::Serializers::InputSummary < McpServer::Serializers::Base
+  def attributes(record)
+    {
+      id: record.id,
+      title_multiloc: record.title_multiloc,
+      author_name: record.author_name,
+      idea_status_code: record.idea_status&.code,
+      likes_count: record.likes_count,
+      dislikes_count: record.dislikes_count,
+      comments_count: record.comments_count,
+      budget: record.budget,
+      published_at: record.published_at,
+      **urls(record).compact
+    }
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_comments.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_comments.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::CreateDemoComments < McpServer::BaseTool
+  MAX_COMMENTS_PER_CALL = 50
+
+  def name = 'create_demo_comments'
+
+  def annotations
+    {
+      read_only_hint: false,
+      destructive_hint: false,
+      idempotent_hint: false,
+      open_world_hint: false
+    }
+  end
+
+  def description
+    <<~DESC.squish
+      Creates demo comments on inputs (ideas, proposals). Each comment gets a generated
+      fake demo author and a backdated timestamp after the input it comments on. Only
+      available on demo and trial platforms. Write comments that fit the input's content.
+      For threaded replies, create the top-level comments first, then pass their returned
+      IDs as parent_id in a second call. Max #{MAX_COMMENTS_PER_CALL} comments per call.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        comments: {
+          type: 'array',
+          minItems: 1,
+          maxItems: MAX_COMMENTS_PER_CALL,
+          items: {
+            type: 'object',
+            properties: {
+              idea_id: { type: 'string', description: 'The ID of the input to comment on.' },
+              body_multiloc: { **multiloc_schema, description: 'Comment body (HTML).' },
+              parent_id: {
+                type: 'string',
+                description: 'ID of an existing comment on the same input, to create a threaded reply.'
+              }
+            },
+            required: %w[idea_id body_multiloc],
+            additionalProperties: false
+          }
+        }
+      },
+      required: %w[comments],
+      additionalProperties: false
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    DEMO_ONLY_MESSAGE = 'Demo comments can only be created on demo and trial platforms.'
+
+    def run
+      return error(DEMO_ONLY_MESSAGE) unless published_writable_platform?
+
+      ideas = Idea.where(id: params[:comments].pluck(:idea_id)).index_by(&:id)
+      missing_idea_id = params[:comments].pluck(:idea_id).find { |id| !ideas[id] }
+      return not_found_error('Idea', missing_idea_id) if missing_idea_id
+
+      parents = Comment.where(id: params[:comments].pluck(:parent_id).compact).index_by(&:id)
+      bad_parent = params[:comments].find do |attributes|
+        attributes[:parent_id] && parents[attributes[:parent_id]]&.idea_id != attributes[:idea_id]
+      end
+      return not_found_error('Parent comment on the same input', bad_parent[:parent_id]) if bad_parent
+
+      ceiling_message = McpServer::DemoData.user_ceiling_error_message(params[:comments].size)
+      return error(ceiling_message) if ceiling_message
+
+      comments = params[:comments].map do |attributes|
+        build_comment(attributes, ideas[attributes[:idea_id]], parents[attributes[:parent_id]])
+      end
+      comments.each { |comment| authorize(comment, :create?) }
+
+      errors = comments.each_with_index.filter_map do |comment, index|
+        { index:, errors: record_errors(comment) } if comment.invalid?
+      end
+      return error('Validation failed:', structured: { errors: }) if errors.any?
+
+      ActiveRecord::Base.transaction do
+        comments.each do |comment|
+          comment.author.save!
+          comment.save!
+        end
+      end
+
+      response(
+        "Created #{comments.size} demo comments",
+        structured: { comment_ids: comments.map(&:id) }
+      )
+    rescue ActiveRecord::RecordInvalid => e
+      invalid_record_error(e.record)
+    end
+
+    private
+
+    def build_comment(attributes, idea, parent)
+      time = Faker::Time.between(from: [idea.created_at, parent&.created_at].compact.max, to: Time.zone.now)
+      Comment.new(
+        idea: idea,
+        parent: parent,
+        body_multiloc: attributes[:body_multiloc],
+        author: McpServer::DemoData.build_author(time - rand(72).hours),
+        created_at: time
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/create_demo_inputs.rb
@@ -120,11 +120,8 @@ class McpServer::Tools::CreateDemoInputs < McpServer::BaseTool
                      "of max #{McpServer::DemoData::MAX_INPUTS_PER_PROJECT}. Do not create more.")
       end
 
-      user_count = McpServer::DemoData.demo_users.count
-      return unless user_count + requested > McpServer::DemoData::MAX_USERS_PER_TENANT
-
-      error("Demo user ceiling reached: this platform has #{user_count} demo users " \
-            "of max #{McpServer::DemoData::MAX_USERS_PER_TENANT}. Do not create more.")
+      user_ceiling_message = McpServer::DemoData.user_ceiling_error_message(requested)
+      error(user_ceiling_message) if user_ceiling_message
     end
 
     def build_ideas(phase)

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
@@ -9,6 +9,7 @@ class McpServer::Tools::GetResource < McpServer::BaseTool
     'area' => { model: Area, serializer: McpServer::Serializers::Area },
     'global_topic' => { model: GlobalTopic, serializer: McpServer::Serializers::GlobalTopic },
     'cause' => { model: Volunteering::Cause, serializer: McpServer::Serializers::Cause },
+    'input' => { model: Idea, serializer: McpServer::Serializers::Input },
     'poll_question' => { model: Polls::Question, serializer: McpServer::Serializers::PollQuestion },
     'poll_option' => { model: Polls::Option, serializer: McpServer::Serializers::PollOption }
   }.freeze

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -8,7 +8,9 @@ class McpServer::Tools::ListInputs < McpServer::BaseTool
     <<~DESC.squish
       Lists the published inputs (ideas, proposals or native survey responses) of a phase,
       newest first, in a lean row shape. Search by title or body. Read a single input's
-      full content (body, form answers) with get_resource type 'input'.
+      full content (body, form answers) with get_resource type 'input'. For bulk analysis
+      across many inputs (e.g. summarizing all survey answers), use run_reporting_sql_query
+      instead of paging through this tool.
     DESC
   end
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::ListInputs < McpServer::BaseTool
+  def name = 'list_inputs'
+  def annotations = READ_ANNOTATIONS
+
+  def description
+    <<~DESC.squish
+      Lists the published inputs (ideas, proposals or native survey responses) of a phase,
+      newest first, in a lean row shape. Search by title or body. Read a single input's
+      full content (body, form answers) with get_resource type 'input'.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        phase_id: { type: 'string', description: 'The ID of the phase to list the inputs of.' },
+        search: { type: 'string', description: 'Search by title or body' },
+        **PAGINATION_SCHEMA
+      },
+      required: %w[phase_id]
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    def run
+      phase = Phase.find_by(id: params[:phase_id])
+      return not_found_error('Phase', params[:phase_id]) unless phase
+
+      scope = phase.ideas.published.order(created_at: :desc)
+      scope = scope.search_by_all(params[:search]) if params[:search].present?
+
+      paginated_response(
+        'inputs',
+        scope,
+        **params.slice(:page, :per_page),
+        serializer: McpServer::Serializers::InputSummary
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
+++ b/back/engines/commercial/mcp_server/app/services/mcp_server/demo_data.rb
@@ -17,6 +17,14 @@ module McpServer::DemoData
     project.ideas.where(author: demo_users).count
   end
 
+  def user_ceiling_error_message(requested)
+    count = demo_users.count
+    return if count + requested <= MAX_USERS_PER_TENANT
+
+    "Demo user ceiling reached: this platform has #{count} demo users " \
+      "of max #{MAX_USERS_PER_TENANT}. Do not create more."
+  end
+
   # Built without a password, so demo users cannot sign in.
   def build_author(registered_at)
     first_name = Faker::Name.first_name

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_comments_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/create_demo_comments_spec.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::CreateDemoComments do
+  let(:current_user) { create(:super_admin) }
+  let(:idea) { create(:idea, created_at: 10.days.ago) }
+
+  def create_comments(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  def comment_input(body, idea_id: idea.id, **attributes)
+    { idea_id:, body_multiloc: { 'en' => body }, **attributes }
+  end
+
+  before { change_lifecycle_stage('demo') }
+
+  it 'creates comments with fake demo authors, backdated after the input' do
+    response = create_comments(comments: [comment_input('Great idea!'), comment_input('I disagree.')])
+
+    expect(response).not_to be_error
+    comments = idea.reload.comments
+    expect(response.structured_content[:comment_ids]).to match_array(comments.map(&:id))
+    expect(idea.comments_count).to eq(2)
+
+    comments.each do |comment|
+      expect(comment.author.email).to end_with("@#{McpServer::DemoData::EMAIL_DOMAIN}")
+      expect(comment.created_at).to be_between(idea.created_at, Time.zone.now)
+    end
+  end
+
+  it 'creates threaded replies after the parent comment' do
+    parent = create(:comment, idea: idea, created_at: 5.days.ago)
+
+    response = create_comments(comments: [comment_input('Well said.', parent_id: parent.id)])
+
+    expect(response).not_to be_error
+    reply = Comment.find(response.structured_content[:comment_ids].sole)
+    expect(reply.parent).to eq(parent)
+    expect(reply.created_at).to be_between(parent.created_at, Time.zone.now)
+  end
+
+  it 'refuses a parent comment from another input' do
+    parent = create(:comment, created_at: 5.days.ago)
+
+    response = create_comments(comments: [comment_input('Well said.', parent_id: parent.id)])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Parent comment on the same input not found')
+    expect(Comment.count).to eq(1)
+  end
+
+  it 'returns not found for an unknown idea' do
+    response = create_comments(comments: [comment_input('Great!', idea_id: 'unknown')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Idea not found')
+  end
+
+  it 'refuses on platforms that are not demo or trial' do
+    change_lifecycle_stage('active')
+
+    response = create_comments(comments: [comment_input('Great!')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('demo and trial platforms')
+    expect(Comment.count).to eq(0)
+  end
+
+  it 'refuses when the demo user ceiling is reached' do
+    stub_const('McpServer::DemoData::MAX_USERS_PER_TENANT', 1)
+
+    response = create_comments(comments: [comment_input('One'), comment_input('Two')])
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Demo user ceiling reached')
+    expect(Comment.count).to eq(0)
+  end
+
+  it 'returns validation errors per comment index and creates nothing' do
+    response = create_comments(comments: [comment_input('Fine.'), comment_input('')])
+
+    expect(response).to be_error
+    errors = response.structured_content[:errors]
+    expect(errors.sole[:index]).to eq(1)
+    expect(Comment.count).to eq(0)
+    expect(McpServer::DemoData.demo_users.count).to eq(0)
+  end
+
+  it 'refuses non-admin users' do
+    response = run_mcp_tool(
+      described_class,
+      params: { comments: [comment_input('Great!')] },
+      current_user: create(:user)
+    )
+
+    expect(response).to be_error
+    expect(Comment.count).to eq(0)
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
@@ -31,6 +31,19 @@ describe McpServer::Tools::GetResource do
     )
   end
 
+  it 'gets an input with its full content' do
+    idea = create(:idea)
+    response = get('input', idea.id)
+    expect(response).not_to be_error
+    expect(response.structured_content).to include(
+      id: idea.id,
+      title_multiloc: idea.title_multiloc,
+      body_multiloc: idea.body_multiloc,
+      author_name: idea.author.full_name,
+      public_url: be_present
+    )
+  end
+
   it 'gets an event' do
     event = create(:event)
     response = get('event', event.id)

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListInputs do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  def list(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  it 'lists the published inputs of a phase, newest first, in a lean row shape' do
+    phase = create(:phase)
+    old_idea = create(:idea, project: phase.project, phases: [phase], published_at: 2.days.ago, created_at: 2.days.ago)
+    new_idea = create(:idea, project: phase.project, phases: [phase])
+    create(:idea, project: phase.project, phases: [phase], publication_status: 'draft')
+    create(:idea) # other project
+
+    response = list(phase_id: phase.id)
+
+    expect(response).not_to be_error
+    rows = response.structured_content[:data]
+    expect(rows.pluck(:id)).to eq [new_idea.id, old_idea.id]
+    expect(rows.first).to match(
+      id: new_idea.id,
+      title_multiloc: new_idea.title_multiloc,
+      author_name: new_idea.author.full_name,
+      idea_status_code: new_idea.idea_status.code,
+      likes_count: 0,
+      dislikes_count: 0,
+      comments_count: 0,
+      budget: new_idea.budget,
+      published_at: be_present,
+      public_url: be_present
+    )
+    expect(rows.first).not_to have_key(:body_multiloc)
+  end
+
+  it 'searches by title' do
+    phase = create(:phase)
+    match = create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'Bike lanes now' })
+    create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'More trees' })
+
+    response = list(phase_id: phase.id, search: 'bike lanes')
+
+    expect(response.structured_content[:data].pluck(:id)).to eq [match.id]
+  end
+
+  it 'paginates' do
+    phase = create(:phase)
+    create_list(:idea, 3, project: phase.project, phases: [phase])
+
+    response = list(phase_id: phase.id, per_page: 2, page: 2)
+
+    expect(response.structured_content[:data].size).to eq(1)
+    expect(response.structured_content.dig(:pagination, :total_count)).to eq(3)
+  end
+
+  it 'returns not found for an unknown phase' do
+    response = list(phase_id: 'unknown')
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Phase not found')
+  end
+end


### PR DESCRIPTION
New `create_demo_comments` MCP tool (TAN-8652): batch-creates demo comments on
inputs. The MCP client LLM writes the text; the backend adds fake demo authors
(with demographics, per TAN-8649) and backdates each comment after its input.
Threaded replies via `parent_id` from a previous call's returned IDs.

Guards: demo/trial platforms only, 50/call, bounded by the shared 5k demo-user
ceiling (now extracted into `DemoData.user_ceiling_error_message`, reused by
`create_demo_inputs`). No SideFx; counter caches stay correct via counter_culture.

:star: **Note: the LLM must already know the input IDs/content (same session, or
reporting SQL) — a `list_inputs`/`get_input` read pair is the planned follow-up.**

Testing: 8 new specs, full suite green, verified live (9 comments incl. 3
threaded replies, counts/timestamps checked in DB).

🤖 Generated with Claude Code

# Changelog
## Added
- [TAN-8652] Add MCP tool for adding demo comments to inputs.