### PR TITLE
[TAN-8659] Add list_inputs tool and input type on get_resource

### DIFF
--- a/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
+++ b/back/engines/commercial/mcp_server/app/controllers/mcp_server/mcp_controller.rb
@@ -115,6 +115,7 @@ module McpServer
       McpServer::Tools::ReplaceFormFields,
       McpServer::Tools::ListProjects,
       McpServer::Tools::ListPhases,
+      McpServer::Tools::ListInputs,
       McpServer::Tools::ListEvents,
       McpServer::Tools::ListCauses,
       McpServer::Tools::ListPollQuestions,

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class McpServer::Serializers::Input < McpServer::Serializers::Base
+  wraps ::WebApi::V1::IdeaSerializer
+
+  def attributes(record)
+    super.merge(**urls(record).compact)
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/serializers/input_summary.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Lean row shape for input listings. Full content via get_resource type 'input'.
+class McpServer::Serializers::InputSummary < McpServer::Serializers::Base
+  def attributes(record)
+    {
+      id: record.id,
+      title_multiloc: record.title_multiloc,
+      author_name: record.author_name,
+      idea_status_code: record.idea_status&.code,
+      likes_count: record.likes_count,
+      dislikes_count: record.dislikes_count,
+      comments_count: record.comments_count,
+      budget: record.budget,
+      published_at: record.published_at,
+      **urls(record).compact
+    }
+  end
+end

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/get_resource.rb
@@ -9,6 +9,7 @@ class McpServer::Tools::GetResource < McpServer::BaseTool
     'area' => { model: Area, serializer: McpServer::Serializers::Area },
     'global_topic' => { model: GlobalTopic, serializer: McpServer::Serializers::GlobalTopic },
     'cause' => { model: Volunteering::Cause, serializer: McpServer::Serializers::Cause },
+    'input' => { model: Idea, serializer: McpServer::Serializers::Input },
     'poll_question' => { model: Polls::Question, serializer: McpServer::Serializers::PollQuestion },
     'poll_option' => { model: Polls::Option, serializer: McpServer::Serializers::PollOption }
   }.freeze

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -8,7 +8,9 @@ class McpServer::Tools::ListInputs < McpServer::BaseTool
     <<~DESC.squish
       Lists the published inputs (ideas, proposals or native survey responses) of a phase,
       newest first, in a lean row shape. Search by title or body. Read a single input's
-      full content (body, form answers) with get_resource type 'input'.
+      full content (body, form answers) with get_resource type 'input'. For bulk analysis
+      across many inputs (e.g. summarizing all survey answers), use run_reporting_sql_query
+      instead of paging through this tool.
     DESC
   end
 

--- a/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
+++ b/back/engines/commercial/mcp_server/app/lib/mcp_server/tools/list_inputs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+class McpServer::Tools::ListInputs < McpServer::BaseTool
+  def name = 'list_inputs'
+  def annotations = READ_ANNOTATIONS
+
+  def description
+    <<~DESC.squish
+      Lists the published inputs (ideas, proposals or native survey responses) of a phase,
+      newest first, in a lean row shape. Search by title or body. Read a single input's
+      full content (body, form answers) with get_resource type 'input'.
+    DESC
+  end
+
+  def input_schema
+    {
+      properties: {
+        phase_id: { type: 'string', description: 'The ID of the phase to list the inputs of.' },
+        search: { type: 'string', description: 'Search by title or body' },
+        **PAGINATION_SCHEMA
+      },
+      required: %w[phase_id]
+    }
+  end
+
+  class Runner < McpServer::BaseTool::Runner
+    def run
+      phase = Phase.find_by(id: params[:phase_id])
+      return not_found_error('Phase', params[:phase_id]) unless phase
+
+      scope = phase.ideas.published.order(created_at: :desc)
+      scope = scope.search_by_all(params[:search]) if params[:search].present?
+
+      paginated_response(
+        'inputs',
+        scope,
+        **params.slice(:page, :per_page),
+        serializer: McpServer::Serializers::InputSummary
+      )
+    end
+  end
+end

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/get_resource_spec.rb
@@ -31,6 +31,19 @@ describe McpServer::Tools::GetResource do
     )
   end
 
+  it 'gets an input with its full content' do
+    idea = create(:idea)
+    response = get('input', idea.id)
+    expect(response).not_to be_error
+    expect(response.structured_content).to include(
+      id: idea.id,
+      title_multiloc: idea.title_multiloc,
+      body_multiloc: idea.body_multiloc,
+      author_name: idea.author.full_name,
+      public_url: be_present
+    )
+  end
+
   it 'gets an event' do
     event = create(:event)
     response = get('event', event.id)

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/list_inputs_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe McpServer::Tools::ListInputs do
+  let_it_be(:current_user) { create(:super_admin) }
+
+  def list(params)
+    run_mcp_tool(described_class, params:, current_user:)
+  end
+
+  it 'lists the published inputs of a phase, newest first, in a lean row shape' do
+    phase = create(:phase)
+    old_idea = create(:idea, project: phase.project, phases: [phase], published_at: 2.days.ago, created_at: 2.days.ago)
+    new_idea = create(:idea, project: phase.project, phases: [phase])
+    create(:idea, project: phase.project, phases: [phase], publication_status: 'draft')
+    create(:idea) # other project
+
+    response = list(phase_id: phase.id)
+
+    expect(response).not_to be_error
+    rows = response.structured_content[:data]
+    expect(rows.pluck(:id)).to eq [new_idea.id, old_idea.id]
+    expect(rows.first).to match(
+      id: new_idea.id,
+      title_multiloc: new_idea.title_multiloc,
+      author_name: new_idea.author.full_name,
+      idea_status_code: new_idea.idea_status.code,
+      likes_count: 0,
+      dislikes_count: 0,
+      comments_count: 0,
+      budget: new_idea.budget,
+      published_at: be_present,
+      public_url: be_present
+    )
+    expect(rows.first).not_to have_key(:body_multiloc)
+  end
+
+  it 'searches by title' do
+    phase = create(:phase)
+    match = create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'Bike lanes now' })
+    create(:idea, project: phase.project, phases: [phase], title_multiloc: { 'en' => 'More trees' })
+
+    response = list(phase_id: phase.id, search: 'bike lanes')
+
+    expect(response.structured_content[:data].pluck(:id)).to eq [match.id]
+  end
+
+  it 'paginates' do
+    phase = create(:phase)
+    create_list(:idea, 3, project: phase.project, phases: [phase])
+
+    response = list(phase_id: phase.id, per_page: 2, page: 2)
+
+    expect(response.structured_content[:data].size).to eq(1)
+    expect(response.structured_content.dig(:pagination, :total_count)).to eq(3)
+  end
+
+  it 'returns not found for an unknown phase' do
+    response = list(phase_id: 'unknown')
+
+    expect(response).to be_error
+    expect(response.content.first[:text]).to include('Phase not found')
+  end
+end


### PR DESCRIPTION
New read surface for inputs (TAN-8659): `list_inputs` returns a phase's
published inputs — lean paginated rows (no bodies) with title/body search;
full content comes from `get_resource` via a new `input` type wrapping the
web API's IdeaSerializer.

Closes the create_demo_comments caveat: the LLM can now discover and read
existing inputs before commenting. Also the read half of "iterate on seeded
ideas" (writes still pending).

Testing: 5 new specs, engine suite green, verified live over MCP
(list → search → get full → comment on a discovered idea).

🤖 Generated with Claude Code

# Changelog
## Added
[TAN-8659] MCP: Add list_inputs MCP tool and input type on get_resource
