### PR TITLE
[TAN-8605] Add missing CSS classes for Intercom tour

### DIFF
--- a/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
+++ b/front/app/containers/Admin/projects/project/phaseSetup/components/PhaseParticipationConfig/components/inputs/NativeSurveyInputs.tsx
@@ -44,7 +44,7 @@ const NativeSurveyInputs = ({
   );
 
   return (
-    <>
+    <Box className="intercom-product-tour-survey-settings">
       <SectionField>
         <Toggle
           checked={!!formData.allow_multiple_responses}
@@ -117,7 +117,7 @@ const NativeSurveyInputs = ({
           {localize(formData.native_survey_button_multiloc)}
         </ButtonWithLink>
       </SectionField>
-    </>
+    </Box>
   );
 };
 

--- a/front/app/containers/Admin/projects/project/projectPage/ProjectPage/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectPage/ProjectPage/index.tsx
@@ -192,7 +192,11 @@ const ProjectPage = () => {
           // Let wheel/scroll fall through to the iframe so the preview stays scrollable
           pointerEvents="none"
         >
-          <CtaWrapper pointerEvents="auto" transform="translateY(7px)">
+          <CtaWrapper
+            className="intercom-product-tour-project-edit-project"
+            pointerEvents="auto"
+            transform="translateY(7px)"
+          >
             <Button
               icon="edit"
               buttonStyle="primary"

--- a/front/app/containers/Admin/projects/project/projectPage/TimelinePhases/index.tsx
+++ b/front/app/containers/Admin/projects/project/projectPage/TimelinePhases/index.tsx
@@ -79,7 +79,11 @@ const TimelinePhases = ({ projectId }: Props) => {
 
       {sortedPhases.length === 0 && <EmptyState />}
 
-      <Box display="flex" flexDirection="column">
+      <Box 
+        className="intercom-product-tour-project-timeline-phases"
+        display="flex"
+        flexDirection="column"
+      >
         {sortedPhases.map((phase, index) => {
           const status = phaseStatus(phase);
           const isSelected = phase.id === phaseId;
@@ -123,7 +127,11 @@ const TimelinePhases = ({ projectId }: Props) => {
         })}
       </Box>
 
-      <Box display="flex" mt="4px">
+      <Box 
+        display="flex"
+        mt="4px"
+        className="intercom-product-tour-project-timeline-new-phase"
+      >
         <ButtonWithLink
           to="/admin/projects/$projectId/phases/new"
           params={{ projectId }}


### PR DESCRIPTION
# Changelog
## Added
- CSS classes `intercom-*` for Intercom tour for Project and Survey admin panels
