### PR TITLE
[TAN-8612] Always epic artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,6 +76,18 @@ parameters:
     type: boolean
     default: false
 
+  # Set by .circleci/monorepo.sh for the halves whose full workflow it is
+  # NOT triggering: epic previews (cl2-deployment/epic, TAN-8612) deploy
+  # the head sha of every labelled PR and need the back image and the
+  # front bundle to exist for every push.
+  epic_back_artifact:
+    type: boolean
+    default: false
+
+  epic_front_artifact:
+    type: boolean
+    default: false
+
 executors:
   cl2-back:
     parameters:
@@ -223,11 +235,19 @@ jobs:
     working_directory: ~/
     docker:
       - image: cimg/base:2025.01
+    parameters:
+      docker_layer_caching:
+        type: boolean
+        # DLC bills a flat 200 credits per job run on top of the compute
+        # minutes: worth it on the developer-facing path (warm build ~20 s),
+        # not for the epic-artifact fallback (cold build ~3-5 min, nothing
+        # urgent waits on it).
+        default: true
     steps:
       - echo_pipeline_parameters
       - shallow-clone
       - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: << parameters.docker_layer_caching >>
       - run: |
           docker build -t citizenlabdotco/back-ee:amd64-$CIRCLE_SHA1 --build-arg BUNDLE_JOBS=4 -f citizenlab/back/Dockerfile citizenlab/.
       - run: |
@@ -1411,6 +1431,33 @@ workflows:
             branches:
               only:
                 - master
+
+  # Epic previews need both artifacts for every sha; monorepo.sh sets
+  # these parameters exactly for the halves it is not building through the
+  # full workflows (including pushes where nothing changed at all). No
+  # Docker layer caching on the image build: DLC bills a flat 200 credits
+  # per job run, several times this job's cold build time.
+  epic-back-artifact:
+    when:
+      and:
+        - << pipeline.parameters.epic_back_artifact >>
+        - not:
+            equal: ["production", << pipeline.git.branch >>]
+    jobs:
+      - back-build-docker-image-amd64:
+          context:
+            - docker-hub-access
+          docker_layer_caching: false
+
+  epic-front-artifact:
+    when:
+      and:
+        - << pipeline.parameters.epic_front_artifact >>
+        - not:
+            equal: ["production", << pipeline.git.branch >>]
+    jobs:
+      - front-build:
+          context: epic-front-bundles
 
   front-deploy-staging:
     when:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,10 +76,8 @@ parameters:
     type: boolean
     default: false
 
-  # Set by .circleci/monorepo.sh for the halves whose full workflow it is
-  # NOT triggering: epic previews (cl2-deployment/epic, TAN-8612) deploy
-  # the head sha of every labelled PR and need the back image and the
-  # front bundle to exist for every push.
+  # Set by .circleci/monorepo.sh in case nothing changed in back/front. This
+  # causes the builds to still happen, necessary for the epic platform
   epic_back_artifact:
     type: boolean
     default: false
@@ -238,10 +236,8 @@ jobs:
     parameters:
       docker_layer_caching:
         type: boolean
-        # DLC bills a flat 200 credits per job run on top of the compute
-        # minutes: worth it on the developer-facing path (warm build ~20 s),
-        # not for the epic-artifact fallback (cold build ~3-5 min, nothing
-        # urgent waits on it).
+        # DLC bills costs 200 credits per job run, and the extra speed is not
+        # always needed
         default: true
     steps:
       - echo_pipeline_parameters
@@ -1432,11 +1428,8 @@ workflows:
               only:
                 - master
 
-  # Epic previews need both artifacts for every sha; monorepo.sh sets
-  # these parameters exactly for the halves it is not building through the
-  # full workflows (including pushes where nothing changed at all). No
-  # Docker layer caching on the image build: DLC bills a flat 200 credits
-  # per job run, several times this job's cold build time.
+  # Epic previews need both artifacts to be built for every sha; monorepo.sh
+  # sets these parameters only in case nothing has changed on back/front
   epic-back-artifact:
     when:
       and:

--- a/.circleci/monorepo.sh
+++ b/.circleci/monorepo.sh
@@ -148,9 +148,13 @@ function print_status {
 
 function create_request_body {
   echo "$1" | 
-  jq --raw-output --arg branch "${CIRCLE_BRANCH}" --arg trigger "${TRIGGER_PARAM_NAME}" --argjson params "${CI_PARAMETERS:-null}" '. | 
+  jq --raw-output --arg branch "${CIRCLE_BRANCH}" --arg trigger "${TRIGGER_PARAM_NAME}" --argjson params "${CI_PARAMETERS:-null}" '. as $statuses | 
+    def uncovered(p): ($statuses | map(select(.package == p)) | first | .changes // 1) == 0;
+    . | 
     map(select(.changes > 0)) | 
     reduce .[] as $i (($params // {}) * { ($trigger): false }; .[$i.package] = true) | 
+    .epic_back_artifact = uncovered("back") | 
+    .epic_front_artifact = uncovered("front") | 
     { branch: $branch, parameters: . } | 
     @json'
 }
@@ -241,11 +245,10 @@ function main {
 
   echo "Number of packages changed: ${changed_packages} / ${total_packages}"
 
-  if [[ "${changed_packages}" != "0" ]]; then
-    create_pipeline "$( create_request_body "${statuses}" )"
-  else
-    echo "No changes in packages. Skip workflow trigger."
+  if [[ "${changed_packages}" == "0" ]]; then
+    echo "No changes in packages. Triggering only the epic artifact builds."
   fi
+  create_pipeline "$( create_request_body "${statuses}" )"
 
   if [[ "${MONOREPO_DEBUG}" == "true" ]]; then
     debug


### PR DESCRIPTION
This changes assures that, in all cases, a back-end and front-end build happen, even if no change has been made. This is needed for epic deployments to work reliably (both in the old and the new epic platform), as they depend on CI to provide the built assets.