### PR TITLE
Permission overrides based on FFs

### DIFF
--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -131,6 +131,12 @@ class Permission < ApplicationRecord
     false
   end
 
+  def require_confirmed_phone_number
+    return false unless AppConfiguration.instance.feature_activated?('sms')
+
+    super
+  end
+
   def everyone_tracking_enabled?
     permitted_by == 'everyone' && everyone_tracking_enabled
   end

--- a/back/app/models/permission.rb
+++ b/back/app/models/permission.rb
@@ -124,17 +124,46 @@ class Permission < ApplicationRecord
   end
 
   def verification_enabled?
-    # Verification can be enabled by the require_verification attribute OR by a verification group
+    # Verification can be enabled by the require_verification attribute OR by a verification group.
+    # Neither means anything without a method to be verified by. A verification group does still
+    # restrict membership, which is reported separately.
+    return false unless verification_possible?
     return true if require_verification
     return true if groups.any? && Verification::VerificationService.new.find_verification_group(groups)
 
     false
   end
 
+  # The settings below are masked rather than cleared once the platform loses what makes them
+  # meaningful: the admin UI stops offering them, so nobody can switch them off, and enforcing
+  # them holds participation behind a step nobody can complete. The stored choice comes back
+  # with the feature.
+  def require_verification
+    return false unless verification_possible?
+
+    super
+  end
+
   def require_confirmed_phone_number
     return false unless AppConfiguration.instance.feature_activated?('sms')
 
     super
+  end
+
+  def require_password
+    return false unless AppConfiguration.instance.feature_activated?('password_login')
+
+    super
+  end
+
+  # Falls back to the platform-wide questions, which is where the one-off
+  # single_use:reset_custom_fields_behavior_without_feature task put these permissions too.
+  # The curated permissions_custom_fields rows are kept, and served again if the feature returns.
+  def custom_fields_behavior
+    behavior = super
+    return 'global' if behavior == 'custom' && !AppConfiguration.instance.feature_activated?('permissions_custom_fields')
+
+    behavior
   end
 
   def everyone_tracking_enabled?
@@ -183,6 +212,10 @@ class Permission < ApplicationRecord
   end
 
   private
+
+  def verification_possible?
+    Verification::VerificationService.new.active_methods(AppConfiguration.instance).any?
+  end
 
   def sanitize_access_denied_explanation_multiloc
     self.access_denied_explanation_multiloc = SanitizationService.new.sanitize_body_multiloc(

--- a/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
+++ b/back/engines/commercial/mcp_server/spec/lib/mcp_server/tools/update_phase_permission_spec.rb
@@ -82,6 +82,11 @@ describe McpServer::Tools::UpdatePhasePermission do
     end
 
     it 'sets the verification expiry' do
+      # require_verification only reads back on a platform that has a verification method.
+      AppConfiguration.instance.settings['id_config'] =
+        { 'allowed' => true, 'enabled' => true, 'id_methods' => [{ name: 'fake_sso', enabled_for_verified_actions: true }] }
+      AppConfiguration.instance.save!
+
       response = run(params.merge(
         permitted_by: 'users',
         require_verification: true,

--- a/back/spec/acceptance/permissions_spec.rb
+++ b/back/spec/acceptance/permissions_spec.rb
@@ -150,6 +150,8 @@ resource 'Permissions' do
       end
 
       context 'for the visiting permission' do
+        include_context 'with sms feature enabled'
+
         let(:action) { 'visiting' }
 
         before do
@@ -289,6 +291,21 @@ resource 'Permissions' do
           expect(response_data.dig(:attributes, :confirmed_phone_number_expiry)).to eq confirmed_phone_number_expiry
           expect(response_data.dig(:attributes, :access_denied_explanation_multiloc)).to eq access_denied_explanation_multiloc
           expect(response_data.dig(:relationships, :groups, :data).pluck(:id)).to match_array group_ids
+        end
+      end
+
+      context 'require_confirmed_phone_number without the sms feature', document: false do
+        let(:permitted_by) { 'users' }
+        let(:require_confirmed_phone_number) { true }
+        let(:confirmed_phone_number_expiry) { 30 }
+
+        example 'is reported as false, while the stored value is kept' do
+          do_request
+          assert_status 200
+          expect(response_data.dig(:attributes, :require_confirmed_phone_number)).to be false
+
+          permission = Permission.find(response_data[:id])
+          expect(permission.read_attribute(:require_confirmed_phone_number)).to be true
         end
       end
 
@@ -479,6 +496,8 @@ resource 'Permissions' do
       end
 
       context 'for the visiting permission' do
+        include_context 'with sms feature enabled'
+
         let(:action) { 'visiting' }
         let(:require_confirmed_email) { false }
         let(:require_confirmed_phone_number) { true }

--- a/back/spec/models/permission_spec.rb
+++ b/back/spec/models/permission_spec.rb
@@ -131,6 +131,35 @@ RSpec.describe Permission do
     end
   end
 
+  describe '#require_confirmed_phone_number' do
+    let(:permission) { create(:permission, :by_users, require_confirmed_phone_number: true) }
+
+    context 'when the sms feature is enabled' do
+      include_context 'with sms feature enabled'
+
+      it 'returns the stored value' do
+        expect(permission.require_confirmed_phone_number).to be true
+        expect(permission.require_confirmed_phone_number?).to be true
+      end
+    end
+
+    context 'when the sms feature is disabled' do
+      it 'is false, whatever is stored' do
+        expect(permission.require_confirmed_phone_number).to be false
+        expect(permission.require_confirmed_phone_number?).to be false
+      end
+
+      it 'masks the stored value rather than clearing it' do
+        expect(permission.reload.read_attribute(:require_confirmed_phone_number)).to be true
+      end
+
+      it 'returns the stored value again once the feature is switched back on' do
+        SettingsService.new.activate_feature!('sms')
+        expect(permission.require_confirmed_phone_number).to be true
+      end
+    end
+  end
+
   describe '#verification_enabled?' do
     it 'is true when require_verification is true' do
       expect(build(:permission, :by_users, require_verification: true).verification_enabled?).to be true

--- a/back/spec/models/permission_spec.rb
+++ b/back/spec/models/permission_spec.rb
@@ -5,6 +5,16 @@ require 'rails_helper'
 RSpec.describe Permission do
   it_behaves_like 'a sanitized html_multiloc', factory: :permission, attribute: :access_denied_explanation_multiloc
 
+  def configure_verification_method
+    AppConfiguration.instance.settings['id_config'] =
+      { 'allowed' => true, 'enabled' => true, 'id_methods' => [{ name: 'fake_sso', enabled_for_verified_actions: true }] }
+    AppConfiguration.instance.save!
+  end
+
+  def verified_members_group
+    create(:smart_group, rules: [{ ruleType: 'verified', predicate: 'is_verified' }])
+  end
+
   describe 'access denied explanation sanitizer' do
     def explanation_of(html)
       create(:permission, access_denied_explanation_multiloc: { 'en' => html })
@@ -160,13 +170,123 @@ RSpec.describe Permission do
     end
   end
 
-  describe '#verification_enabled?' do
-    it 'is true when require_verification is true' do
-      expect(build(:permission, :by_users, require_verification: true).verification_enabled?).to be true
+  describe '#require_verification' do
+    let(:permission) { create(:permission, :by_users, require_verification: true) }
+
+    context 'when a verification method is configured' do
+      before { configure_verification_method }
+
+      it 'returns the stored value' do
+        expect(permission.require_verification).to be true
+        expect(permission.require_verification?).to be true
+      end
     end
 
-    it 'is false when verification is not required and there is no verification group' do
-      expect(build(:permission, :by_users).verification_enabled?).to be false
+    context 'when no verification method is configured' do
+      it 'is false, whatever is stored' do
+        expect(permission.require_verification).to be false
+        expect(permission.require_verification?).to be false
+      end
+
+      it 'masks the stored value rather than clearing it' do
+        expect(permission.reload.read_attribute(:require_verification)).to be true
+      end
+
+      it 'returns the stored value again once a method is configured' do
+        configure_verification_method
+        expect(permission.require_verification).to be true
+      end
+    end
+  end
+
+  describe '#require_password' do
+    let(:permission) { create(:permission, :by_users, require_password: true) }
+
+    it 'returns the stored value while password_login is enabled' do
+      expect(permission.require_password).to be true
+      expect(permission.require_password?).to be true
+    end
+
+    context 'when password_login is disabled' do
+      before { SettingsService.new.deactivate_feature!('password_login') }
+
+      it 'is false, whatever is stored' do
+        expect(permission.require_password).to be false
+        expect(permission.require_password?).to be false
+      end
+
+      it 'masks the stored value rather than clearing it' do
+        expect(permission.reload.read_attribute(:require_password)).to be true
+      end
+
+      it 'returns the stored value again once the feature is switched back on' do
+        SettingsService.new.activate_feature!('password_login')
+        expect(permission.require_password).to be true
+      end
+    end
+  end
+
+  describe '#custom_fields_behavior' do
+    let(:permission) { create(:permission, :by_users, custom_fields_behavior: 'custom') }
+
+    it 'returns the stored value while permissions_custom_fields is enabled' do
+      expect(permission.custom_fields_behavior).to eq 'custom'
+    end
+
+    context 'when permissions_custom_fields is disabled' do
+      before { SettingsService.new.deactivate_feature!('permissions_custom_fields') }
+
+      it "falls back to the platform-wide questions instead of the action's own" do
+        expect(permission.custom_fields_behavior).to eq 'global'
+      end
+
+      it 'masks the stored value rather than clearing it' do
+        expect(permission.reload.read_attribute(:custom_fields_behavior)).to eq 'custom'
+      end
+
+      it 'returns the stored value again once the feature is switched back on' do
+        SettingsService.new.activate_feature!('permissions_custom_fields')
+        expect(permission.custom_fields_behavior).to eq 'custom'
+      end
+
+      it 'leaves the other behaviors alone' do
+        %w[global disabled].each do |behavior|
+          permission.update!(custom_fields_behavior: behavior)
+          expect(permission.custom_fields_behavior).to eq behavior
+        end
+      end
+    end
+  end
+
+  describe '#verification_enabled?' do
+    context 'when a verification method is configured' do
+      before { configure_verification_method }
+
+      it 'is true when require_verification is true' do
+        expect(create(:permission, :by_users, require_verification: true).verification_enabled?).to be true
+      end
+
+      it 'is true when a verification group is set' do
+        permission = create(:permission, :by_users, groups: [verified_members_group])
+        expect(permission.verification_enabled?).to be true
+      end
+
+      it 'is false when verification is not required and there is no verification group' do
+        expect(create(:permission, :by_users).verification_enabled?).to be false
+      end
+    end
+
+    context 'when no verification method is configured' do
+      it 'is false even when require_verification is true' do
+        expect(create(:permission, :by_users, require_verification: true).verification_enabled?).to be false
+      end
+
+      # The group still restricts who may participate, which is reported as a group
+      # membership requirement rather than as a verification step.
+      it 'is false even when a verification group is set' do
+        permission = create(:permission, :by_users, groups: [verified_members_group])
+        expect(permission.verification_enabled?).to be false
+      end
     end
   end
 

--- a/back/spec/services/permissions/permission_inheritance_service_spec.rb
+++ b/back/spec/services/permissions/permission_inheritance_service_spec.rb
@@ -19,7 +19,13 @@ describe Permissions::PermissionInheritanceService do
     )
   end
 
-  before { described_class.clear_source_permission_cache }
+  before do
+    # The copied require_verification is only carried through on a platform that can verify.
+    AppConfiguration.instance.settings['id_config'] =
+      { 'allowed' => true, 'enabled' => true, 'id_methods' => [{ name: 'fake_sso', enabled_for_verified_actions: true }] }
+    AppConfiguration.instance.save!
+    described_class.clear_source_permission_cache
+  end
 
   describe '#inheritable?' do
     it 'is true for any action of a phase' do

--- a/back/spec/services/permissions/permissions_custom_fields_service_spec.rb
+++ b/back/spec/services/permissions/permissions_custom_fields_service_spec.rb
@@ -139,6 +139,29 @@ describe Permissions::PermissionsCustomFieldsService do
       end
     end
 
+    # Curating an action's own questions is the permissions_custom_fields feature; without it
+    # the platform-wide questions are asked instead. See Permission#custom_fields_behavior.
+    context "custom_fields_behavior is 'custom' without the permissions_custom_fields feature" do
+      it 'returns the platform fields rather than the curated ones' do
+        permission = create(:permission, permitted_by: 'users', custom_fields_behavior: 'custom')
+        create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field_birthyear, enabled: false))
+        SettingsService.new.deactivate_feature!('permissions_custom_fields')
+
+        fields = service.fields_for_permission(permission)
+        expect(fields.map { |field| field.custom_field.code }).to eq %w[domicile gender]
+        expect(fields.map(&:persisted?)).to all(be false)
+      end
+
+      it 'serves the curated ones again once the feature returns' do
+        permission = create(:permission, permitted_by: 'users', custom_fields_behavior: 'custom')
+        curated_field = create(:permissions_custom_field, permission: permission, custom_field: create(:custom_field_birthyear))
+        SettingsService.new.deactivate_feature!('permissions_custom_fields')
+        SettingsService.new.activate_feature!('permissions_custom_fields')
+
+        expect(service.fields_for_permission(permission)).to eq [curated_field]
+      end
+    end
+
     context "custom_fields_behavior is 'custom'" do
       let(:permission) { create(:permission, permitted_by: 'users') }
 

--- a/back/spec/services/permissions/user_requirements_service_spec.rb
+++ b/back/spec/services/permissions/user_requirements_service_spec.rb
@@ -780,6 +780,41 @@ describe Permissions::UserRequirementsService do
       end
     end
 
+    # The sms feature is what makes a phone number addable and confirmable at all,
+    # so a permission that kept require_confirmed_phone_number after it was switched
+    # off must not ask for one. See Permission#require_confirmed_phone_number.
+    context 'when a confirmed phone number is required but the sms feature is off' do
+      let(:permission) do
+        create(
+          :permission,
+          permitted_by: 'users',
+          require_confirmed_email: false,
+          require_name: false,
+          require_password: false,
+          require_confirmed_phone_number: true
+        )
+      end
+
+      it 'asks nothing of a user without a phone number' do
+        user.update!(phone: nil, new_phone: nil, phone_confirmed_at: nil)
+        requirements = service.requirements(permission, user)
+        expect(requirements[:authentication][:phone_action_required]).to be_nil
+        expect(service.permitted?(requirements)).to be true
+      end
+
+      it 'asks nothing of a user with an unconfirmed phone number' do
+        user.update!(phone: '+3212345678', phone_confirmed_at: nil)
+        requirements = service.requirements(permission, user)
+        expect(requirements[:authentication][:phone_action_required]).to be_nil
+        expect(service.permitted?(requirements)).to be true
+      end
+
+      it 'asks nothing when there is no user yet' do
+        requirements = service.requirements(permission, nil)
+        expect(requirements[:authentication][:phone_action_required]).to be_nil
+      end
+    end
+
     # Re-confirmation of an already-confirmed email once confirmed_email_expiry has
     # elapsed. The top-level `user` has a confirmed email (email_confirmed_at: Time.now,
     # confirmation_required? false), so the only thing that can put them back into a

--- a/back/spec/services/permissions/user_requirements_service_spec.rb
+++ b/back/spec/services/permissions/user_requirements_service_spec.rb
@@ -525,6 +525,13 @@ describe Permissions::UserRequirementsService do
         let(:groups) { [create(:group), create(:smart_group, rules: [{ ruleType: 'verified', predicate: 'is_verified' }])] }
         let(:group_permission) { create(:permission, permitted_by: 'users', groups: groups) }
 
+        before do
+          # A verification group only asks for verification where verifying is possible.
+          AppConfiguration.instance.settings['id_config'] =
+            { 'allowed' => true, 'enabled' => true, 'id_methods' => [{ name: 'fake_sso', enabled_for_verified_actions: true }] }
+          AppConfiguration.instance.save!
+        end
+
         context 'there is no user' do
           it 'requires verification' do
             requirements = service.requirements(group_permission, nil)
@@ -718,6 +725,25 @@ describe Permissions::UserRequirementsService do
           expect(requirements[:authentication][:missing_user_attributes]).to eq []
           expect(requirements[:authentication][:email_action_required]).to eq :confirm_email
         end
+      end
+    end
+
+    # A verification method is what makes a user verifiable at all, so a permission that kept
+    # require_verification after the platform's last method was removed must not ask for it.
+    # See Permission#require_verification.
+    context 'verification via require_verification without a configured verification method' do
+      let(:verified_permission) { create(:permission, :by_verified) }
+
+      it 'does not require verification when there is no user' do
+        requirements = service.requirements(verified_permission, nil)
+        expect(requirements[:verification]).to be false
+      end
+
+      it 'does not require verification for an unverified user' do
+        user.update!(verified: false)
+        requirements = service.requirements(verified_permission, user)
+        expect(requirements[:verification]).to be false
+        expect(service.permitted?(requirements)).to be true
       end
     end
 
@@ -946,6 +972,28 @@ describe Permissions::UserRequirementsService do
             expect(requirements[:authentication][:phone_action_required]).to eq :reconfirm_phone
           end
         end
+      end
+    end
+
+    # A password is not a credential anyone can log in with once password_login is off, and the
+    # admin UI stops offering the toggle. See Permission#require_password.
+    context 'when a password is required but password_login is off' do
+      let(:permission) do
+        create(:permission, permitted_by: 'users', require_name: false, require_password: true)
+      end
+
+      before { SettingsService.new.deactivate_feature!('password_login') }
+
+      it 'does not ask for a password from a user without one' do
+        user.update!(password_digest: nil)
+        requirements = service.requirements(permission, user)
+        expect(requirements[:authentication][:missing_user_attributes]).not_to include(:password)
+        expect(service.permitted?(requirements)).to be true
+      end
+
+      it 'does not ask for a password when there is no user' do
+        requirements = service.requirements(permission, nil)
+        expect(requirements[:authentication][:missing_user_attributes]).not_to include(:password)
       end
     end
 


### PR DESCRIPTION
# Changelog
## Technical
- Override `require_confirmed_phone_number` if `sms` FF disabled
- Override `require_verification` if no verification method configured
- Override `require_password` if `password_login` FF disabled
- Override `custom_fields_behavior` if `permissions_custom_fields` FF disabled
