### PR TITLE
[TAN-8584] Import ideas with PDF Scans : increase rubyllm timeout

### DIFF
--- a/back/config/initializers/ruby_llm.rb
+++ b/back/config/initializers/ruby_llm.rb
@@ -4,6 +4,7 @@ RubyLLM.configure do |config|
   config.bedrock_secret_key = ENV.fetch('AWS_SECRET_ACCESS_KEY', nil)
   config.bedrock_api_key = ENV.fetch('AWS_ACCESS_KEY_ID', nil)
   config.bedrock_region = ENV.fetch('AWS_TOXICITY_DETECTION_REGION', nil)
+  config.request_timeout = 900
 end
 
 # The model refresh can fail if the remote service is unavailable. We had to choose

--- a/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
+++ b/back/engines/commercial/bulk_import_ideas/app/services/bulk_import_ideas/parsers/pdf/llm_form_parser.rb
@@ -39,6 +39,10 @@ module BulkImportIdeas::Parsers::Pdf
         raise unless e.message.include?('grammar is too large')
 
         response = llm.chat(message)
+      rescue RubyLLM::ForbiddenError => e
+        raise unless e.message.include?('Signature expired')
+
+        raise BulkImportIdeas::Error.new 'bulk_import_pdf_parsing_timeout', value: file_uploader.url
       end
       parse_response(response)
     end

--- a/front/app/components/UI/Error/messages.ts
+++ b/front/app/components/UI/Error/messages.ts
@@ -296,6 +296,11 @@ export default defineMessages({
     defaultMessage:
       'The uploaded PDF file appears to be malformed. Try exporting the PDF again from your source and then upload again.',
   },
+  bulk_import_pdf_parsing_timeout: {
+    id: 'app.errors.bulk_import_pdf_parsing_timeout',
+    defaultMessage:
+      'The uploaded PDF is taking too long to process. Try exporting the PDF again from your source and then upload again.',
+  },
   bulk_import_maximum_pdf_pages_exceeded: {
     id: 'app.errors.bulk_import_maximum_pdf_pages_exceeded',
     defaultMessage: 'The maximum of {value} pages in a PDF has been exceeded.',

--- a/front/app/translations/en.json
+++ b/front/app/translations/en.json
@@ -2604,6 +2604,7 @@
   "app.errors.bulk_import_maximum_pdf_pages_exceeded": "The maximum of {value} pages in a PDF has been exceeded.",
   "app.errors.bulk_import_not_enough_pdf_pages": "The uploaded PDF does not have enough pages - it should have at least the same number of pages as the downloaded template.",
   "app.errors.bulk_import_pdf_pages_not_divisible": "The total number of pages in the PDF must be evenly divisible by the specified number of pages per form.",
+  "app.errors.bulk_import_pdf_parsing_timeout": "The uploaded PDF is taking too long to process. Try exporting the PDF again from your source and then upload again.",
   "app.errors.bulk_import_publication_date_invalid_format": "Idea with invalid publication date format \"{value}\". Please use the format \"DD-MM-YYYY\".",
   "app.errors.bulk_import_user_not_valid": "A user could not be created from the import data: {value}. This issue occurs in the row with ID {row}.",
   "app.errors.cannot_contain_ideas": "The participation method you selected does not support this type of post. Please edit your selection and try again.",


### PR DESCRIPTION
# Changelog
## Added
- a new error is shown to the user when the LLM request takes longer than 15 min
## Changed
- LLM request timeout increase to 15 minutes (default was 5 minutes)
## Technical
- RubyLLM doesn't provide a proper time out error, it throws a `RubyLLM::ForbiddenError` because AWS is responding with a "Signature expired" when retrying after a time out. We only managed this specific case for now without a proper retry because the import process already took a long time without user feedback.

# For translators
The new error message is displayed when the PDF scan import failed : 
<img width="615" height="356" alt="Capture d’écran 2026-09-09 à 14 07 22" src="https://github.com/user-attachments/assets/49be1bb0-6f63-41b7-8056-d10a511e6160" />