### PR TITLE
TAN-8639 Fix image and formatting disappearing on submit idea

### DIFF
--- a/back/app/services/export/xlsx/utils.rb
+++ b/back/app/services/export/xlsx/utils.rb
@@ -39,6 +39,14 @@ module Export
         sanitized_name
       end
 
+      # `HtmlToPlainText#convert_to_text` starts with `txt = html` and then rewrites it with
+      # `gsub!`, so it edits the very string it is handed. Callers read that string off a record
+      # - `MultilocService#t` returns the string held in the multiloc itself - so without a copy
+      # the record is rewritten in memory, and the next save of it persists plain text.
+      def convert_to_text(html, *)
+        super(html.dup, *)
+      end
+
       def convert_to_text_long_lines(html)
         convert_to_text(html).tr("\n", ' ')
       end

--- a/back/engines/commercial/flag_inappropriate_content/spec/services/toxicity_detection_service_spec.rb
+++ b/back/engines/commercial/flag_inappropriate_content/spec/services/toxicity_detection_service_spec.rb
@@ -126,6 +126,24 @@ describe FlagInappropriateContent::ToxicityDetectionService do
 
       expect(service.check_toxicity(comment)).to be_nil
     end
+
+    # Serializing the input to text used to rewrite the body in place, images and all, and the
+    # caller then persisted that flattened body on its next save of the same object.
+    it 'leaves the input it serializes untouched' do
+      html = '<p><img data-cl2-text-image-text-reference="c0ffee">Trees for the square</p>'
+      idea = create(:idea, body_multiloc: { 'en' => html.dup })
+
+      expect(llm).to receive(:chat) do |prompt, **|
+        expect(prompt).to include 'Trees for the square'
+        expect(prompt).not_to include '<p>'
+        { 'category' => 'E', 'reason' => 'Not toxic.' }
+      end
+
+      service.check_toxicity(idea, attributes: %i[title_multiloc body_multiloc])
+
+      expect(idea).not_to be_changed
+      expect(idea.body_multiloc).to eq({ 'en' => html })
+    end
   end
 
   private

--- a/back/spec/services/export/xlsx/utils_spec.rb
+++ b/back/spec/services/export/xlsx/utils_spec.rb
@@ -26,10 +26,33 @@ describe Export::Xlsx::Utils do
     end
   end
 
+  describe 'convert_to_text' do
+    # The gem edits the string it is given in place. Callers pass a value read off a record, so
+    # a conversion that rewrote it would flatten the record itself and be saved from there.
+    it 'leaves the html it is given untouched' do
+      html = +'<p><img src="https://example.com/tree.png">Trees for the square</p>'
+
+      expect(service.convert_to_text(html)).to eq 'Trees for the square'
+      expect(html).to eq '<p><img src="https://example.com/tree.png">Trees for the square</p>'
+    end
+
+    it 'accepts a frozen string' do
+      expect(service.convert_to_text('<p>line1</p>')).to eq 'line1'
+    end
+  end
+
   describe 'convert_to_text_long_lines' do
     it 'converts html to text and replaces each newline by a space' do
       actual = service.convert_to_text_long_lines(+"<p>line1<p>\n<strong>line2</strong>")
       expect(actual).to eq 'line1 line2'
+    end
+
+    it 'leaves the html it is given untouched' do
+      html = +'<p>line1<p>line2'
+
+      service.convert_to_text_long_lines(html)
+
+      expect(html).to eq '<p>line1<p>line2'
     end
   end
 


### PR DESCRIPTION
# Changelog
## Fixed
- Clients who had toxicity detection on: ideas were stripped to plain text, removing images and formatting. Now should be resolved.